### PR TITLE
🧭 Keep wind arrows compass-aligned when the map rotates or tilts

### DIFF
--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -227,6 +227,13 @@ export default class Map extends Component<MapSignature> {
   get markerInitOptions() {
     return {
       anchor: 'center' as const,
+      // Pin the marker to the map plane so MapLibre counter-rotates it by the
+      // bearing and tilts it by the pitch on every rotate/pitch event. The wind
+      // direction stays in the marker's own SVG `rotate(...)`, so the net effect
+      // is an arrow that keeps pointing at true compass north and lies flat on
+      // the ground in 3D, instead of staying fixed to the screen (#46).
+      pitchAlignment: 'map' as const,
+      rotationAlignment: 'map' as const,
     };
   }
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Wind arrows on the map now keep pointing at true compass directions when you rotate the map, and lie flat on the terrain when you tilt into 3D, instead of staying fixed to the screen and pointing the wrong way.
 - The currently selected navigation item is now clearly highlighted with a solid background on both the desktop top bar and the mobile menu, so it's obvious which page you're on.
 - The navbar search results now appear in a single clean panel (previously two overlapping boxes with mismatched rounded corners), and the search field placeholder is shortened to "Search".
 - Station search now favors stations near you when your location is already known, so the closest matches rise to the top instead of results being ranked by name alone (your location is never requested just to search).


### PR DESCRIPTION
Closes #46.

## Problem

Station wind arrows are MapLibre HTML markers, and the wind direction was applied as an SVG `rotate(direction)` transform. HTML markers default to `rotationAlignment: 'auto'` (= `viewport`), so they are pinned to the **screen**. When you rotate the map (or tilt into 3D), the screen-locked arrow no longer lines up with true compass north and floats upright instead of lying on the terrain.

## Fix

A single change in [app/components/map/index.gts](app/components/map/index.gts) — add `rotationAlignment: 'map'` and `pitchAlignment: 'map'` to the marker init options.

MapLibre already re-composes each marker's element transform on every `rotate`/`pitch` event as `… rotateX(pitch) rotateZ(rotation − bearing)`. Pinning the marker to the map plane lets MapLibre natively counter-rotate it by the bearing and tilt it by the pitch. The wind direction stays in the marker's own reactive SVG `rotate(...)` getter, so the net result is an arrow that:

- keeps pointing at true compass direction regardless of map rotation, and
- lies flat on the ground when tilted into 3D.

No bearing/pitch event subscriptions, no imperative `setRotation` bookkeeping, and the direction stays reactive across data refreshes — consistent with the app's declarative, no-imperative-DOM-state conventions. At the default top-down view (bearing 0, pitch 0) the transform is identical to before, so there is no visual regression.

## Verification

- `pnpm lint` clean.
- `pnpm test:ember:dev` — all 58 tests pass.

Note: the acceptance suite uses a flat test style and does not exercise map bearing/pitch, so this is verified against the MapLibre transform contract plus the passing existing tests rather than an automated rotated-map assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)