### PR TITLE
🧭 Show selected station as the browser favicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,11 @@ state, route models, and query params.
 - Do **not** add test-only seams, exposed instance handles, or DOM hacks to production components to make them testable.
   DOM selectors in tests are fine; production test hooks are not. Prefer a smaller real test, or skip the test, over
   complicating the production API.
+- **Never reach for raw DOM in tests** (`document.querySelector`/`querySelectorAll`, `getElementById`, `.textContent`,
+  `.getAttribute`, etc.). Assert with **qunit-dom** (`assert.dom(selector).exists()/.hasText()/.hasAttribute(...)`, and
+  `assert.dom(selector, rootElement)` to scope — e.g. `document.head` for head content); `hasAttribute` accepts a regex
+  for partial matches. For non-assertion queries — `waitUntil` predicates, or collecting values for a `deepEqual` —
+  use the `@ember/test-helpers` `find`/`findAll` helpers, never `document.querySelector*`.
 
 ### Changelog
 

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -1,32 +1,14 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
-import windToColour from 'winds-mobi-client-web/helpers/wind-to-colour';
+import {
+  colourForWindReading,
+  MARKER_CONTRAST_OUTLINE_COLOUR,
+  MARKER_CONTRAST_OUTLINE_WIDTH,
+  MARKER_GUSTS_OUTLINE_WIDTH,
+  stationArrowGeometry,
+} from 'winds-mobi-client-web/utils/station-arrow';
 import type { Station } from 'winds-mobi-client-web/services/store';
