### PR TITLE
Start the map on the user's location (fixes #32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,11 @@ state, route models, and query params.
 - **Prefer declarative, derived state.** Express derived data as `get` getters from tracked/route/query-param state.
   Excessive local `@tracked` is a smell — look for a simpler root state to derive from. Don't add duplicate guard state
   preemptively; only add "pending/applied/in-flight" tracking after confirming a real rerender or repeated-invocation bug.
+- **No imperative bookkeeping in untracked private fields.** Don't reach for plain `#flag`/`#counter`/`#didX` fields to
+  gate one-time setup, dedupe stale async results, or remember "have I done this yet." That's imperative state that
+  side-steps reactivity. Instead: subscribe/teardown once via a **modifier**; derive one-shot conditions from existing
+  state (e.g. "still the default view?") so they self-disarm; and detect stale async by comparing the current cached
+  value/Future identity rather than a version counter. Reactive state that the template reads must be `@tracked`.
 - Keep imperative DOM / third-party library integration inside **modifiers** ([app/modifiers/](app/modifiers/)).
 - **Never use Ember's runloop** (`@ember/runloop`: `scheduleOnce`, `next`, `later`, `debounce`, `run`, etc.). If you
   reach for it to defer a state write or break a render cycle, that's a signal the state is modeled imperatively —

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -31,8 +31,12 @@ import {
   responseData,
 } from 'winds-mobi-client-web/utils/request-response';
 import { DEFAULT_POSITION_OPTIONS } from 'winds-mobi-client-web/utils/location';
