### PR TITLE
v0.0.18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ https://warp-drive.io/llms-full.txt
   - `app/components/station/wind/index.gts`: `w-dir`, `w-avg`, `w-max`
   - `app/components/station/air/index.gts`: `temp`, `hum`, `rain`
 - Warp Drive supports partial resource payloads via upsert, but only one level deep. Reusing the same `history` identity with different top-level primitive fields is fine as long as the handler only emits attributes that were actually present in the payload; do not normalize omitted fields to `undefined`, and do not rely on partial deep merges for object-valued fields.
+- For partial station payloads, station handlers must omit missing station-level and `last.*` attributes entirely instead of serializing them as `undefined`.
 - Prefer existing Frontile and Tailwind patterns for shared UI.
 - Update `translations/en-us.yaml` when UI text changes.
 - Do not edit generated or installed files such as `dist/` or `node_modules/`.

--- a/app/builders/station.ts
+++ b/app/builders/station.ts
@@ -45,7 +45,6 @@ const mapStationQueryKeys = [
   'short',
   'loc',
   'status',
-  'pv-name',
   'alt',
   'peak',
   'last._id',

--- a/app/components/navbar/index.gts
+++ b/app/components/navbar/index.gts
@@ -6,7 +6,6 @@ import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
 import NavbarLogo from './logo';
 import NavbarMenuDesktop from './menu/desktop';
 import NavbarMenuMobile from './menu/mobile';
-import NavbarRefreshControl from './refresh-control';
 
 export interface NavbarSignature {
   Args: {};
@@ -30,10 +29,6 @@ export default class Navbar extends Component<NavbarSignature> {
           <NavbarLogo />
 
           <NavbarMenuDesktop />
-
-          <div class="hidden items-center gap-2 md:ml-3 md:flex">
-            <NavbarRefreshControl />
-          </div>
 
           <div class="ml-auto md:hidden">
             <NavbarMenuMobile />

--- a/app/components/navbar/menu/desktop.gts
+++ b/app/components/navbar/menu/desktop.gts
@@ -1,11 +1,14 @@
 import { LinkTo } from '@ember/routing';
 import { t } from 'ember-intl';
+import NavbarRefreshControl from '../refresh-control';
 import { NAVBAR_MENU_ITEMS } from './items';
 
 <template>
   <div class="hidden min-w-0 flex-1 md:flex">
     <div class="flex flex-1 justify-center">
-      <div class="inline-flex items-center gap-1 rounded-full bg-slate-100 p-1">
+      <div
+        class="inline-flex items-center gap-1 rounded-full bg-slate-100 p-1 shadow-inner shadow-white/80"
+      >
         {{#each NAVBAR_MENU_ITEMS as |item|}}
           <LinkTo
             @route={{item.route}}
@@ -17,6 +20,10 @@ import { NAVBAR_MENU_ITEMS } from './items';
             {{t item.labelKey}}
           </LinkTo>
         {{/each}}
+
+        <span class="mx-1 h-6 w-px bg-slate-200"></span>
+
+        <NavbarRefreshControl @appearance="desktop" />
       </div>
     </div>
   </div>

--- a/app/components/navbar/menu/mobile.gts
+++ b/app/components/navbar/menu/mobile.gts
@@ -86,7 +86,7 @@ export default class NavbarMenuMobile extends Component<NavbarMenuMobileSignatur
                 </Button>
               {{/each}}
 
-              <NavbarRefreshControl @isFullWidth={{true}} />
+              <NavbarRefreshControl @appearance="mobile" />
             </div>
           </drawer.Body>
         </Drawer>

--- a/app/components/navbar/refresh-control.gts
+++ b/app/components/navbar/refresh-control.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { Button } from '@frontile/buttons';
+import type { PressEvent } from '@frontile/utilities/modifiers/press';
 import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
 import ArrowClockwise from 'ember-phosphor-icons/components/ph-arrow-clockwise';
@@ -9,7 +10,7 @@ import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
 
 export interface NavbarRefreshControlSignature {
   Args: {
-    isFullWidth?: boolean;
+    appearance: 'desktop' | 'mobile';
   };
   Blocks: {
     default: [];
@@ -21,52 +22,65 @@ export default class NavbarRefreshControl extends Component<NavbarRefreshControl
   @service declare mapRefresh: MapRefreshService;
   @service declare intl: IntlService;
 
+  get isMobileAppearance() {
+    return this.args.appearance === 'mobile';
+  }
+
   get buttonClass() {
-    if (this.args.isFullWidth) {
+    if (this.isMobileAppearance) {
       return 'w-full justify-start';
     }
 
-    return 'size-10 p-0';
+    return 'size-9 rounded-full p-0 text-slate-500 transition hover:bg-white/70 hover:text-wind-20';
   }
 
-  get elapsedLabel() {
-    const totalSeconds = Math.floor(this.mapRefresh.elapsedMs / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-
-    return `${minutes.toString().padStart(2, '0')}:${seconds
-      .toString()
-      .padStart(2, '0')}`;
-  }
-
-  get title() {
-    const ariaLabel = String(this.intl.t('map.refresh.ariaLabel'));
-
-    return `${ariaLabel} (${this.intl.t('map.refresh.sinceLast', {
-      value: this.elapsedLabel,
-    })})`;
+  get ariaLabel() {
+    return String(this.intl.t('map.refresh.ariaLabel'));
   }
 
   @action
-  handleRefresh() {
+  handleRefresh(event: PressEvent) {
+    const icon = event.target.querySelector('[data-refresh-icon]');
+
+    if (icon instanceof Element) {
+      icon.animate(
+        [
+          { transform: 'rotate(0deg)' },
+          { transform: 'rotate(360deg)' },
+        ],
+        {
+          duration: 550,
+          easing: 'linear',
+          iterations: 1,
+        }
+      );
+    }
+
     this.mapRefresh.refreshNow();
   }
 
   <template>
     <Button
-      aria-label={{this.title}}
+      aria-label={{this.ariaLabel}}
       data-test-navbar-refresh
-      @appearance="outlined"
+      @appearance={{if this.isMobileAppearance "outlined" "custom"}}
       @class={{this.buttonClass}}
-      title={{this.title}}
       @onPress={{this.handleRefresh}}
     >
-      <span class="inline-flex items-center gap-2">
-        <ArrowClockwise @size={{14}} />
-        {{#if @isFullWidth}}
+      {{#if this.isMobileAppearance}}
+        <span class="inline-flex items-center gap-2">
+          <span data-refresh-icon>
+            <ArrowClockwise @size={{14}} />
+          </span>
           <span>{{t "map.refresh.label"}}</span>
-        {{/if}}
-      </span>
+        </span>
+      {{else}}
+        <span class="grid size-full place-items-center">
+          <span data-refresh-icon class="inline-flex">
+            <ArrowClockwise @size={{14}} />
+          </span>
+        </span>
+      {{/if}}
     </Button>
   </template>
 }

--- a/app/components/navbar/refresh-control.gts
+++ b/app/components/navbar/refresh-control.gts
@@ -44,10 +44,7 @@ export default class NavbarRefreshControl extends Component<NavbarRefreshControl
 
     if (icon instanceof Element) {
       icon.animate(
-        [
-          { transform: 'rotate(0deg)' },
-          { transform: 'rotate(360deg)' },
-        ],
+        [{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }],
         {
           duration: 550,
           easing: 'linear',

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -28,7 +28,9 @@ export default class StationHeader extends Component<StationHeaderSignature> {
   @service declare intl: IntlService;
 
   get hasProviderLink() {
-    return Boolean(this.args.station.providerName && this.args.station.providerUrl);
+    return Boolean(
+      this.args.station.providerName && this.args.station.providerUrl
+    );
   }
 
   get lastReadingRelativeSeconds() {

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -27,6 +27,10 @@ export default class StationHeader extends Component<StationHeaderSignature> {
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
   @service declare intl: IntlService;
 
+  get hasProviderLink() {
+    return Boolean(this.args.station.providerName && this.args.station.providerUrl);
+  }
+
   get lastReadingRelativeSeconds() {
     return Math.round(
       this.args.station.last.timestamp / 1000 - Date.now() / 1000
@@ -89,22 +93,24 @@ export default class StationHeader extends Component<StationHeaderSignature> {
           </StationMetaItem>
         {{/if}}
 
-        <StationMetaItem
-          @icon={{ArrowSquareUpRight}}
-          @label={{t "station.meta.provider"}}
-        >
-          <span>
-            <a
-              data-test-station-provider-link
-              href={{@station.providerUrl}}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="underline decoration-slate-300 underline-offset-3 transition hover:text-slate-900 hover:decoration-slate-500"
-            >
-              {{@station.providerName}}
-            </a>
-          </span>
-        </StationMetaItem>
+        {{#if this.hasProviderLink}}
+          <StationMetaItem
+            @icon={{ArrowSquareUpRight}}
+            @label={{t "station.meta.provider"}}
+          >
+            <span>
+              <a
+                data-test-station-provider-link
+                href={{@station.providerUrl}}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline decoration-slate-300 underline-offset-3 transition hover:text-slate-900 hover:decoration-slate-500"
+              >
+                {{@station.providerName}}
+              </a>
+            </span>
+          </StationMetaItem>
+        {{/if}}
       </dl>
     </div>
   </template>

--- a/app/handlers/station.ts
+++ b/app/handlers/station.ts
@@ -33,6 +33,10 @@ interface StationApiPayload {
   };
 }
 
+function hasOwn<T extends object>(obj: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
 function normalizeProviderUrl(urls?: Record<string, string>) {
   if (!urls) {
     return undefined;
@@ -59,37 +63,90 @@ function normalizePressure(
 }
 
 function jsonApifyFields(elm: StationApiPayload) {
-  const last = elm.last
-    ? {
-        timestamp: elm.last._id ? elm.last._id * 1000 : undefined,
-        direction: elm.last['w-dir'],
-        speed: elm.last['w-avg'],
-        gusts: elm.last['w-max'],
-        temperature: elm.last.temp,
-        humidity: elm.last.hum,
-        rain: elm.last.rain,
-        pressure: normalizePressure(elm.last.pres),
+  const attributes: Record<string, unknown> = {
+    _id: elm._id,
+  };
+
+  if (hasOwn(elm, 'alt')) {
+    attributes.altitude = elm.alt;
+  }
+
+  if (hasOwn(elm, 'loc')) {
+    attributes.location = elm.loc
+      ? {
+          coordinates: elm.loc.coordinates,
+        }
+      : elm.loc;
+  }
+
+  if (hasOwn(elm, 'peak')) {
+    attributes.isPeak = elm.peak;
+  }
+
+  if (hasOwn(elm, 'pv-name')) {
+    attributes.providerName = elm['pv-name'];
+  }
+
+  if (hasOwn(elm, 'short') || hasOwn(elm, 'name')) {
+    attributes.name = elm.short ?? elm.name;
+  }
+
+  if (hasOwn(elm, 'status')) {
+    attributes.status = elm.status;
+  }
+
+  if (hasOwn(elm, 'url')) {
+    attributes.providerUrl = normalizeProviderUrl(elm.url);
+  }
+
+  if (hasOwn(elm, 'last') && elm.last) {
+    const last: Record<string, unknown> = {};
+
+    if (hasOwn(elm.last, '_id') && elm.last._id !== undefined) {
+      last.timestamp = elm.last._id * 1000;
+    }
+
+    if (hasOwn(elm.last, 'w-dir')) {
+      last.direction = elm.last['w-dir'];
+    }
+
+    if (hasOwn(elm.last, 'w-avg')) {
+      last.speed = elm.last['w-avg'];
+    }
+
+    if (hasOwn(elm.last, 'w-max')) {
+      last.gusts = elm.last['w-max'];
+    }
+
+    if (hasOwn(elm.last, 'temp')) {
+      last.temperature = elm.last.temp;
+    }
+
+    if (hasOwn(elm.last, 'hum')) {
+      last.humidity = elm.last.hum;
+    }
+
+    if (hasOwn(elm.last, 'rain')) {
+      last.rain = elm.last.rain;
+    }
+
+    if (hasOwn(elm.last, 'pres')) {
+      const pressure = normalizePressure(elm.last.pres);
+
+      if (pressure !== undefined) {
+        last.pressure = pressure;
       }
-    : undefined;
+    }
+
+    if (Object.keys(last).length > 0) {
+      attributes.last = last;
+    }
+  }
 
   return {
     type: 'station',
     id: elm._id,
-    attributes: {
-      _id: elm._id,
-      altitude: elm.alt,
-      location: elm.loc
-        ? {
-            coordinates: elm.loc.coordinates,
-          }
-        : undefined,
-      isPeak: elm.peak,
-      providerName: elm['pv-name'],
-      name: elm.short ?? elm.name,
-      status: elm.status,
-      providerUrl: normalizeProviderUrl(elm.url),
-      last,
-    },
+    attributes,
   };
 }
 

--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -108,8 +108,8 @@ export type Station = {
   latitude: number;
   longitude: number;
   isPeak: boolean;
-  providerName: string;
-  providerUrl: string;
+  providerName?: string;
+  providerUrl?: string;
   name: string;
   last: {
     timestamp: number;

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.19 - 2026-04-02
+
+### Fixed
+
+- Fixed station details so provider links now appear reliably the first time a station sidebar opens, instead of sometimes only showing up after reopening or switching stations.
+
 ## v0.0.18 - 2026-04-02
 
 ### Changed

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.0.18 - 2026-04-02
+
+### Changed
+
+- Refined the desktop navbar so the refresh action now sits directly with the main navigation as a compact icon button, while the mobile drawer keeps a full-width labeled refresh button.
+- Simplified the refresh action presentation by removing the extra countdown and hover title text, and added a subtle one-shot spin animation on the refresh icon when you trigger a manual refresh.
+- Trimmed the map station payload further so provider details are loaded only when opening a station, keeping the initial map data leaner.
+
+### Fixed
+
+- Fixed station sidebar provider links so they now appear only when a complete provider link is available, avoiding empty or incomplete provider entries while station details are still loading.
+
 ## v0.0.17 - 2026-04-01
 
 ### Changed

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## v0.0.19 - 2026-04-02
-
-### Fixed
-
-- Fixed station details so provider links now appear reliably the first time a station sidebar opens, instead of sometimes only showing up after reopening or switching stations.
-
 ## v0.0.18 - 2026-04-02
 
 ### Changed
@@ -16,6 +10,7 @@
 
 ### Fixed
 
+- Fixed station details so provider links now appear reliably the first time a station sidebar opens, instead of sometimes only showing up after reopening or switching stations.
 - Fixed station sidebar provider links so they now appear only when a complete provider link is available, avoiding empty or incomplete provider entries while station details are still loading.
 
 ## v0.0.17 - 2026-04-01

--- a/tests/acceptance/map-query-params-test.ts
+++ b/tests/acceptance/map-query-params-test.ts
@@ -129,12 +129,6 @@ module('Acceptance | map query params', function (hooks) {
     const initialStationRequestCount = countStationRequests(store.calls);
 
     assert.dom('[data-test-navbar-refresh]').exists();
-    assert
-      .dom('[data-test-navbar-refresh]')
-      .hasAttribute(
-        'title',
-        'Refresh map and station data (00:00 since last refresh)'
-      );
 
     await click('[data-test-navbar-refresh]');
     await settled();
@@ -143,12 +137,6 @@ module('Acceptance | map query params', function (hooks) {
       countStationRequests(store.calls),
       initialStationRequestCount + 1
     );
-    assert
-      .dom('[data-test-navbar-refresh]')
-      .hasAttribute(
-        'title',
-        'Refresh map and station data (00:00 since last refresh)'
-      );
   });
 
   test('it auto refreshes stations after the refresh interval', async function (assert) {

--- a/tests/acceptance/map-query-params-test.ts
+++ b/tests/acceptance/map-query-params-test.ts
@@ -1,6 +1,12 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { click, currentURL, visit, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  currentURL,
+  settled,
+  visit,
+  waitUntil,
+} from '@ember/test-helpers';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
 import MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
@@ -118,6 +124,7 @@ module('Acceptance | map query params', function (hooks) {
 
     await visit('/map?mapLng=8.12345&mapLat=46.54321&mapZoom=9.5');
     await waitUntil(() => countStationRequests(store.calls) > 0);
+    await settled();
 
     const initialStationRequestCount = countStationRequests(store.calls);
 
@@ -130,6 +137,7 @@ module('Acceptance | map query params', function (hooks) {
       );
 
     await click('[data-test-navbar-refresh]');
+    await settled();
 
     assert.strictEqual(
       countStationRequests(store.calls),

--- a/tests/integration/components/station/header-test.ts
+++ b/tests/integration/components/station/header-test.ts
@@ -1,0 +1,71 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { Type } from '@warp-drive/core/types/symbols';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+import type { Station } from 'winds-mobi-client-web/services/store';
+
+type StationHeaderTestContext = {
+  station: Station;
+};
+
+const BASE_STATION: Omit<Station, 'providerUrl'> = {
+  id: 'windline-4109',
+  altitude: 1200,
+  latitude: 46.7,
+  longitude: 7.8,
+  isPeak: false,
+  providerName: 'windline.ch',
+  name: 'Windline 4109',
+  last: {
+    timestamp: 1_710_000_000_000,
+    direction: 240,
+    speed: 12,
+    gusts: 18,
+    temperature: 7,
+    humidity: 65,
+    pressure: 1012,
+    rain: 0,
+  },
+  [Type]: 'station',
+};
+
+module('Integration | Component | station/header', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it hides the provider meta item when the provider name is missing', async function (this: StationHeaderTestContext, assert) {
+    this.station = {
+      ...BASE_STATION,
+      providerName: undefined,
+    };
+
+    await render(hbs`<Station::Header @station={{this.station}} />`);
+
+    assert.dom('[data-test-station-provider-link]').doesNotExist();
+    assert.dom(this.element).doesNotIncludeText('Provider');
+  });
+
+  test('it hides the provider meta item when the provider URL is missing', async function (this: StationHeaderTestContext, assert) {
+    this.station = {
+      ...BASE_STATION,
+    };
+
+    await render(hbs`<Station::Header @station={{this.station}} />`);
+
+    assert.dom('[data-test-station-provider-link]').doesNotExist();
+    assert.dom(this.element).doesNotIncludeText('Provider');
+  });
+
+  test('it renders the provider link when the provider URL is available', async function (this: StationHeaderTestContext, assert) {
+    this.station = {
+      ...BASE_STATION,
+      providerUrl: 'https://windline.ch/station/4109',
+    };
+
+    await render(hbs`<Station::Header @station={{this.station}} />`);
+
+    assert
+      .dom('[data-test-station-provider-link]')
+      .hasAttribute('href', 'https://windline.ch/station/4109');
+  });
+});

--- a/tests/unit/handlers/station-test.ts
+++ b/tests/unit/handlers/station-test.ts
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import StationHandler from 'winds-mobi-client-web/handlers/station';
+
+module('Unit | Handler | station', function () {
+  test('it only serializes station attributes present in the payload', async function (assert) {
+    const response = await StationHandler.request<{
+      data: {
+        id: string;
+        attributes: Record<string, unknown>;
+      };
+    }>(
+      {
+        request: {
+          url: 'https://winds.mobi/api/2.3/stations/holfuy-1850?keys=short&keys=alt&keys=last._id&keys=last.w-avg',
+        },
+      } as never,
+      async () =>
+        ({
+          content: {
+            _id: 'holfuy-1850',
+            short: 'Holfuy 1850',
+            alt: 1850,
+            last: {
+              _id: 1_774_341_507,
+              'w-avg': 12,
+            },
+          },
+        }) as never
+    );
+
+    assert.deepEqual(response.data.attributes, {
+      _id: 'holfuy-1850',
+      altitude: 1850,
+      name: 'Holfuy 1850',
+      last: {
+        timestamp: 1_774_341_507_000,
+        speed: 12,
+      },
+    });
+    assert.false('providerName' in response.data.attributes);
+    assert.false('providerUrl' in response.data.attributes);
+    assert.false('status' in response.data.attributes);
+  });
+
+  test('it keeps explicit provider fields from a detail payload', async function (assert) {
+    const response = await StationHandler.request<{
+      data: {
+        id: string;
+        attributes: Record<string, unknown>;
+      };
+    }>(
+      {
+        request: {
+          url: 'https://winds.mobi/api/2.3/stations/holfuy-1850?keys=pv-name&keys=url',
+        },
+      } as never,
+      async () =>
+        ({
+          content: {
+            _id: 'holfuy-1850',
+            'pv-name': 'holfuy.com',
+            url: {
+              en: 'https://holfuy.com/en/weather/1850',
+            },
+          },
+        }) as never
+    );
+
+    assert.deepEqual(response.data.attributes, {
+      _id: 'holfuy-1850',
+      providerName: 'holfuy.com',
+      providerUrl: 'https://holfuy.com/en/weather/1850',
+    });
+  });
+});


### PR DESCRIPTION
### Changed

- Refined the desktop navbar so the refresh action now sits directly with the main navigation as a compact icon button, while the mobile drawer keeps a full-width labeled refresh button.
- Simplified the refresh action presentation by removing the extra countdown and hover title text, and added a subtle one-shot spin animation on the refresh icon when you trigger a manual refresh.
- Trimmed the map station payload further so provider details are loaded only when opening a station, keeping the initial map data leaner.

### Fixed

- Fixed station details so provider links now appear reliably the first time a station sidebar opens, instead of sometimes only showing up after reopening or switching stations.
- Fixed station sidebar provider links so they now appear only when a complete provider link is available, avoiding empty or incomplete provider entries while station details are still loading.