### PR TITLE
⚙️ Local settings page + navigation & search polish

### DIFF
--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { on } from '@ember/modifier';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import {
   colourForWindReading,
   MARKER_CONTRAST_OUTLINE_COLOUR,
@@ -20,6 +22,8 @@ export interface MapStationMarkerSignature {
 }
 
 export default class MapStationMarker extends Component<MapStationMarkerSignature> {
+  @service declare settings: SettingsService;
+
   get geometry() {
     return stationArrowGeometry(this.args.station.isPeak);
   }
@@ -89,7 +93,7 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
           <path
             d={{this.arrowPath}}
             fill={{this.markerColor}}
-            stroke={{this.gustsColor}}
+            stroke={{if this.settings.showGustsOutline this.gustsColor "none"}}
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width={{MARKER_GUSTS_OUTLINE_WIDTH}}

--- a/app/components/navbar/menu/desktop.gts
+++ b/app/components/navbar/menu/desktop.gts
@@ -7,7 +7,8 @@ import { NAVBAR_MENU_ITEMS } from './items';
     {{#each NAVBAR_MENU_ITEMS as |item|}}
       <LinkTo
         @route={{item.route}}
-        class="inline-flex items-center gap-1.5 rounded-full border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 aria-[current=page]:border-wind-20 aria-[current=page]:bg-wind-20 aria-[current=page]:text-white"
+        @activeClass="border-wind-20 bg-wind-20 font-semibold text-white shadow-sm hover:border-wind-20 hover:text-white"
+        class="inline-flex items-center gap-1.5 rounded-full border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900"
         data-test-navbar-link={{item.route}}
       >
         <item.icon @size={{16}} />

--- a/app/components/navbar/menu/items.ts
+++ b/app/components/navbar/menu/items.ts
@@ -1,6 +1,7 @@
 import type { ComponentLike } from '@glint/template';
 import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import MapTrifold from 'ember-phosphor-icons/components/ph-map-trifold';
+import Gear from 'ember-phosphor-icons/components/ph-gear';
 import Lifebuoy from 'ember-phosphor-icons/components/ph-lifebuoy';
 
 export interface NavbarMenuItem {
@@ -10,7 +11,7 @@ export interface NavbarMenuItem {
     };
   }>;
   labelKey: string;
-  route: 'help' | 'map' | 'nearby';
+  route: 'help' | 'map' | 'nearby' | 'settings';
 }
 
 export const NAVBAR_MENU_ITEMS: readonly NavbarMenuItem[] = [
@@ -23,6 +24,11 @@ export const NAVBAR_MENU_ITEMS: readonly NavbarMenuItem[] = [
     icon: Binoculars,
     labelKey: 'navigation.nearby',
     route: 'nearby',
+  },
+  {
+    icon: Gear,
+    labelKey: 'navigation.settings',
+    route: 'settings',
   },
   {
     icon: Lifebuoy,

--- a/app/components/navbar/menu/mobile.gts
+++ b/app/components/navbar/menu/mobile.gts
@@ -65,7 +65,7 @@ export default class NavbarMenuMobile extends Component<NavbarMenuMobileSignatur
               {{#each NAVBAR_MENU_ITEMS as |item|}}
                 <LinkTo
                   @route={{item.route}}
-                  @activeClass="border-wind-20 bg-wind-5 text-wind-20"
+                  @activeClass="border-wind-20 bg-wind-20 font-semibold text-white shadow-sm hover:bg-wind-20 hover:text-white"
                   data-test-navbar-link={{item.route}}
                   class="inline-flex w-full items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 hover:text-slate-950"
                   {{on "click" this.close}}

--- a/app/components/navbar/search.gts
+++ b/app/components/navbar/search.gts
@@ -257,50 +257,46 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
         {{#if this.isPopoverOpen}}
           <popover.Content
             @blockScroll={{false}}
-            @class="p-0"
+            @class="overflow-hidden rounded-2xl border border-slate-200 bg-white p-0 shadow-xl shadow-slate-900/12"
             @closeOnEscapeKey={{true}}
             @closeOnOutsideClick={{true}}
             @disableFocusTrap={{true}}
             @preventAutoFocus={{true}}
             @size="trigger"
           >
-            <div
-              class="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-xl shadow-slate-900/12"
-            >
-              {{#if this.isLoading}}
-                <p
-                  data-test-navbar-search-loading
-                  class="px-4 py-3 text-sm font-medium text-slate-500"
-                >
-                  {{t "navigation.search.loading"}}
-                </p>
-              {{else if this.results.length}}
-                <ul
-                  aria-label={{t "navigation.search.label"}}
-                  data-test-navbar-search-results
-                  role="listbox"
-                  class="max-h-80 overflow-y-auto p-1"
-                >
-                  {{#each this.results as |station index|}}
-                    <li role="presentation">
-                      <NavbarSearchResult
-                        @isActive={{this.isActiveResult index}}
-                        @onActivate={{fn this.activateResult index}}
-                        @onSelect={{fn this.selectStation station}}
-                        @station={{station}}
-                      />
-                    </li>
-                  {{/each}}
-                </ul>
-              {{else if this.hasNoResults}}
-                <p
-                  data-test-navbar-search-empty
-                  class="px-4 py-3 text-sm font-medium text-slate-500"
-                >
-                  {{t "navigation.search.empty"}}
-                </p>
-              {{/if}}
-            </div>
+            {{#if this.isLoading}}
+              <p
+                data-test-navbar-search-loading
+                class="px-4 py-3 text-sm font-medium text-slate-500"
+              >
+                {{t "navigation.search.loading"}}
+              </p>
+            {{else if this.results.length}}
+              <ul
+                aria-label={{t "navigation.search.label"}}
+                data-test-navbar-search-results
+                role="listbox"
+                class="max-h-80 overflow-y-auto p-1"
+              >
+                {{#each this.results as |station index|}}
+                  <li role="presentation">
+                    <NavbarSearchResult
+                      @isActive={{this.isActiveResult index}}
+                      @onActivate={{fn this.activateResult index}}
+                      @onSelect={{fn this.selectStation station}}
+                      @station={{station}}
+                    />
+                  </li>
+                {{/each}}
+              </ul>
+            {{else if this.hasNoResults}}
+              <p
+                data-test-navbar-search-empty
+                class="px-4 py-3 text-sm font-medium text-slate-500"
+              >
+                {{t "navigation.search.empty"}}
+              </p>
+            {{/if}}
           </popover.Content>
         {{/if}}
       </Popover>

--- a/app/components/settings/showcase/favicon.gts
+++ b/app/components/settings/showcase/favicon.gts
@@ -1,5 +1,3 @@
-import { t } from 'ember-intl';
-import Wind from 'ember-phosphor-icons/components/ph-wind';
 import SettingsWindArrow from 'winds-mobi-client-web/components/settings/wind-arrow';
 
 export interface SettingsShowcaseFaviconSignature {
@@ -10,8 +8,9 @@ export interface SettingsShowcaseFaviconSignature {
 }
 
 // A small browser-tab mock: when the preference is on, the favicon slot holds
-// the selected station's wind arrow; when off, it falls back to the generic
-// winds.mobi mark.
+// the selected station's wind arrow; when off, it falls back to the standard
+// winds.mobi favicon. The tab title stays the station's name either way, so the
+// preview isolates exactly what the toggle changes.
 <template>
   <div
     class="flex items-center gap-2 rounded-t-lg border border-b-0 border-slate-300 bg-slate-100 px-3 py-2 shadow-inner"
@@ -27,16 +26,11 @@ export interface SettingsShowcaseFaviconSignature {
           @showGusts={{true}}
         />
       {{else}}
-        <Wind @size={{16}} class="text-wind-20" />
+        <img src="/favicon.ico" alt="" class="h-4 w-4" />
       {{/if}}
     </span>
-    <span class="truncate text-xs font-medium text-slate-600">winds.mobi</span>
-    <span
-      class="ml-auto text-[10px] uppercase tracking-wide text-slate-400"
-    >{{if
-        @enabled
-        (t "settings.preview.faviconStation")
-        (t "settings.preview.faviconDefault")
-      }}</span>
+    <span class="truncate text-xs font-medium text-slate-600">
+      Höhematte | winds.mobi
+    </span>
   </div>
 </template>

--- a/app/components/settings/showcase/favicon.gts
+++ b/app/components/settings/showcase/favicon.gts
@@ -1,0 +1,42 @@
+import { t } from 'ember-intl';
+import Wind from 'ember-phosphor-icons/components/ph-wind';
+import SettingsWindArrow from 'winds-mobi-client-web/components/settings/wind-arrow';
+
+export interface SettingsShowcaseFaviconSignature {
+  Args: {
+    enabled: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+// A small browser-tab mock: when the preference is on, the favicon slot holds
+// the selected station's wind arrow; when off, it falls back to the generic
+// winds.mobi mark.
+<template>
+  <div
+    class="flex items-center gap-2 rounded-t-lg border border-b-0 border-slate-300 bg-slate-100 px-3 py-2 shadow-inner"
+    ...attributes
+  >
+    <span class="flex h-4 w-4 shrink-0 items-center justify-center">
+      {{#if @enabled}}
+        <SettingsWindArrow
+          class="h-4 w-4"
+          @direction={{135}}
+          @speed={{18}}
+          @gusts={{32}}
+          @showGusts={{true}}
+        />
+      {{else}}
+        <Wind @size={{16}} class="text-wind-20" />
+      {{/if}}
+    </span>
+    <span class="truncate text-xs font-medium text-slate-600">winds.mobi</span>
+    <span
+      class="ml-auto text-[10px] uppercase tracking-wide text-slate-400"
+    >{{if
+        @enabled
+        (t "settings.preview.faviconStation")
+        (t "settings.preview.faviconDefault")
+      }}</span>
+  </div>
+</template>

--- a/app/components/settings/showcase/graph-sync.gts
+++ b/app/components/settings/showcase/graph-sync.gts
@@ -1,20 +1,20 @@
 import { array } from '@ember/helper';
 import { t } from 'ember-intl';
-import Link from 'ember-phosphor-icons/components/ph-link';
-import LinkBreak from 'ember-phosphor-icons/components/ph-link-break';
+import StationSyncToggle from 'winds-mobi-client-web/components/station/sync-toggle';
 
 export interface SettingsShowcaseGraphSyncSignature {
   Args: {
     enabled: boolean;
+    onChange: (value: boolean) => void;
   };
   Element: HTMLDivElement;
 }
 
-// Two stacked mini graphs (wind + air). When synced, a single shared vertical
-// cursor crosses both at the same time; when not, each has its own. A link /
-// broken-link badge sits between them.
+// Two stacked mini graphs (wind + air): when synced they share one vertical
+// cursor, otherwise each has its own. Below them sits the same "Sync" toggle
+// used in the station detail panel, reflecting (and driving) the preference.
 <template>
-  <div class="relative grid gap-2 rounded-lg bg-slate-100 p-3" ...attributes>
+  <div class="grid gap-2 rounded-lg bg-slate-100 p-3" ...attributes>
     {{#each
       (array (t "settings.preview.graphWind") (t "settings.preview.graphAir"))
       as |label index|
@@ -46,15 +46,8 @@ export interface SettingsShowcaseGraphSyncSignature {
       </div>
     {{/each}}
 
-    <span
-      class="absolute left-1/2 top-1/2 flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-500 shadow-sm"
-      aria-hidden="true"
-    >
-      {{#if @enabled}}
-        <Link @size={{14}} />
-      {{else}}
-        <LinkBreak @size={{14}} />
-      {{/if}}
-    </span>
+    <div class="flex justify-center pt-1">
+      <StationSyncToggle @isSelected={{@enabled}} @onChange={{@onChange}} />
+    </div>
   </div>
 </template>

--- a/app/components/settings/showcase/graph-sync.gts
+++ b/app/components/settings/showcase/graph-sync.gts
@@ -1,0 +1,60 @@
+import { array } from '@ember/helper';
+import { t } from 'ember-intl';
+import Link from 'ember-phosphor-icons/components/ph-link';
+import LinkBreak from 'ember-phosphor-icons/components/ph-link-break';
+
+export interface SettingsShowcaseGraphSyncSignature {
+  Args: {
+    enabled: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+// Two stacked mini graphs (wind + air). When synced, a single shared vertical
+// cursor crosses both at the same time; when not, each has its own. A link /
+// broken-link badge sits between them.
+<template>
+  <div class="relative grid gap-2 rounded-lg bg-slate-100 p-3" ...attributes>
+    {{#each
+      (array (t "settings.preview.graphWind") (t "settings.preview.graphAir"))
+      as |label index|
+    }}
+      <div class="rounded-md border border-slate-200 bg-white px-2 py-1.5">
+        <p
+          class="text-[10px] font-medium uppercase tracking-wide text-slate-400"
+        >
+          {{label}}
+        </p>
+        <svg viewBox="0 0 100 24" class="h-6 w-full" aria-hidden="true">
+          <polyline
+            fill="none"
+            stroke="var(--color-wind-20)"
+            stroke-width="2"
+            points="0,18 20,10 40,14 60,5 80,12 100,7"
+          />
+          {{! Synced: both cursors share x=60. Otherwise the second drifts. }}
+          <line
+            x1={{if @enabled "60" (if index "32" "60")}}
+            x2={{if @enabled "60" (if index "32" "60")}}
+            y1="0"
+            y2="24"
+            stroke="#475569"
+            stroke-width="1"
+            stroke-dasharray="2 2"
+          />
+        </svg>
+      </div>
+    {{/each}}
+
+    <span
+      class="absolute left-1/2 top-1/2 flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-500 shadow-sm"
+      aria-hidden="true"
+    >
+      {{#if @enabled}}
+        <Link @size={{14}} />
+      {{else}}
+        <LinkBreak @size={{14}} />
+      {{/if}}
+    </span>
+  </div>
+</template>

--- a/app/components/settings/showcase/gusts.gts
+++ b/app/components/settings/showcase/gusts.gts
@@ -1,0 +1,25 @@
+import SettingsWindArrow from 'winds-mobi-client-web/components/settings/wind-arrow';
+
+export interface SettingsShowcaseGustsSignature {
+  Args: {
+    enabled: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+// A single station arrow on a map-like backdrop; its gusts-coloured outline
+// appears or disappears with the preference, exactly as the on-map marker does.
+<template>
+  <div
+    class="flex items-center justify-center rounded-lg bg-slate-100 p-4"
+    ...attributes
+  >
+    <SettingsWindArrow
+      class="h-16 w-16"
+      @direction={{135}}
+      @speed={{18}}
+      @gusts={{38}}
+      @showGusts={{@enabled}}
+    />
+  </div>
+</template>

--- a/app/components/settings/wind-arrow.gts
+++ b/app/components/settings/wind-arrow.gts
@@ -1,0 +1,69 @@
+import Component from '@glimmer/component';
+import {
+  colourForWindReading,
+  MARKER_CONTRAST_OUTLINE_COLOUR,
+  MARKER_CONTRAST_OUTLINE_WIDTH,
+  MARKER_GUSTS_OUTLINE_WIDTH,
+  stationArrowGeometry,
+} from 'winds-mobi-client-web/utils/station-arrow';
+
+export interface SettingsWindArrowSignature {
+  Args: {
+    direction: number;
+    speed: number;
+    gusts: number;
+    // When false the gusts-coloured outline is hidden, leaving the plain
+    // black-rimmed wind-speed arrow — mirroring the on-map marker.
+    showGusts: boolean;
+  };
+  Element: SVGSVGElement;
+}
+
+// Presentational copy of the on-map station arrow used to give the settings
+// page a live preview. It deliberately mirrors [map/station-marker.gts]: the
+// same geometry, the black contrast under-stroke, and the gusts outline on top.
+// The reading is a fixed sample (now-dated, so colours are never the stale
+// grey) since the preview illustrates the toggle, not real data.
+export default class SettingsWindArrow extends Component<SettingsWindArrowSignature> {
+  geometry = stationArrowGeometry(false);
+
+  get markerColor() {
+    return colourForWindReading(this.args.speed, Date.now());
+  }
+
+  get gustsColor() {
+    return colourForWindReading(this.args.gusts, Date.now());
+  }
+
+  get rotationTransform() {
+    return `rotate(${this.args.direction} ${this.geometry.rotationCentre})`;
+  }
+
+  <template>
+    <svg
+      aria-hidden="true"
+      class="overflow-visible"
+      viewBox={{this.geometry.viewBox}}
+      ...attributes
+    >
+      <g transform={{this.rotationTransform}}>
+        <path
+          d={{this.geometry.path}}
+          fill={{this.markerColor}}
+          stroke={{MARKER_CONTRAST_OUTLINE_COLOUR}}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width={{MARKER_CONTRAST_OUTLINE_WIDTH}}
+        />
+        <path
+          d={{this.geometry.path}}
+          fill={{this.markerColor}}
+          stroke={{if @showGusts this.gustsColor "none"}}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width={{MARKER_GUSTS_OUTLINE_WIDTH}}
+        />
+      </g>
+    </svg>
+  </template>
+}

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -3,14 +3,12 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import type RouterService from '@ember/routing/router-service';
 import { on } from '@ember/modifier';
-import { Switch } from '@frontile/forms';
 import StationHeader from './header';
 import StationSummary from './summary';
 import StationAir from './air';
 import StationWind from './wind';
+import StationSyncToggle from './sync-toggle';
 import { t } from 'ember-intl';
-import LockSimple from 'ember-phosphor-icons/components/ph-lock-simple';
-import LockSimpleOpen from 'ember-phosphor-icons/components/ph-lock-simple-open';
 import {
   parseMapView,
   serializeMapView,
@@ -85,21 +83,10 @@ export default class StationIndex extends Component<StationIndexSignature> {
             <StationWind @stationId={{@station.id}} />
             <StationAir @stationId={{@station.id}} />
             <div class="flex">
-              <Switch
+              <StationSyncToggle
                 @isSelected={{this.isTimeSeriesSyncEnabled}}
                 @onChange={{this.toggleTimeSeriesSync}}
-                @intent="success"
-                @label={{t "station.timeSeries.sync"}}
-                aria-label={{t "station.timeSeries.syncToggle"}}
-              >
-                <:startContent>
-                  <LockSimple @size={{14}} />
-                </:startContent>
-
-                <:endContent>
-                  <LockSimpleOpen @size={{14}} />
-                </:endContent>
-              </Switch>
+              />
             </div>
           </div>
         {{/if}}

--- a/app/components/station/sync-toggle.gts
+++ b/app/components/station/sync-toggle.gts
@@ -1,0 +1,33 @@
+import { Switch } from '@frontile/forms';
+import { t } from 'ember-intl';
+import LockSimple from 'ember-phosphor-icons/components/ph-lock-simple';
+import LockSimpleOpen from 'ember-phosphor-icons/components/ph-lock-simple-open';
+
+export interface StationSyncToggleSignature {
+  Args: {
+    isSelected: boolean;
+    onChange: (value: boolean) => void;
+  };
+  Element: HTMLInputElement;
+}
+
+// The wind/air graph "Sync" switch, shared by the station detail panel and the
+// settings preview so both render the exact same control.
+<template>
+  <Switch
+    @isSelected={{@isSelected}}
+    @onChange={{@onChange}}
+    @intent="success"
+    @label={{t "station.timeSeries.sync"}}
+    aria-label={{t "station.timeSeries.syncToggle"}}
+    ...attributes
+  >
+    <:startContent>
+      <LockSimple @size={{14}} />
+    </:startContent>
+
+    <:endContent>
+      <LockSimpleOpen @size={{14}} />
+    </:endContent>
+  </Switch>
+</template>

--- a/app/router.ts
+++ b/app/router.ts
@@ -11,5 +11,6 @@ Router.map(function () {
     this.route('station', { path: '/:station_id' });
   });
   this.route('nearby');
+  this.route('settings');
   this.route('help');
 });

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -1,0 +1,28 @@
+import Service from '@ember/service';
+import { trackedInLocalStorage } from 'winds-mobi-client-web/utils/tracked-local-storage';
+
+// User-facing display preferences, persisted in the browser so they survive
+// reloads and stay device-local. Each property is reactive (tracked) and
+// mirrored to localStorage by `trackedInLocalStorage`; consumers read
+// `settings.<name>` directly and re-render when it changes. The stored value
+// is omitted while it equals `defaultValue`, so defaults can evolve later.
+export default class SettingsService extends Service {
+  // Render the selected station's wind arrow as the browser-tab favicon.
+  @trackedInLocalStorage({ keyName: 'settings.faviconFollowsStation' })
+  faviconFollowsStation = true;
+
+  // Draw the gusts-coloured outline around wind arrows on the map.
+  @trackedInLocalStorage({ keyName: 'settings.showGustsOutline' })
+  showGustsOutline = true;
+
+  // Whether a freshly opened station panel starts with its wind and air graphs
+  // synced. The per-panel switch remains the live override for that session.
+  @trackedInLocalStorage({ keyName: 'settings.syncGraphsByDefault' })
+  syncGraphsByDefault = true;
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    settings: SettingsService;
+  }
+}

--- a/app/services/time-series-sync.ts
+++ b/app/services/time-series-sync.ts
@@ -1,5 +1,7 @@
 import Service from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 
 export interface SyncRange {
   min: number;
@@ -31,7 +33,11 @@ export interface SyncChart {
 const SYNC_TRIGGER = 'time-series-sync';
 
 export default class TimeSeriesSyncService extends Service {
-  @tracked isSyncEnabled = true;
+  @service declare settings: SettingsService;
+
+  // Seed the live sync state from the persisted preference. The per-panel
+  // switch then overrides it for the rest of the session via `setSyncEnabled`.
+  @tracked isSyncEnabled = this.settings.syncGraphsByDefault;
 
   private charts = new Set<SyncChart>();
   private currentRange?: SyncRange;

--- a/app/templates/help.gts
+++ b/app/templates/help.gts
@@ -39,7 +39,7 @@ export default class HelpTemplate extends Component<HelpTemplateSignature> {
       <div
         class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8"
       >
-        <StationSectionCard @title={{t "help.title"}}>
+        <StationSectionCard @title={{t "help.title"}} @titleClass="sr-only">
           <div class="grid gap-3">
             <p class="max-w-3xl text-sm leading-6 text-slate-600">
               {{t "help.intro"}}

--- a/app/templates/map/station.gts
+++ b/app/templates/map/station.gts
@@ -8,6 +8,7 @@ import type RouterService from '@ember/routing/router-service';
 import { findRecord } from 'winds-mobi-client-web/builders/station';
 import { stationFaviconDataUri } from 'winds-mobi-client-web/utils/station-favicon';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station as StationModel } from 'winds-mobi-client-web/services/store.js';
 
 interface MapStationTemplateSignature {
@@ -21,6 +22,7 @@ export default class MapStationTemplate extends Component<MapStationTemplateSign
   @service
   declare store: typeof import('winds-mobi-client-web/services/store').default;
   @service declare mapRefresh: MapRefreshService;
+  @service declare settings: SettingsService;
 
   get stationId() {
     return this.router.currentRoute?.params['station_id'];
@@ -71,9 +73,15 @@ export default class MapStationTemplate extends Component<MapStationTemplateSign
       {{#if this.station}}
         {{pageTitle this.station.name}}
 
-        {{#in-element this.documentHead insertBefore=null}}
-          <link rel="icon" type="image/svg+xml" href={{this.faviconDataUri}} />
-        {{/in-element}}
+        {{#if this.settings.faviconFollowsStation}}
+          {{#in-element this.documentHead insertBefore=null}}
+            <link
+              rel="icon"
+              type="image/svg+xml"
+              href={{this.faviconDataUri}}
+            />
+          {{/in-element}}
+        {{/if}}
       {{/if}}
 
       <Station @station={{this.station}} />

--- a/app/templates/settings.gts
+++ b/app/templates/settings.gts
@@ -41,7 +41,7 @@ export default class SettingsTemplate extends Component<SettingsTemplateSignatur
       <div
         class="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8"
       >
-        <StationSectionCard @title={{t "settings.title"}}>
+        <StationSectionCard @title={{t "settings.title"}} @titleClass="sr-only">
           <p class="max-w-2xl text-sm leading-6 text-slate-600">
             {{t "settings.intro"}}
           </p>
@@ -100,6 +100,7 @@ export default class SettingsTemplate extends Component<SettingsTemplateSignatur
               </div>
               <SettingsShowcaseGraphSync
                 @enabled={{this.settings.syncGraphsByDefault}}
+                @onChange={{this.setSyncGraphsByDefault}}
               />
             </div>
           </dl>

--- a/app/templates/settings.gts
+++ b/app/templates/settings.gts
@@ -1,0 +1,110 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { pageTitle } from 'ember-page-title';
+import { t } from 'ember-intl';
+import { Switch } from '@frontile/forms';
+import StationSectionCard from 'winds-mobi-client-web/components/station/section-card';
+import SettingsShowcaseFavicon from 'winds-mobi-client-web/components/settings/showcase/favicon';
+import SettingsShowcaseGusts from 'winds-mobi-client-web/components/settings/showcase/gusts';
+import SettingsShowcaseGraphSync from 'winds-mobi-client-web/components/settings/showcase/graph-sync';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
+
+interface SettingsTemplateSignature {
+  Args: {
+    model: unknown;
+  };
+}
+
+export default class SettingsTemplate extends Component<SettingsTemplateSignature> {
+  @service declare settings: SettingsService;
+
+  @action
+  setFaviconFollowsStation(value: boolean) {
+    this.settings.faviconFollowsStation = value;
+  }
+
+  @action
+  setShowGustsOutline(value: boolean) {
+    this.settings.showGustsOutline = value;
+  }
+
+  @action
+  setSyncGraphsByDefault(value: boolean) {
+    this.settings.syncGraphsByDefault = value;
+  }
+
+  <template>
+    {{pageTitle (t "settings.title")}}
+
+    <section class="min-h-0 flex-1 overflow-y-auto bg-slate-200">
+      <div
+        class="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8"
+      >
+        <StationSectionCard @title={{t "settings.title"}}>
+          <p class="max-w-2xl text-sm leading-6 text-slate-600">
+            {{t "settings.intro"}}
+          </p>
+
+          <dl class="mt-4 divide-y divide-slate-200">
+            <div
+              class="grid items-center gap-4 py-4 sm:grid-cols-[minmax(0,1fr)_14rem]"
+            >
+              <div>
+                <Switch
+                  data-test-setting="faviconFollowsStation"
+                  @isSelected={{this.settings.faviconFollowsStation}}
+                  @onChange={{this.setFaviconFollowsStation}}
+                  @intent="success"
+                  @label={{t "settings.faviconFollowsStation.label"}}
+                  @description={{t
+                    "settings.faviconFollowsStation.description"
+                  }}
+                />
+              </div>
+              <SettingsShowcaseFavicon
+                @enabled={{this.settings.faviconFollowsStation}}
+              />
+            </div>
+
+            <div
+              class="grid items-center gap-4 py-4 sm:grid-cols-[minmax(0,1fr)_14rem]"
+            >
+              <div>
+                <Switch
+                  data-test-setting="showGustsOutline"
+                  @isSelected={{this.settings.showGustsOutline}}
+                  @onChange={{this.setShowGustsOutline}}
+                  @intent="success"
+                  @label={{t "settings.showGustsOutline.label"}}
+                  @description={{t "settings.showGustsOutline.description"}}
+                />
+              </div>
+              <SettingsShowcaseGusts
+                @enabled={{this.settings.showGustsOutline}}
+              />
+            </div>
+
+            <div
+              class="grid items-center gap-4 py-4 sm:grid-cols-[minmax(0,1fr)_14rem]"
+            >
+              <div>
+                <Switch
+                  data-test-setting="syncGraphsByDefault"
+                  @isSelected={{this.settings.syncGraphsByDefault}}
+                  @onChange={{this.setSyncGraphsByDefault}}
+                  @intent="success"
+                  @label={{t "settings.syncGraphsByDefault.label"}}
+                  @description={{t "settings.syncGraphsByDefault.description"}}
+                />
+              </div>
+              <SettingsShowcaseGraphSync
+                @enabled={{this.settings.syncGraphsByDefault}}
+              />
+            </div>
+          </dl>
+        </StationSectionCard>
+      </div>
+    </section>
+  </template>
+}

--- a/app/utils/tracked-local-storage.ts
+++ b/app/utils/tracked-local-storage.ts
@@ -1,0 +1,124 @@
+import { tracked } from '@glimmer/tracking';
+
+// One reactive cell per storage key. Reading `cell.value` in a template
+// subscribes it; writing re-renders. The cell is created (and seeded) the first
+// time a key is accessed — we set `value` *before* reading it, so there's no
+// "mutated after consumed" autotrack violation. The (singleton) settings
+// service shares one cell per key.
+class Cell<T> {
+  @tracked value!: T;
+}
+
+const cells = new Map<string, Cell<unknown>>();
+
+function cellFor<T>(key: string, seed: () => T): Cell<T> {
+  let cell = cells.get(key) as Cell<T> | undefined;
+
+  if (!cell) {
+    cell = new Cell<T>();
+    cell.value = seed();
+    cells.set(key, cell as Cell<unknown>);
+  }
+
+  return cell;
+}
+
+function safeGet(key: string): string | null {
+  try {
+    return globalThis.localStorage?.getItem(key) ?? null;
+  } catch {
+    // Private-mode / disabled storage: fall back to the in-memory cell only.
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    globalThis.localStorage?.setItem(key, value);
+  } catch {
+    // Ignore write failures; the tracked cell still reflects the value.
+  }
+}
+
+function safeRemove(key: string): void {
+  try {
+    globalThis.localStorage?.removeItem(key);
+  } catch {
+    // Ignore.
+  }
+}
+
+function readStored<T>(key: string, fallback: T): T {
+  const raw = safeGet(key);
+
+  if (raw === null) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export interface TrackedLocalStorageOptions {
+  // Storage key; defaults to the decorated property name.
+  keyName?: string;
+}
+
+interface FieldDescriptor {
+  initializer?: () => unknown;
+}
+
+/**
+ * Decorator that mirrors a tracked property to `localStorage` (reads re-render,
+ * writes persist). The property's own initializer is the default: while the
+ * current value equals it the key is removed from storage, so the default can
+ * evolve later. Written in the legacy decorator shape that `decorator-transforms`
+ * supports, matching how `@tracked` is used in this app:
+ *
+ * ```ts
+ * @trackedInLocalStorage({ keyName: 'settings.showThing' })
+ * showThing = true;
+ * ```
+ *
+ * Returns `any` so it type-checks as a property decorator under the app's
+ * standard-decorator tsconfig; the property's type still comes from its
+ * initializer.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function trackedInLocalStorage(
+  options: TrackedLocalStorageOptions = {}
+): any {
+  return function (
+    _target: object,
+    propertyKey: string,
+    descriptor?: FieldDescriptor
+  ) {
+    const key = options.keyName ?? propertyKey;
+    const seed = () => readStored(key, descriptor?.initializer?.() as unknown);
+
+    return {
+      get(): unknown {
+        return cellFor(key, seed).value;
+      },
+
+      set(value: unknown) {
+        const cell = cellFor(key, seed);
+        const defaultValue = descriptor?.initializer?.() as unknown;
+
+        if (value === defaultValue) {
+          safeRemove(key);
+        } else {
+          safeSet(key, JSON.stringify(value));
+        }
+
+        cell.value = value;
+      },
+
+      configurable: true,
+      enumerable: true,
+    };
+  };
+}

--- a/app/utils/tracked-local-storage.ts
+++ b/app/utils/tracked-local-storage.ts
@@ -87,7 +87,6 @@ interface FieldDescriptor {
  * standard-decorator tsconfig; the property's type still comes from its
  * initializer.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function trackedInLocalStorage(
   options: TrackedLocalStorageOptions = {}
 ): any {
@@ -97,7 +96,7 @@ export function trackedInLocalStorage(
     descriptor?: FieldDescriptor
   ) {
     const key = options.keyName ?? propertyKey;
-    const seed = () => readStored(key, descriptor?.initializer?.() as unknown);
+    const seed = () => readStored(key, descriptor?.initializer?.());
 
     return {
       get(): unknown {
@@ -106,7 +105,7 @@ export function trackedInLocalStorage(
 
       set(value: unknown) {
         const cell = cellFor(key, seed);
-        const defaultValue = descriptor?.initializer?.() as unknown;
+        const defaultValue = descriptor?.initializer?.();
 
         if (value === defaultValue) {
           safeRemove(key);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,10 +309,6 @@ packages:
   '@asamuzakjp/css-color@3.1.3':
     resolution: {integrity: sha512-u25AyjuNrRFGb1O7KmWEu0ExN6iJMlUmDSlOPW/11JF8khOrIGG6oCoYpC+4mZlthNVhFUahk68lNrNI91f6Yg==}
 
-  '@babel/code-frame@7.24.7':
-    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
@@ -587,10 +583,6 @@ packages:
 
   '@babel/helpers@7.29.2':
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/highlight@7.24.7':
-    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.27.0':
@@ -8768,11 +8760,6 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 10.4.3
 
-  '@babel/code-frame@7.24.7':
-    dependencies:
-      '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
-
   '@babel/code-frame@7.26.2':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
@@ -8879,8 +8866,8 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8934,6 +8921,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.4
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -8971,7 +8971,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
@@ -9005,8 +9005,8 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9054,6 +9054,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -9065,7 +9074,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.29.0
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
@@ -9082,7 +9091,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-wrap-function': 7.25.0
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9100,7 +9109,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9109,13 +9118,22 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.27.0
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
+      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.28.4
@@ -9133,15 +9151,15 @@ snapshots:
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9170,9 +9188,9 @@ snapshots:
 
   '@babel/helper-wrap-function@7.25.0':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9194,13 +9212,6 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/highlight@7.24.7':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
@@ -9217,7 +9228,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9271,7 +9282,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9349,6 +9360,11 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.4)':
@@ -9441,6 +9457,11 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
@@ -9469,7 +9490,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.28.4)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9557,10 +9578,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.28.4)
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -9581,7 +9602,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
 
   '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -9698,9 +9719,9 @@ snapshots:
   '@babel/plugin-transform-function-name@7.25.1(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9774,7 +9795,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-simple-access': 7.24.7
     transitivePeerDependencies:
@@ -9791,10 +9812,10 @@ snapshots:
   '@babel/plugin-transform-modules-systemjs@7.25.0(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9811,7 +9832,7 @@ snapshots:
   '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -9871,7 +9892,7 @@ snapshots:
   '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.28.4)
@@ -10089,6 +10110,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10321,14 +10353,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/regjsgen@0.8.0': {}
@@ -11658,7 +11690,7 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
@@ -12156,7 +12188,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.30.1(eslint@9.25.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.0
+      debug: 4.4.3
       eslint: 9.25.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -12169,7 +12201,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.30.1
       '@typescript-eslint/visitor-keys': 8.30.1
-      debug: 4.4.0
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -12442,7 +12474,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12624,7 +12656,7 @@ snapshots:
 
   async-disk-cache@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       heimdalljs: 0.2.6
       istextorbinary: 2.6.0
       mkdirp: 0.5.6
@@ -12951,7 +12983,7 @@ snapshots:
 
   broccoli-babel-transpiler@7.8.1:
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       '@babel/polyfill': 7.12.1
       broccoli-funnel: 2.0.2
       broccoli-merge-trees: 3.0.2
@@ -14945,7 +14977,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.25.0(jiti@2.6.1)):
     dependencies:
       eslint: 9.25.0(jiti@2.6.1)
-      semver: 7.7.1
+      semver: 7.7.4
 
   eslint-config-prettier@9.1.0(eslint@9.25.0(jiti@2.6.1)):
     dependencies:
@@ -15968,7 +16000,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17250,7 +17282,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -17607,9 +17639,9 @@ snapshots:
 
   remove-types@1.0.0:
     dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.28.4)
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.29.0)
       prettier: 2.8.8
     transitivePeerDependencies:
       - supports-color
@@ -18241,7 +18273,7 @@ snapshots:
 
   stagehand@1.0.1:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18475,7 +18507,7 @@ snapshots:
 
   sync-disk-cache@2.1.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 3.0.2
@@ -19425,7 +19457,7 @@ snapshots:
 
   workerpool@3.1.2:
     dependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.29.0
       object-assign: 4.1.1
       rsvp: 4.8.5
     transitivePeerDependencies:

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- A new Settings page (reachable from the menu on desktop and mobile) lets you customise the interface, with a live preview of each option beside it. You can choose whether the browser tab shows the selected station, whether wind gusts are drawn as an arrow outline on the map, and whether station graphs start synced. Your choices are saved in this browser.
 - The browser tab icon now becomes the selected station's wind arrow — coloured by wind speed and gusts, rotated to the wind direction, and shaped for peaks — so an open station's latest reading is visible at a glance even from another tab. Closing the station restores the default icon.
 
 ### Changed

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Changed
 
+- The currently selected navigation item is now clearly highlighted with a solid background on both the desktop top bar and the mobile menu, so it's obvious which page you're on.
+- The navbar search results now appear in a single clean panel (previously two overlapping boxes with mismatched rounded corners), and the search field placeholder is shortened to "Search".
 - Station search now favors stations near you when your location is already known, so the closest matches rise to the top instead of results being ranked by name alone (your location is never requested just to search).
 
 ## v0.3.0 - 2026-06-16

--- a/tests/acceptance/settings-route-test.ts
+++ b/tests/acceptance/settings-route-test.ts
@@ -1,0 +1,76 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { click, currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
+
+// The settings route doesn't fetch stations, but the shared navbar is always
+// rendered; a no-op store keeps any incidental request from failing.
+class FakeStoreService extends Service {
+  request() {
+    return Promise.resolve({ content: { data: [] } });
+  }
+}
+
+const STORAGE_KEYS = [
+  'settings.faviconFollowsStation',
+  'settings.showGustsOutline',
+  'settings.syncGraphsByDefault',
+];
+
+module('Acceptance | settings route', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:store', FakeStoreService);
+    STORAGE_KEYS.forEach((key) => window.localStorage.removeItem(key));
+  });
+
+  hooks.afterEach(function () {
+    STORAGE_KEYS.forEach((key) => window.localStorage.removeItem(key));
+  });
+
+  test('it shows the three preferences, on by default', async function (assert) {
+    await visit('/settings');
+
+    assert.dom('[data-test-navbar-link="settings"]').hasText('Settings');
+    assert.dom('[data-test-setting="faviconFollowsStation"]').isChecked();
+    assert.dom('[data-test-setting="showGustsOutline"]').isChecked();
+    assert.dom('[data-test-setting="syncGraphsByDefault"]').isChecked();
+  });
+
+  test('toggling a preference persists it to local storage', async function (assert) {
+    await visit('/settings');
+
+    await click('[data-test-setting="showGustsOutline"]');
+
+    assert.dom('[data-test-setting="showGustsOutline"]').isNotChecked();
+    assert.strictEqual(
+      window.localStorage.getItem('settings.showGustsOutline'),
+      'false',
+      'the disabled preference is written to local storage'
+    );
+
+    // Back to the default removes the stored override.
+    await click('[data-test-setting="showGustsOutline"]');
+
+    assert.dom('[data-test-setting="showGustsOutline"]').isChecked();
+    assert.strictEqual(
+      window.localStorage.getItem('settings.showGustsOutline'),
+      null,
+      'restoring the default clears the stored override'
+    );
+  });
+
+  test('it navigates to settings from the mobile menu without reloading', async function (assert) {
+    await visit('/map');
+
+    await click('[data-test-navbar-mobile-menu-button]');
+    await click(
+      '[data-test-navbar-mobile-menu] [data-test-navbar-link="settings"]'
+    );
+
+    assert.strictEqual(currentURL(), '/settings');
+    assert.dom('[data-test-navbar-mobile-menu]').doesNotExist();
+    assert.dom('[data-test-setting="faviconFollowsStation"]').exists();
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -12,7 +12,7 @@ navigation:
   help: Help
   search:
     label: Search stations
-    placeholder: Search stations
+    placeholder: Search
     loading: Searching stations…
     empty: No stations found.
 
@@ -38,8 +38,6 @@ settings:
       so zooming or panning one moves the other. You can still unlink them per
       station.
   preview:
-    faviconStation: Station
-    faviconDefault: Default
     graphWind: Wind
     graphAir: Air
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -8,12 +8,40 @@ navigation:
   menu: Menu
   map: Map
   nearby: Nearby
+  settings: Settings
   help: Help
   search:
     label: Search stations
     placeholder: Search stations
     loading: Searching stations…
     empty: No stations found.
+
+settings:
+  title: Settings
+  intro: >-
+    Personalise how winds.mobi looks and behaves. These preferences are stored
+    in this browser only and take effect right away.
+  faviconFollowsStation:
+    label: Selected station in the browser tab
+    description: >-
+      Replace the browser-tab icon with the open station's wind arrow, so its
+      latest reading is visible at a glance from another tab.
+  showGustsOutline:
+    label: Show gusts as arrow outline
+    description: >-
+      Draw a second, gusts-coloured outline around each wind arrow on the map.
+      Turn off for a simpler arrow showing average wind only.
+  syncGraphsByDefault:
+    label: Sync wind & air graphs
+    description: >-
+      Open station panels with the wind and air graphs sharing one time range,
+      so zooming or panning one moves the other. You can still unlink them per
+      station.
+  preview:
+    faviconStation: Station
+    faviconDefault: Default
+    graphWind: Wind
+    graphAir: Air
 
 help:
   title: Help


### PR DESCRIPTION
## What

Implements the **local settings page** (closes #45) and a few UI polish items that came out of reviewing it.

### Settings page (#45)
- New `settings` route (sibling of map / nearby / help), reachable from both the desktop top bar and the mobile menu.
- Frontile switches with label + description on the left, and a **live preview** of each option on the right (a table-like layout).
- Three preferences, persisted to `localStorage`, all defaulting **on**:
  - **Selected station in the browser tab** — gates the dynamic favicon.
  - **Show gusts as arrow outline** — toggles the gusts-coloured outline on the map markers.
  - **Sync wind & air graphs** — seeds the station panel's graph-sync default; the per-panel switch stays the live override.
- Previews are genuinely live: the favicon preview shows the standard `/favicon.ico` when off (and a realistic `Höhematte | winds.mobi` tab title to isolate what changes), the gusts preview is the real arrow, and the graph-sync preview reuses the **exact same Sync toggle** from the station panel (extracted into a shared component).

### Persistence: why no addon
The issue suggested an Ember addon for tracked-localStorage. The only one (`ember-tracked-local-storage`) is a **v1 addon** that builds for production/test but breaks the **Vite dev server** two different ways (`window.require` when prebundled; a `default`/star-export error when excluded), and there's no Vite-native v2 alternative. Rather than pile on bundler workarounds (which the repo conventions forbid), persistence is a small in-app decorator — [`app/utils/tracked-local-storage.ts`](app/utils/tracked-local-storage.ts): a tracked cell per key mirrored to `localStorage`, written in the legacy decorator shape `decorator-transforms` supports (same mechanism behind `@tracked`). No new dependency, identical behaviour in dev/test/prod.

### Polish
- **Selected nav link is now clearly highlighted** (solid `bg-wind-20` + white text) on desktop and mobile. The old styling keyed off `aria-[current=page]:` variants, but LinkTo here emits the `active` class rather than an `aria-current="page"` attribute, so those utilities never applied — switched to `@activeClass`, which is actually applied.
- **Cleaner search results dropdown.** Frontile's overlay and our inner wrapper each had their own background/border/rounded corners, overlapping with mismatched radii. Now `popover.Content` is styled directly (Frontile merges via tailwind-merge) and the redundant wrapper is gone — a single clean panel. Placeholder shortened to "Search".
- **Settings & Help page headings** are now screen-reader-only (they duplicated the page/tab title).

## Why
The app had no place to customise interface behaviour; pilots want to toggle small display options and have them remembered per device. The polish items address concrete visual issues surfaced while building and reviewing the page.

## Testing
- New acceptance test: settings route renders, defaults are on, toggling persists to `localStorage` (round-trip), and mobile-menu navigation works.
- Full suite green on both the **dev server** (`test:ember:dev`) and the **isolated build** (`test:ember`): 58/58.
- `pnpm lint` clean.

## Commits
1. ⚙️ Add local settings page
2. 💅 Refine settings page previews and reuse the panel sync toggle
3. ♿ Make the Help page heading screen-reader-only
4. 🎯 Clearly highlight the selected navigation link
5. 🔍 Tidy the navbar search dropdown and shorten its placeholder
6. 📝 Update changelog for navigation and search polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)