+import bindGeolocateEvents, {
+  type GeolocateEventHandlers,
+} from 'winds-mobi-client-web/modifiers/bind-geolocate-events';
 import {
   approximateMapBoundsFromView,
+  INITIAL_LOCATION_ZOOM,
   mapViewsEqual,
   mapViewFromMap,
   parseMapView,
@@ -108,7 +112,6 @@ export default class Map extends Component<MapSignature> {
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
 
   @tracked stations: Station[] = [];
-  #requestVersion = 0;
 
   private navigationControl = new NavigationControl({
     showCompass: true,
@@ -116,11 +119,21 @@ export default class Map extends Component<MapSignature> {
   });
   private geolocateControl = new GeolocateControl({
     positionOptions: DEFAULT_POSITION_OPTIONS,
+    fitBoundsOptions: { maxZoom: INITIAL_LOCATION_ZOOM },
     showAccuracyCircle: true,
     showUserLocation: true,
     trackUserLocation: true,
   });
-  #didBindGeolocateEvents = false;
+
+  // Stable handler object for the `bindGeolocateEvents` modifier.
+  geolocateHandlers: GeolocateEventHandlers = {
+    onStart: () => this.nearbyLocation.beginLocationRequest(),
+    onGeolocate: (position) => {
+      this.nearbyLocation.updateFromPosition(position);
+      this.centerOnInitialLocation(position);
+    },
+    onError: (error) => this.nearbyLocation.updateFromError(error),
+  };
 
   private terrainControl =
     config.environment === 'test'
@@ -158,10 +171,12 @@ export default class Map extends Component<MapSignature> {
 
     const request =
       this.requestStore.request<RequestResponse<Station[]>>(options);
-    const requestVersion = ++this.#requestVersion;
 
     void request.then((result) => {
-      if (this.#requestVersion !== requestVersion) {
+      // Ignore a stale response: if the routed view changed while this request
+      // was in flight, `this.request` is now a different (cached) Future and its
+      // own result will set the stations.
+      if (this.request !== request) {
         return;
       }
 
@@ -212,13 +227,19 @@ export default class Map extends Component<MapSignature> {
     });
   }
 
+  // True on a fresh load where no view is present in the URL, so the routed view
+  // still equals the whole-Switzerland default.
+  get isInitialDefaultView() {
+    return mapViewsEqual(this.mapView, parseMapView());
+  }
+
   @action
   handleMapLoaded() {
-    // The initial request viewport is already derived from the routed map view
-    // (see the `request` getter fallback); writing `requestedViewport` here would
-    // mutate tracked state that the same render already read. Real bounds are
-    // captured on the first `moveend` instead.
-    this.bindGeolocateEvents();
+    // On a fresh load, ask the map's own geolocation for the user's position and
+    // center on it; otherwise the whole-Switzerland default view stays (#32).
+    if (this.isInitialDefaultView && config.environment !== 'test') {
+      this.geolocateControl.trigger();
+    }
   }
 
   @action
@@ -254,21 +275,23 @@ export default class Map extends Component<MapSignature> {
     });
   }
 
-  private bindGeolocateEvents() {
-    if (this.#didBindGeolocateEvents) {
+  // Center the routed view on the user the first time geolocation resolves after
+  // a fresh load. Guarded by the derived `isInitialDefaultView`: once we center,
+  // the routed view is no longer the default, so later tracking updates and
+  // manual geolocations don't re-center. Runs from the async geolocate event
+  // (post-render), so updating the URL here is safe; everything else (fly-to,
+  // station request) follows the routed view.
+  private centerOnInitialLocation(position: GeolocationPosition) {
+    if (!this.isInitialDefaultView) {
       return;
     }
 
-    this.#didBindGeolocateEvents = true;
-
-    this.geolocateControl.on('trackuserlocationstart', () => {
-      this.nearbyLocation.beginLocationRequest();
-    });
-    this.geolocateControl.on('geolocate', (event) => {
-      this.nearbyLocation.updateFromPosition(event.data);
-    });
-    this.geolocateControl.on('error', (event) => {
-      this.nearbyLocation.updateFromError(event.data);
+    this.router.replaceWith({
+      queryParams: serializeMapView({
+        longitude: position.coords.longitude,
+        latitude: position.coords.latitude,
+        zoom: INITIAL_LOCATION_ZOOM,
+      }),
     });
   }
 
@@ -283,7 +306,11 @@ export default class Map extends Component<MapSignature> {
   }
 
   <template>
-    <div data-test-map-container class="relative h-full w-full">
+    <div
+      data-test-map-container
+      class="relative h-full w-full"
+      {{bindGeolocateEvents this.geolocateControl this.geolocateHandlers}}
+    >
       <Request @request={{this.request}}>
         <:content></:content>
       </Request>

--- a/app/modifiers/bind-geolocate-events.ts
+++ b/app/modifiers/bind-geolocate-events.ts
@@ -1,0 +1,40 @@
+import { modifier } from 'ember-modifier';
+import type { GeolocateControl } from 'maplibre-gl';
+
+export interface GeolocateEventHandlers {
+  onStart: () => void;
+  onGeolocate: (position: GeolocationPosition) => void;
+  onError: (error?: GeolocationPositionError) => void;
+}
+
+interface BindGeolocateEventsSignature {
+  Element: HTMLElement;
+  Args: {
+    Positional: [GeolocateControl, GeolocateEventHandlers];
+  };
+}
+
+// Subscribe to a MapLibre GeolocateControl's events for the element's lifetime,
+// tearing the subscriptions down on destroy — instead of binding imperatively
+// with a one-time guard flag.
+const bindGeolocateEvents = modifier<BindGeolocateEventsSignature>(
+  (_element, [control, handlers]) => {
+    const onStart = () => handlers.onStart();
+    const onGeolocate = (event: { data: GeolocationPosition }) =>
+      handlers.onGeolocate(event.data);
+    const onError = (event: { data?: GeolocationPositionError }) =>
+      handlers.onError(event.data);
+
+    control.on('trackuserlocationstart', onStart);
+    control.on('geolocate', onGeolocate);
+    control.on('error', onError);
+
+    return () => {
+      control.off('trackuserlocationstart', onStart);
+      control.off('geolocate', onGeolocate);
+      control.off('error', onError);
+    };
+  }
+);
+
+export default bindGeolocateEvents;

--- a/app/utils/map-view.ts
+++ b/app/utils/map-view.ts
@@ -1,8 +1,14 @@
 import type { Map as MaplibreMap } from 'ember-maplibre-gl';
 
-export const DEFAULT_MAP_LNG = 7.82667;
-export const DEFAULT_MAP_LAT = 46.69299;
-export const DEFAULT_MAP_ZOOM = 10.94;
+// Whole-Switzerland overview: the default when no view is in the URL and the
+// user's location is unavailable (see issue #32).
+export const DEFAULT_MAP_LNG = 8.2275;
+export const DEFAULT_MAP_LAT = 46.8011;
+export const DEFAULT_MAP_ZOOM = 7;
+
+// Zoom applied when centering the map on the user's location at startup — a
+// large area around them rather than a street-level view.
+export const INITIAL_LOCATION_ZOOM = 10;
 export const MAP_REQUEST_COORDINATE_THRESHOLD = 0.01;
 export const MAP_REQUEST_ZOOM_THRESHOLD = 0.25;
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0 - 2026-06-15
+
+### Changed
+
+- The map now starts centered on your location when it is available, showing a large area around you; when location is unavailable it opens on the whole of Switzerland instead of always jumping to a fixed region around Interlaken on a new tab or refresh.
+
 ## v0.1.0 - 2026-04-05
 
 ### Added


### PR DESCRIPTION
Fixes #32.

> Stacked on #33 (`mb/station-search`) — base is that branch so the diff stays scoped. Retarget to `main` once #33 merges.

## Problem
Opening a new tab or refreshing always defaulted the map to a fixed region around Interlaken, even when the user had granted location access.

## Change
- **Default view** is now a **whole-Switzerland overview** (zoom 7) instead of Interlaken — fixes the issue for users without location.
- **On a fresh load** (routed view still equals the default), the map's own `GeolocateControl` is triggered (`.trigger()`, the supported API — no second location mechanism, no hacks) and the routed view is centered on the first fix at a large-area zoom (10). If location is denied/unavailable, it stays on Switzerland.

Everything (fly-to, station request) keeps following the routed view, so this composes with the unidirectional map flow from #33.

## Idiomatic notes
Implemented without imperative untracked-field bookkeeping:
- Geolocate events are subscribed via a module-scope `ember-modifier` (`bind-geolocate-events`) with teardown, not a one-time guard flag.
- The one-shot "center on first fix" is derived from `isInitialDefaultView` (self-disarms once centered) rather than a boolean flag.
- Stale station responses are detected by comparing the cached request Future identity rather than a version counter.

CLAUDE.md updated with the corresponding guidance (no runloop already documented; added: no imperative untracked private-field state).

## Notes / for review
- Auto-trigger **prompts for geolocation on every fresh load** when permission isn't already granted (matches "ask the map for location at startup").
- No acceptance test for the geolocation trigger itself (mocking `GeolocateControl` would need brittle production seams); the auto-trigger is skipped in the test env. The Switzerland default is covered by the existing suite.

## Testing
- `pnpm lint` clean
- `pnpm test:ember` — **47/47 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)