### PR TITLE
🔎 Increase station panel readability

### DIFF
--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -56,7 +56,7 @@ export default class Polar extends Component<PolarSignature> {
         },
         distance: '86%',
         style: {
-          fontSize: '10px',
+          fontSize: '11px',
         },
       },
     },
@@ -103,7 +103,7 @@ export default class Polar extends Component<PolarSignature> {
               labels: {
                 distance: '78%',
                 style: {
-                  fontSize: '8px',
+                  fontSize: '10px',
                 },
               },
             },

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -98,17 +98,17 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
       ],
       buttonSpacing: 4,
       buttonTheme: {
-        height: 22,
-        padding: 2,
+        height: 24,
+        padding: 3,
         r: 6,
         style: {
-          fontSize: '10px',
+          fontSize: '12px',
           fontWeight: '600',
         },
       },
       selected: 4,
       labelStyle: {
-        fontSize: '10px',
+        fontSize: '12px',
       },
     },
     title: {
@@ -120,8 +120,8 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
       crosshair: true,
       labels: {
         style: {
-          fontSize: '10px',
-          lineHeight: '12px',
+          fontSize: '12px',
+          lineHeight: '14px',
         },
         useHTML: true,
         formatter: function (this: {
@@ -170,8 +170,8 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
             xAxis: {
               labels: {
                 style: {
-                  fontSize: '9px',
-                  lineHeight: '11px',
+                  fontSize: '11px',
+                  lineHeight: '13px',
                 },
               },
             },
@@ -185,8 +185,8 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
             xAxis: {
               labels: {
                 style: {
-                  fontSize: '8px',
-                  lineHeight: '10px',
+                  fontSize: '10px',
+                  lineHeight: '12px',
                 },
               },
             },

--- a/app/components/station/air/presenter.gts
+++ b/app/components/station/air/presenter.gts
@@ -85,6 +85,9 @@ export default class StationAirContent extends Component<StationAirContentSignat
           },
           labels: {
             format: '{value:.0f}°C',
+            style: {
+              fontSize: '12px',
+            },
           },
           maxPadding: 0.04,
           minPadding: 0.02,
@@ -101,6 +104,9 @@ export default class StationAirContent extends Component<StationAirContentSignat
           },
           labels: {
             format: '{value:.0f}%',
+            style: {
+              fontSize: '12px',
+            },
           },
           maxPadding: 0.04,
           minPadding: 0.02,

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -48,7 +48,7 @@ export default class StationHeader extends Component<StationHeaderSignature> {
       </h2>
 
       <dl
-        class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium text-slate-500"
+        class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] font-medium text-slate-500"
       >
         {{! Peaks (free-flight take-off sites) get the mountain glyph; other }}
         {{! stations get a plain location pin, mirroring the map-marker shape. }}

--- a/app/components/station/meta-item.gts
+++ b/app/components/station/meta-item.gts
@@ -19,7 +19,7 @@ export interface StationMetaItemSignature {
   <div class="flex items-center gap-1.5">
     <dt class="sr-only">{{@label}}</dt>
     <dd class="m-0 inline-flex items-center gap-1.5" ...attributes>
-      <@icon @size={{12}} class="text-slate-400" />
+      <@icon @size={{14}} class="text-slate-400" />
       {{yield}}
     </dd>
   </div>

--- a/app/components/station/metric-card.gts
+++ b/app/components/station/metric-card.gts
@@ -92,13 +92,13 @@ export default class StationMetricCard extends Component<StationMetricCardSignat
         ...attributes
       >
         <dt
-          class="text-[9px] font-medium leading-tight text-slate-500 md:text-[11px]
+          class="text-[11px] font-medium leading-tight text-slate-500 md:text-xs
             {{if @labelClass @labelClass}}"
         >
           {{@label}}
         </dt>
         <dd
-          class="mt-0.5 text-[13px] font-semibold leading-tight md:mt-1.5 md:text-base
+          class="mt-0.5 text-base font-semibold leading-tight md:mt-1.5 md:text-lg
             {{if @valueClass @valueClass}}"
         >
           {{this.formattedValue}}

--- a/app/components/station/section-card.gts
+++ b/app/components/station/section-card.gts
@@ -15,7 +15,7 @@ export interface StationSectionCardSignature {
     ...attributes
   >
     <p
-      class="text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-500 md:text-[11px] md:tracking-[0.16em]
+      class="text-[11px] font-semibold uppercase tracking-[0.1em] text-slate-500 md:text-xs md:tracking-[0.14em]
         {{if @titleClass @titleClass}}"
     >
       {{@title}}

--- a/app/components/station/wind/presenter.gts
+++ b/app/components/station/wind/presenter.gts
@@ -67,6 +67,9 @@ export default class StationWindContent extends Component<StationWindContentSign
         },
         labels: {
           format: '{value:.0f} km/h',
+          style: {
+            fontSize: '12px',
+          },
         },
         maxPadding: 0.04,
         minPadding: 0.02,

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Station search now favors stations near you when your location is already known, so the closest matches rise to the top instead of results being ranked by name alone (your location is never requested just to search).
+- Made the station detail panel easier to read, especially on mobile: larger values and labels in the summary and last-hour cards, bigger compass labels (N, NE, E…) on the wind-direction chart, and larger axis and range-selector text in the wind and air charts.
 
 ## v0.3.0 - 2026-06-16
 


### PR DESCRIPTION
Why: The station detail panel — especially on mobile — rendered values, labels, compass directions, and chart text too small to read comfortably. How: Bumped font sizes in the summary/last-hour metric cards, section headings, and header meta line; enlarged the wind-direction compass labels (N, NE, E…) and the wind/air chart axis and range-selector text. Notes: Style/Highcharts-option changes only; no behavior changes.