-
-// Two whole-marker shapes that share a circular hub: regular stations get the
-// rounded-shoulder arrow; peaks get the v1 "star"-shouldered arrow so they read
-// as a different shape on the map (echoing the round/triangle distinction of the
-// v1 map). Each shape has its own viewBox; both are 340 units tall so they render
-// at the same on-screen size, and each rotates around its own viewBox centre.
-const STATION_ARROW_PATH =
-  'M -60,147.1 C -31.1,138.5 -10,111.7 -10,80 -10,48.3 -31.1,21.5 -60,12.9 V -70 h -40 v 82.9 c -28.9,8.6 -50,35.4 -50,67.1 0,31.7 21.1,58.5 50,67.1 V 195 l -50,-25 70,100 70,-100 -50,25 z M -115,80 c 0,-19.3 15.7,-35 35,-35 19.3,0 35,15.7 35,35 0,19.3 -15.7,35 -35,35 -19.3,0 -35,-15.7 -35,-35 z';
-const STATION_ARROW_VIEW_BOX = '-150 -70 140 340';
-const STATION_ARROW_ROTATION_CENTRE = '-80 100';
-const STATION_PEAK_ARROW_PATH =
-  'M20,67.4L88.3-51H20v-99h-40v99h-68.3L-20,67.4V115l-50-25L0,190L70,90l-50,25V67.4z M-35,0c0-19.3,15.7-35,35-35S35-19.3,35,0S19.3,35,0,35S-35,19.3-35,0z';
-const STATION_PEAK_ARROW_VIEW_BOX = '-89 -150 178 340';
-const STATION_PEAK_ARROW_ROTATION_CENTRE = '0 20';
-const STALE_READING_THRESHOLD = 24 * 60 * 60 * 1000;
-const STALE_STATION_COLOUR = 'rgb(148, 163, 184)';
-// The arrow carries two readings as a double outline: the gusts colour is the
-// visible outline, drawn over a slightly wider black stroke. SVG strokes are
-// single-valued and centred, so the path is rendered twice in the same rotation
-// group — black underneath, gusts on top — leaving a thin black rim beyond the
-// gusts ring for contrast against the map.
-const MARKER_CONTRAST_OUTLINE_COLOUR = 'rgb(0, 0, 0)';
-const MARKER_CONTRAST_OUTLINE_WIDTH = '32';
-const MARKER_GUSTS_OUTLINE_WIDTH = '16';
 
 export interface MapStationMarkerSignature {
   Args: {
@@ -38,44 +20,30 @@ export interface MapStationMarkerSignature {
 }
 
 export default class MapStationMarker extends Component<MapStationMarkerSignature> {
+  get geometry() {
+    return stationArrowGeometry(this.args.station.isPeak);
+  }
+
   get arrowPath() {
-    return this.args.station.isPeak
-      ? STATION_PEAK_ARROW_PATH
-      : STATION_ARROW_PATH;
+    return this.geometry.path;
   }
 
   get viewBox() {
-    return this.args.station.isPeak
-      ? STATION_PEAK_ARROW_VIEW_BOX
-      : STATION_ARROW_VIEW_BOX;
-  }
-
-  private colourForWindReading(speed: number) {
-    const { timestamp } = this.args.station.last;
-
-    if (!Number.isFinite(timestamp)) {
-      return windToColour(speed);
-    }
-
-    return Date.now() - timestamp > STALE_READING_THRESHOLD
-      ? STALE_STATION_COLOUR
-      : windToColour(speed);
+    return this.geometry.viewBox;
   }
 
   get markerColor() {
-    return this.colourForWindReading(this.args.station.last.speed);
+    const { speed, timestamp } = this.args.station.last;
+    return colourForWindReading(speed, timestamp);
   }
 
   get gustsColor() {
-    return this.colourForWindReading(this.args.station.last.gusts);
+    const { gusts, timestamp } = this.args.station.last;
+    return colourForWindReading(gusts, timestamp);
   }
 
   get rotationTransform() {
-    const centre = this.args.station.isPeak
-      ? STATION_PEAK_ARROW_ROTATION_CENTRE
-      : STATION_ARROW_ROTATION_CENTRE;
-
-    return `rotate(${this.args.station.last.direction} ${centre})`;
+    return `rotate(${this.args.station.last.direction} ${this.geometry.rotationCentre})`;
   }
 
   get buttonClass() {

--- a/app/templates/map/station.gts
+++ b/app/templates/map/station.gts
@@ -6,6 +6,7 @@ import { cached } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 import { findRecord } from 'winds-mobi-client-web/builders/station';
+import { stationFaviconDataUri } from 'winds-mobi-client-web/utils/station-favicon';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
 import type { Station as StationModel } from 'winds-mobi-client-web/services/store.js';
 
@@ -52,10 +53,27 @@ export default class MapStationTemplate extends Component<MapStationTemplateSign
       : undefined;
   }
 
+  get faviconDataUri(): string | undefined {
+    return this.station ? stationFaviconDataUri(this.station) : undefined;
+  }
+
+  // `{{in-element}}` destination for the dynamic favicon. While a station is
+  // open this renders the only explicit `<link rel="icon">`, so the browser
+  // uses it; Glimmer removes it when the panel tears down, falling back to the
+  // static `/favicon.ico`. `insertBefore=null` appends rather than clearing the
+  // head's existing content.
+  get documentHead() {
+    return document.head;
+  }
+
   <template>
     {{#if this.stationId}}
       {{#if this.station}}
         {{pageTitle this.station.name}}
+
+        {{#in-element this.documentHead insertBefore=null}}
+          <link rel="icon" type="image/svg+xml" href={{this.faviconDataUri}} />
+        {{/in-element}}
       {{/if}}
 
       <Station @station={{this.station}} />

--- a/app/utils/station-arrow.ts
+++ b/app/utils/station-arrow.ts
@@ -1,0 +1,72 @@
+import windToColour from 'winds-mobi-client-web/helpers/wind-to-colour';
+
+// Two whole-marker shapes that share a circular hub: regular stations get the
+// rounded-shoulder arrow; peaks get the v1 "star"-shouldered arrow so they read
+// as a different shape (echoing the round/triangle distinction of the v1 map).
+// Each shape has its own viewBox; both are 340 units tall so they render at the
+// same on-screen size, and each rotates around its own viewBox centre.
+//
+// These constants are the single source of truth for the arrow geometry, shared
+// by the on-map marker ([app/components/map/station-marker.gts]) and the dynamic
+// browser favicon ([app/utils/station-favicon.ts]).
+export const STATION_ARROW_PATH =
+  'M -60,147.1 C -31.1,138.5 -10,111.7 -10,80 -10,48.3 -31.1,21.5 -60,12.9 V -70 h -40 v 82.9 c -28.9,8.6 -50,35.4 -50,67.1 0,31.7 21.1,58.5 50,67.1 V 195 l -50,-25 70,100 70,-100 -50,25 z M -115,80 c 0,-19.3 15.7,-35 35,-35 19.3,0 35,15.7 35,35 0,19.3 -15.7,35 -35,35 -19.3,0 -35,-15.7 -35,-35 z';
+export const STATION_ARROW_VIEW_BOX = '-150 -70 140 340';
+export const STATION_ARROW_ROTATION_CENTRE = '-80 100';
+export const STATION_PEAK_ARROW_PATH =
+  'M20,67.4L88.3-51H20v-99h-40v99h-68.3L-20,67.4V115l-50-25L0,190L70,90l-50,25V67.4z M-35,0c0-19.3,15.7-35,35-35S35-19.3,35,0S19.3,35,0,35S-35,19.3-35,0z';
+export const STATION_PEAK_ARROW_VIEW_BOX = '-89 -150 178 340';
+export const STATION_PEAK_ARROW_ROTATION_CENTRE = '0 20';
+
+// The on-map marker leans on `overflow-visible` so the rotating arrow may spill
+// past its (tall, narrow) viewBox. A clipped context like a favicon can't do
+// that, so each shape also carries a square viewBox centred on its rotation
+// centre, large enough to contain the arrow at any rotation plus the outline.
+export const STATION_ARROW_FAVICON_VIEW_BOX = '-300 -120 440 440';
+export const STATION_PEAK_ARROW_FAVICON_VIEW_BOX = '-220 -200 440 440';
+
+const STALE_READING_THRESHOLD = 24 * 60 * 60 * 1000;
+export const STALE_STATION_COLOUR = 'rgb(148, 163, 184)';
+
+// The arrow carries two readings as a double outline: the gusts colour is the
+// visible outline, drawn over a slightly wider black stroke. SVG strokes are
+// single-valued and centred, so the path is rendered twice in the same rotation
+// group — black underneath, gusts on top — leaving a thin black rim beyond the
+// gusts ring for contrast.
+export const MARKER_CONTRAST_OUTLINE_COLOUR = 'rgb(0, 0, 0)';
+export const MARKER_CONTRAST_OUTLINE_WIDTH = '32';
+export const MARKER_GUSTS_OUTLINE_WIDTH = '16';
+
+export interface StationArrowGeometry {
+  path: string;
+  viewBox: string;
+  rotationCentre: string;
+  faviconViewBox: string;
+}
+
+export function stationArrowGeometry(isPeak: boolean): StationArrowGeometry {
+  return isPeak
+    ? {
+        path: STATION_PEAK_ARROW_PATH,
+        viewBox: STATION_PEAK_ARROW_VIEW_BOX,
+        rotationCentre: STATION_PEAK_ARROW_ROTATION_CENTRE,
+        faviconViewBox: STATION_PEAK_ARROW_FAVICON_VIEW_BOX,
+      }
+    : {
+        path: STATION_ARROW_PATH,
+        viewBox: STATION_ARROW_VIEW_BOX,
+        rotationCentre: STATION_ARROW_ROTATION_CENTRE,
+        faviconViewBox: STATION_ARROW_FAVICON_VIEW_BOX,
+      };
+}
+
+// A reading older than a day is drawn grey rather than in its wind-speed colour.
+export function colourForWindReading(speed: number, timestamp: number): string {
+  if (!Number.isFinite(timestamp)) {
+    return windToColour(speed);
+  }
+
+  return Date.now() - timestamp > STALE_READING_THRESHOLD
+    ? STALE_STATION_COLOUR
+    : windToColour(speed);
+}

--- a/app/utils/station-favicon.ts
+++ b/app/utils/station-favicon.ts
@@ -1,0 +1,48 @@
+import {
+  colourForWindReading,
+  MARKER_CONTRAST_OUTLINE_COLOUR,
+  MARKER_CONTRAST_OUTLINE_WIDTH,
+  MARKER_GUSTS_OUTLINE_WIDTH,
+  stationArrowGeometry,
+} from 'winds-mobi-client-web/utils/station-arrow';
+import type { Station } from 'winds-mobi-client-web/services/store';
+
+// `windToColour` yields the wind-band colour as a CSS custom property reference
+// (`var(--color-wind-XX)`), which resolves against the live document for the
+// on-map marker. A favicon is rendered as an isolated SVG document where those
+// variables are undefined, so resolve them to concrete `rgb(...)` values here.
+// Keeping the CSS as the single source of truth (rather than duplicating the
+// RGB table) means the favicon tracks any palette change automatically.
+function resolveColour(colour: string): string {
+  const match = colour.match(/^var\((--[\w-]+)\)$/);
+
+  if (!match || typeof document === 'undefined') {
+    return colour;
+  }
+
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(match[1] as string)
+    .trim();
+
+  return value || colour;
+}
+
+// Builds an `image/svg+xml` data URI of the station's wind arrow, mirroring the
+// on-map marker (wind-speed fill, gusts-coloured outline over a black contrast
+// rim, rotated to the wind direction) so a selected station's reading is visible
+// in the browser tab.
+export function stationFaviconDataUri(station: Station): string {
+  const geometry = stationArrowGeometry(station.isPeak);
+  const { direction, speed, gusts, timestamp } = station.last;
+  const fill = resolveColour(colourForWindReading(speed, timestamp));
+  const gustsColour = resolveColour(colourForWindReading(gusts, timestamp));
+
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="${geometry.faviconViewBox}">` +
+    `<g transform="rotate(${direction} ${geometry.rotationCentre})">` +
+    `<path d="${geometry.path}" fill="${fill}" stroke="${MARKER_CONTRAST_OUTLINE_COLOUR}" stroke-linecap="round" stroke-linejoin="round" stroke-width="${MARKER_CONTRAST_OUTLINE_WIDTH}"/>` +
+    `<path d="${geometry.path}" fill="${fill}" stroke="${gustsColour}" stroke-linecap="round" stroke-linejoin="round" stroke-width="${MARKER_GUSTS_OUTLINE_WIDTH}"/>` +
+    `</g></svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- The browser tab icon now becomes the selected station's wind arrow — coloured by wind speed and gusts, rotated to the wind direction, and shaped for peaks — so an open station's latest reading is visible at a glance even from another tab. Closing the station restores the default icon.
+
 ## v0.3.0 - 2026-06-16
 
 ### Changed

--- a/tests/acceptance/map-station-panel-test.ts
+++ b/tests/acceptance/map-station-panel-test.ts
@@ -395,4 +395,27 @@ module('Acceptance | map station panel', function (hooks) {
         initialHistoryRequests + STATION_HISTORY_REQUESTS_PER_REFRESH
     );
   });
+
+  test('it shows the selected station as the browser favicon and restores it on close', async function (assert) {
+    await visit('/map/holfuy-1804?mapLat=46.67719&mapLng=7.86323&mapZoom=13');
+
+    assert
+      .dom("link[type='image/svg+xml']", document.head)
+      .exists('a favicon link is rendered into the document head')
+      .hasAttribute(
+        'href',
+        /^data:image\/svg\+xml,/,
+        'the favicon is an inline svg data uri'
+      )
+      .hasAttribute(
+        'href',
+        /rotate\(240/,
+        "the favicon arrow points to the station's wind direction"
+      );
+
+    await click('[data-test-station-close]');
+    await waitUntil(() => currentURL().startsWith('/map?'));
+
+    assert.dom("link[type='image/svg+xml']", document.head).doesNotExist();
+  });
 });

--- a/tests/acceptance/navbar-search-test.ts
+++ b/tests/acceptance/navbar-search-test.ts
@@ -4,6 +4,7 @@ import {
   click,
   currentURL,
   fillIn,
+  find,
   settled,
   visit,
   waitUntil,
@@ -159,9 +160,7 @@ module('Acceptance | navbar search', function (hooks) {
     await visit('/map?mapLat=46.54321&mapLng=8.12345&mapZoom=9.5');
     await fillIn('[data-test-navbar-search="navbar"] input', 'leh');
     await waitUntil(() => countSearchRequests(store.calls) > 0);
-    await waitUntil(
-      () => document.querySelector('[data-test-navbar-search-results]') !== null
-    );
+    await waitUntil(() => find('[data-test-navbar-search-results]'));
 
     assert
       .dom('[data-test-navbar-search-result="holfuy-1850"]')
@@ -184,11 +183,8 @@ module('Acceptance | navbar search', function (hooks) {
   test('it uses zoom 10 when searching from a non-map route', async function (assert) {
     await visit('/help');
     await fillIn('[data-test-navbar-search="navbar"] input', 'leh');
-    await waitUntil(
-      () =>
-        document.querySelector(
-          '[data-test-navbar-search-result="holfuy-1850"]'
-        ) !== null
+    await waitUntil(() =>
+      find('[data-test-navbar-search-result="holfuy-1850"]')
     );
 
     await click('[data-test-navbar-search-result="holfuy-1850"]');
@@ -213,9 +209,7 @@ module('Acceptance | navbar search', function (hooks) {
 
     await fillIn('[data-test-navbar-search="navbar"] input', 'zz');
     await waitUntil(() => countSearchRequests(store.calls) > 0);
-    await waitUntil(
-      () => document.querySelector('[data-test-navbar-search-empty]') !== null
-    );
+    await waitUntil(() => find('[data-test-navbar-search-empty]'));
 
     assert.dom('[data-test-navbar-search-empty]').hasText('No stations found.');
   });
@@ -223,11 +217,8 @@ module('Acceptance | navbar search', function (hooks) {
   test('it clears the search field and closes the results after selecting a station', async function (assert) {
     await visit('/map?mapLat=46.54321&mapLng=8.12345&mapZoom=9.5');
     await fillIn('[data-test-navbar-search="navbar"] input', 'leh');
-    await waitUntil(
-      () =>
-        document.querySelector(
-          '[data-test-navbar-search-result="holfuy-1850"]'
-        ) !== null
+    await waitUntil(() =>
+      find('[data-test-navbar-search-result="holfuy-1850"]')
     );
 
     await click('[data-test-navbar-search-result="holfuy-1850"]');

--- a/tests/acceptance/nearby-route-test.ts
+++ b/tests/acceptance/nearby-route-test.ts
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { click, visit, waitUntil } from '@ember/test-helpers';
+import { click, findAll, visit, waitUntil } from '@ember/test-helpers';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
 import MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
@@ -135,8 +135,7 @@ function stubGrantedPermission(nearbyLocation: NearbyLocationService) {
 async function waitForNearbyStations() {
   await waitUntil(
     () =>
-      document.querySelectorAll(NEARBY_STATION_CARD_SELECTOR).length ===
-      STATION_FIXTURES.length
+      findAll(NEARBY_STATION_CARD_SELECTOR).length === STATION_FIXTURES.length
   );
 }
 

--- a/tests/integration/components/station/last-hour/index-test.ts
+++ b/tests/integration/components/station/last-hour/index-test.ts
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { render, settled } from '@ember/test-helpers';
+import { find, findAll, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { Type } from '@warp-drive/core/types/symbols';
 import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
@@ -67,14 +67,14 @@ function lastHourRequestUrl(stationId: string) {
   ).url!;
 }
 
-function renderedPointSignature(root: Element) {
-  return [...root.querySelectorAll('.highcharts-point')]
+function renderedPointSignature() {
+  return findAll('.highcharts-point')
     .map((point) => point.getAttribute('d'))
     .filter((value): value is string => Boolean(value));
 }
 
-function renderedGraphSignature(root: Element) {
-  return root.querySelector('.highcharts-graph')?.getAttribute('d');
+function renderedGraphSignature() {
+  return find('.highcharts-graph')?.getAttribute('d');
 }
 
 module('Integration | Component | station/last-hour', function (hooks) {
@@ -181,8 +181,8 @@ module('Integration | Component | station/last-hour', function (hooks) {
     await render(hbs`<Station::LastHour @stationId={{this.stationId}} />`);
     await settled();
 
-    const stationAInitialPoints = renderedPointSignature(this.element);
-    const stationAInitialGraph = renderedGraphSignature(this.element);
+    const stationAInitialPoints = renderedPointSignature();
+    const stationAInitialGraph = renderedGraphSignature();
 
     assert.true(stationAInitialPoints.length > 0);
     assert.true(Boolean(stationAInitialGraph));
@@ -193,14 +193,8 @@ module('Integration | Component | station/last-hour', function (hooks) {
     this.stationId = 'station-a';
     await settled();
 
-    assert.deepEqual(
-      renderedPointSignature(this.element),
-      stationAInitialPoints
-    );
-    assert.strictEqual(
-      renderedGraphSignature(this.element),
-      stationAInitialGraph
-    );
+    assert.deepEqual(renderedPointSignature(), stationAInitialPoints);
+    assert.strictEqual(renderedGraphSignature(), stationAInitialGraph);
 
     deferredStationBHistory.resolve({
       content: {
@@ -209,13 +203,7 @@ module('Integration | Component | station/last-hour', function (hooks) {
     });
     await settled();
 
-    assert.deepEqual(
-      renderedPointSignature(this.element),
-      stationAInitialPoints
-    );
-    assert.strictEqual(
-      renderedGraphSignature(this.element),
-      stationAInitialGraph
-    );
+    assert.deepEqual(renderedPointSignature(), stationAInitialPoints);
+    assert.strictEqual(renderedGraphSignature(), stationAInitialGraph);
   });
 });

--- a/tests/integration/components/station/wind-direction/graph-test.ts
+++ b/tests/integration/components/station/wind-direction/graph-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render, settled } from '@ember/test-helpers';
+import { find, findAll, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { Type } from '@warp-drive/core/types/symbols';
 import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
@@ -9,14 +9,14 @@ type WindDirectionGraphTestContext = {
   data: History[];
 };
 
-function renderedPointSignature(root: Element) {
-  return [...root.querySelectorAll('.highcharts-point')]
+function renderedPointSignature() {
+  return findAll('.highcharts-point')
     .map((point) => point.getAttribute('d'))
     .filter((value): value is string => Boolean(value));
 }
 
-function renderedGraphSignature(root: Element) {
-  return root.querySelector('.highcharts-graph')?.getAttribute('d');
+function renderedGraphSignature() {
+  return find('.highcharts-graph')?.getAttribute('d');
 }
 
 module(
@@ -104,8 +104,8 @@ module(
       await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
       await settled();
 
-      const firstStationInitialPoints = renderedPointSignature(this.element);
-      const firstStationInitialGraph = renderedGraphSignature(this.element);
+      const firstStationInitialPoints = renderedPointSignature();
+      const firstStationInitialGraph = renderedGraphSignature();
 
       assert.true(firstStationInitialPoints.length > 0);
       assert.true(Boolean(firstStationInitialGraph));
@@ -180,14 +180,8 @@ module(
 
       await settled();
 
-      assert.deepEqual(
-        renderedPointSignature(this.element),
-        firstStationInitialPoints
-      );
-      assert.strictEqual(
-        renderedGraphSignature(this.element),
-        firstStationInitialGraph
-      );
+      assert.deepEqual(renderedPointSignature(), firstStationInitialPoints);
+      assert.strictEqual(renderedGraphSignature(), firstStationInitialGraph);
     });
   }
 );

--- a/tests/unit/utils/station-favicon-test.ts
+++ b/tests/unit/utils/station-favicon-test.ts
@@ -1,0 +1,93 @@
+import { module, test } from 'qunit';
+import { Type } from '@warp-drive/core/types/symbols';
+import { stationFaviconDataUri } from 'winds-mobi-client-web/utils/station-favicon';
+import type { Station } from 'winds-mobi-client-web/services/store';
+
+const BASE_STATION: Station = {
+  id: 'holfuy-1804',
+  altitude: 1804,
+  latitude: 46.67719,
+  longitude: 7.86323,
+  isPeak: false,
+  providerName: 'Holfuy',
+  providerUrl: 'https://example.com/stations/holfuy-1804',
+  name: 'Holfuy 1804',
+  last: {
+    timestamp: Date.now(),
+    direction: 240,
+    speed: 12,
+    gusts: 18,
+    temperature: 7,
+    humidity: 65,
+    pressure: 1012,
+    rain: 0,
+  },
+  [Type]: 'station',
+};
+
+function decode(dataUri: string): string {
+  const [, payload] = dataUri.split(',');
+  return decodeURIComponent(payload ?? '');
+}
+
+module('Unit | Utility | station-favicon', function () {
+  test('it builds an svg data uri rotated to the wind direction', function (assert) {
+    const dataUri = stationFaviconDataUri(BASE_STATION);
+
+    assert.true(
+      dataUri.startsWith('data:image/svg+xml,'),
+      'it produces an svg data uri'
+    );
+
+    const svg = decode(dataUri);
+
+    assert.true(svg.includes('<svg'), 'it contains an svg root');
+    assert.true(
+      svg.includes('rotate(240 -80 100)'),
+      'it rotates the arrow to the wind direction around the regular centre'
+    );
+    assert.strictEqual(
+      svg.match(/<path/g)?.length,
+      2,
+      'it draws the contrast and gusts strokes as two paths'
+    );
+  });
+
+  test('it uses the peak geometry for peak stations', function (assert) {
+    const svg = decode(
+      stationFaviconDataUri({ ...BASE_STATION, isPeak: true })
+    );
+
+    assert.true(
+      svg.includes('rotate(240 0 20)'),
+      'it rotates around the peak rotation centre'
+    );
+    assert.true(
+      svg.includes('-220 -200 440 440'),
+      'it uses the peak favicon viewBox'
+    );
+  });
+
+  test('it resolves wind-band colours to concrete values', function (assert) {
+    const svg = decode(stationFaviconDataUri(BASE_STATION));
+
+    assert.false(
+      svg.includes('var(--color-wind'),
+      'it does not leak unresolved CSS custom properties into the favicon'
+    );
+  });
+
+  test('it greys out stale readings', function (assert) {
+    const svg = decode(
+      stationFaviconDataUri({
+        ...BASE_STATION,
+        last: { ...BASE_STATION.last, timestamp: 0 },
+      })
+    );
+
+    assert.true(
+      svg.includes('rgb(148, 163, 184)'),
+      'a day-old reading is drawn in the stale colour'
+    );
+  });
+});


### PR DESCRIPTION
Closes #38

## Why
Surface the open station's live wind reading in the browser tab — not just its name — so a glance at the tab tells you speed, gusts, direction, and whether it's a peak.

## How
- Extracted the on-map marker's arrow geometry + colour logic into a shared `utils/station-arrow` module (single source of truth), and refactored `map/station-marker` to consume it.
- `utils/station-favicon` renders an SVG data URI mirroring the marker: wind-speed fill, gusts-coloured outline, rotation to wind direction, peak shape, stale-reading grey. Wind-band CSS custom properties are resolved to concrete `rgb(...)` since a favicon is an isolated document.
- The station route declaratively renders a single `<link rel="icon">` into the document head via the built-in `{{in-element this.documentHead insertBefore=null}}`. Glimmer inserts/updates/removes it reactively, so the tab icon tracks the open station and falls back to the default favicon on close — no imperative DOM bookkeeping, no modifier.

## Notes
- With no competing static icon link, the rendered SVG link is the only explicit favicon while a station is open, so the browser uses it unambiguously.
- Added unit coverage for the data-URI builder and an acceptance test asserting the head link appears on select and is removed on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)