### PR TITLE
Fix devcontainer build: drop stale patches COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN corepack enable && \
   pnpm config set store-dir "$PNPM_HOME/store" --global
 
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
-COPY patches ./patches
 RUN pnpm add -g ember-cli
 RUN pnpm install
 EXPOSE 4200


### PR DESCRIPTION
## Problem
The VS Code dev container / `docker compose build` failed:

```
ERROR [base 6/8] COPY patches ./patches
failed to compute cache key: "/patches": not found
```

The `Dockerfile` copies a `patches/` directory that doesn't exist, and the project has no pnpm `patchedDependencies`, so the step is dead.

## Fix
Removed the `COPY patches ./patches` line. `pnpm install` needs no patches directory.

## Verification
`docker build --target base .` now runs through `pnpm install` and exports the image successfully.

> Stacked on #35 (`mb/maplibre-0.6`) per "based on the latest branch". It's an independent one-line fix, so it can be retargeted/cherry-picked onto `main` if you want it merged sooner to unblock the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)