### PR TITLE
🧭 Bias station search toward known location

### DIFF
--- a/app/builders/station.ts
+++ b/app/builders/station.ts
@@ -9,6 +9,7 @@ import type {
 import type { QueryParamsSource } from '@warp-drive/core/types/params';
 import { query as jsonApiQuery } from '@warp-drive/utilities/json-api';
 import type { MapBounds } from 'winds-mobi-client-web/utils/map-view';
+import type { Coordinates } from 'winds-mobi-client-web/utils/location';
 
 import { findRecord as jsonApiFindRecord } from '@warp-drive/utilities/json-api';
 
@@ -144,7 +145,7 @@ function nearbyQuery<T>(
 function searchQuery<T>(
   type: string,
   search: string,
-  near?: { latitude: number; longitude: number },
+  near?: Coordinates,
   limit = 8,
   options?: ConstrainedRequestOptions
 ): QueryRequestOptions<{ data: T[] }> {

--- a/app/builders/station.ts
+++ b/app/builders/station.ts
@@ -144,6 +144,7 @@ function nearbyQuery<T>(
 function searchQuery<T>(
   type: string,
   search: string,
+  near?: { latitude: number; longitude: number },
   limit = 8,
   options?: ConstrainedRequestOptions
 ): QueryRequestOptions<{ data: T[] }> {
@@ -154,6 +155,10 @@ function searchQuery<T>(
       keys: [...summaryStationQueryKeys],
       limit,
       search: search.trim(),
+      ...(near && {
+        'near-lat': near.latitude,
+        'near-lon': near.longitude,
+      }),
     },
     options
   );

--- a/app/components/navbar/search.gts
+++ b/app/components/navbar/search.gts
@@ -13,6 +13,7 @@ import { Popover } from '@frontile/overlays';
 import { t } from 'ember-intl';
 import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
+import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import { searchQuery } from 'winds-mobi-client-web/builders/station';
 import { serializeMapView } from 'winds-mobi-client-web/utils/map-view';
 import {
@@ -32,6 +33,8 @@ const SEARCH_RESULT_ZOOM = 10;
 
 export default class NavbarSearch extends Component<NavbarSearchSignature> {
   @service declare router: RouterService;
+  @service('nearby-location')
+  declare nearbyLocation: NearbyLocationService;
   @service
   declare store: typeof import('winds-mobi-client-web/services/store').default;
 
@@ -58,7 +61,11 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
     }
 
     return this.store.request<RequestResponse<Station[]>>(
-      searchQuery<Station>('station', this.settledQuery)
+      searchQuery<Station>(
+        'station',
+        this.settledQuery,
+        this.nearbyLocation.coordinates
+      )
     );
   }
 

--- a/app/services/nearby-location.ts
+++ b/app/services/nearby-location.ts
@@ -1,11 +1,12 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { DEFAULT_POSITION_OPTIONS } from 'winds-mobi-client-web/utils/location';
+import {
+  type Coordinates,
+  DEFAULT_POSITION_OPTIONS,
+} from 'winds-mobi-client-web/utils/location';
 
-export type NearbyCoordinates = {
+export type NearbyCoordinates = Coordinates & {
   accuracy: number;
-  latitude: number;
-  longitude: number;
 };
 
 export type NearbyLocationErrorCode =

--- a/app/utils/location.ts
+++ b/app/utils/location.ts
@@ -1,3 +1,11 @@
+// A bare geographic point. Shared by anything that needs only latitude and
+// longitude (the search location bias, the nearby-location service, …) so the
+// shape is defined once rather than re-inlined per consumer.
+export type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
 export const DEFAULT_POSITION_OPTIONS: PositionOptions = {
   enableHighAccuracy: true,
   maximumAge: 5 * 60 * 1000,

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The browser tab icon now becomes the selected station's wind arrow — coloured by wind speed and gusts, rotated to the wind direction, and shaped for peaks — so an open station's latest reading is visible at a glance even from another tab. Closing the station restores the default icon.
 
+### Changed
+
+- Station search now favors stations near you when your location is already known, so the closest matches rise to the top instead of results being ranked by name alone (your location is never requested just to search).
+
 ## v0.3.0 - 2026-06-16
 
 ### Changed

--- a/tests/acceptance/navbar-search-test.ts
+++ b/tests/acceptance/navbar-search-test.ts
@@ -137,6 +137,14 @@ function countSearchRequests(calls: string[]) {
   ).length;
 }
 
+function lastSearchRequestParams(calls: string[]) {
+  const url = [...calls]
+    .reverse()
+    .find((call) => call.includes('/stations?') && call.includes('search='));
+
+  return url ? new URL(url, 'https://winds.mobi').searchParams : undefined;
+}
+
 module('Acceptance | navbar search', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -162,6 +170,18 @@ module('Acceptance | navbar search', function (hooks) {
     await waitUntil(() => countSearchRequests(store.calls) > 0);
     await waitUntil(() => find('[data-test-navbar-search-results]'));
 
+    const searchParams = lastSearchRequestParams(store.calls);
+    assert.strictEqual(
+      searchParams?.get('near-lat'),
+      '46.69299',
+      'the search is biased toward the known latitude'
+    );
+    assert.strictEqual(
+      searchParams?.get('near-lon'),
+      '7.82667',
+      'the search is biased toward the known longitude'
+    );
+
     assert
       .dom('[data-test-navbar-search-result="holfuy-1850"]')
       .includesText('Lehn');
@@ -178,6 +198,26 @@ module('Acceptance | navbar search', function (hooks) {
       mapLng: '7.82554',
       mapZoom: '10',
     });
+  });
+
+  test('it searches without a location bias when the position is unknown', async function (assert) {
+    const store = this.owner.lookup('service:store') as FakeStoreService;
+    const nearbyLocation = this.owner.lookup('service:nearby-location');
+    nearbyLocation.coordinates = undefined;
+
+    await visit('/map?mapLat=46.54321&mapLng=8.12345&mapZoom=9.5');
+    await fillIn('[data-test-navbar-search="navbar"] input', 'leh');
+    await waitUntil(() => countSearchRequests(store.calls) > 0);
+
+    const searchParams = lastSearchRequestParams(store.calls);
+    assert.false(
+      searchParams?.has('near-lat'),
+      'no latitude bias is sent when the position is unknown'
+    );
+    assert.false(
+      searchParams?.has('near-lon'),
+      'no longitude bias is sent when the position is unknown'
+    );
   });
 
   test('it uses zoom 10 when searching from a non-map route', async function (assert) {

--- a/tests/unit/builders/station-test.ts
+++ b/tests/unit/builders/station-test.ts
@@ -28,4 +28,24 @@ module('Unit | Builder | station', function () {
     assert.false(url.searchParams.has('within-pt2-lat'));
     assert.false(url.searchParams.has('within-pt2-lon'));
   });
+
+  test('searchQuery omits the location bias when no position is given', function (assert) {
+    const request = searchQuery('station', 'leh') as { url: string };
+    const url = new URL(request.url, 'https://winds.mobi');
+
+    assert.false(url.searchParams.has('near-lat'));
+    assert.false(url.searchParams.has('near-lon'));
+  });
+
+  test('searchQuery biases toward a known position when one is given', function (assert) {
+    const request = searchQuery('station', 'leh', {
+      latitude: 46.68084,
+      longitude: 7.82554,
+    }) as { url: string };
+    const url = new URL(request.url, 'https://winds.mobi');
+
+    assert.strictEqual(url.searchParams.get('near-lat'), '46.68084');
+    assert.strictEqual(url.searchParams.get('near-lon'), '7.82554');
+    assert.strictEqual(url.searchParams.get('search'), 'leh');
+  });
 });


### PR DESCRIPTION
Why: When the user's position is already known, search results should prioritize nearby stations instead of being purely text-ranked.

How: searchQuery accepts an optional near {latitude, longitude} and appends near-lat/near-lon when present; navbar/search injects nearby-location and passes its coordinates into the request getter.

Notes: Only uses an already-known position — it never triggers a geolocation permission prompt. The request getter reads tracked coordinates, so it re-fires declaratively if position becomes known mid-search.