### PR TITLE
🔗 Link station names to their zoomed map page

### DIFF
--- a/app/components/navbar/search.gts
+++ b/app/components/navbar/search.gts
@@ -15,7 +15,10 @@ import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import { searchQuery } from 'winds-mobi-client-web/builders/station';
-import { serializeMapView } from 'winds-mobi-client-web/utils/map-view';
+import {
+  serializeMapView,
+  STATION_FOCUS_ZOOM,
+} from 'winds-mobi-client-web/utils/map-view';
 import {
   type RequestResponse,
   responseData,
@@ -29,7 +32,6 @@ export interface NavbarSearchSignature {
 
 const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_MS = 200;
-const SEARCH_RESULT_ZOOM = 10;
 
 export default class NavbarSearch extends Component<NavbarSearchSignature> {
   @service declare router: RouterService;
@@ -212,7 +214,7 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
     const queryParams = serializeMapView({
       latitude: station.latitude,
       longitude: station.longitude,
-      zoom: SEARCH_RESULT_ZOOM,
+      zoom: STATION_FOCUS_ZOOM,
     });
 
     this.resetSearch();

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
+import { LinkTo } from '@ember/routing';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
@@ -11,6 +12,10 @@ import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
 import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
+import {
+  serializeMapView,
+  STATION_FOCUS_ZOOM,
+} from 'winds-mobi-client-web/utils/map-view';
 import StationMetaItem from './meta-item';
 
 export interface StationHeaderSignature {
@@ -38,13 +43,29 @@ export default class StationHeader extends Component<StationHeaderSignature> {
     );
   }
 
+  // Query params that focus the map on this station — shared with the navbar
+  // search so clicking a name behaves like selecting a search result (#47).
+  get focusQueryParams() {
+    return serializeMapView({
+      latitude: this.args.station.latitude,
+      longitude: this.args.station.longitude,
+      zoom: STATION_FOCUS_ZOOM,
+    });
+  }
+
   <template>
     <div class="min-w-0">
-      <h2
-        data-test-station-title
-        class="min-w-0 truncate text-xl font-bold text-slate-950"
-      >
-        {{@station.name}}
+      <h2 class="min-w-0">
+        <LinkTo
+          data-test-station-title
+          @route="map.station"
+          @model={{@station.id}}
+          @query={{this.focusQueryParams}}
+          title={{t "station.showOnMap"}}
+          class="block truncate text-xl font-bold text-slate-950 underline decoration-transparent underline-offset-3 transition hover:decoration-slate-300"
+        >
+          {{@station.name}}
+        </LinkTo>
       </h2>
 
       <dl

--- a/app/utils/map-view.ts
+++ b/app/utils/map-view.ts
@@ -9,6 +9,10 @@ export const DEFAULT_MAP_ZOOM = 7;
 // Zoom applied when centering the map on the user's location — a comfortable
 // regional area around them rather than a wide country-level or street-level view.
 export const INITIAL_LOCATION_ZOOM = 11;
+
+// Zoom applied when focusing a single station — selecting a search result or
+// clicking a station name (see issue #47). Keep these paths consistent.
+export const STATION_FOCUS_ZOOM = 10;
 export const MAP_REQUEST_COORDINATE_THRESHOLD = 0.01;
 export const MAP_REQUEST_ZOOM_THRESHOLD = 0.25;
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- A station's name is now a link: click it — in the detail panel or in a nearby-station card — to open that station on the map, zoomed in to it.
 - A new Settings page (reachable from the menu on desktop and mobile) lets you customise the interface, with a live preview of each option beside it. You can choose whether the browser tab shows the selected station, whether wind gusts are drawn as an arrow outline on the map, and whether station graphs start synced. Your choices are saved in this browser.
 - The browser tab icon now becomes the selected station's wind arrow — coloured by wind speed and gusts, rotated to the wind direction, and shaped for peaks — so an open station's latest reading is visible at a glance even from another tab. Closing the station restores the default icon.
 

--- a/tests/acceptance/map-station-panel-test.ts
+++ b/tests/acceptance/map-station-panel-test.ts
@@ -243,6 +243,19 @@ module('Acceptance | map station panel', function (hooks) {
     assert.dom('[data-test-station-air-section]').exists();
   });
 
+  test('it zooms in to the open station when its name is clicked', async function (this: MapStationPanelTestContext, assert) {
+    await visit('/map/holfuy-1804?mapLat=46.67719&mapLng=7.86323&mapZoom=8');
+    await click('[data-test-station-title]');
+    await waitUntil(() => currentURL().includes('mapZoom=10'));
+    await settled();
+
+    assertCurrentRoute(assert, '/map/holfuy-1804', {
+      mapLat: '46.67719',
+      mapLng: '7.86323',
+      mapZoom: '10',
+    });
+  });
+
   test('it closes from the explicit close button and preserves map query params', async function (this: MapStationPanelTestContext, assert) {
     await visit('/map/holfuy-1804?mapLat=46.67719&mapLng=7.86323&mapZoom=13');
     await click('[data-test-station-close]');

--- a/tests/acceptance/nearby-route-test.ts
+++ b/tests/acceptance/nearby-route-test.ts
@@ -1,6 +1,13 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { click, findAll, visit, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  currentURL,
+  findAll,
+  settled,
+  visit,
+  waitUntil,
+} from '@ember/test-helpers';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
 import MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
@@ -82,6 +89,18 @@ class FakeStoreService extends Service {
       return Promise.resolve({
         content: {
           data: HISTORY_FIXTURES,
+        },
+      });
+    }
+
+    const singleStation = STATION_FIXTURES.find((station) =>
+      url.includes(`/stations/${station.id}?`)
+    );
+
+    if (singleStation) {
+      return Promise.resolve({
+        content: {
+          data: singleStation,
         },
       });
     }
@@ -201,6 +220,26 @@ module('Acceptance | nearby route', function (hooks) {
     assert.dom(NEARBY_LOCATION_BUTTON_SELECTOR).doesNotExist();
     assert.dom(NEARBY_STATION_CARD_SELECTOR).exists({ count: 2 });
     assert.true(countStationRequests(store.calls) > 0);
+  });
+
+  test('it opens the map zoomed to a station when its name is clicked', async function (assert) {
+    const nearbyLocation = this.owner.lookup(
+      'service:nearby-location'
+    ) as NearbyLocationService;
+
+    stubGrantedPermission(nearbyLocation);
+
+    await visit('/nearby');
+    await waitForNearbyStations();
+
+    await click(`${NEARBY_STATION_CARD_SELECTOR} [data-test-station-title]`);
+    await waitUntil(() => currentURL().startsWith('/map/holfuy-1804?'));
+    await settled();
+
+    const params = new URL(currentURL(), 'https://winds.mobi').searchParams;
+    assert.strictEqual(params.get('mapLat'), '46.521');
+    assert.strictEqual(params.get('mapLng'), '6.632');
+    assert.strictEqual(params.get('mapZoom'), '10');
   });
 
   test('it keeps the refresh button visible and refreshes nearby stations', async function (assert) {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -114,6 +114,7 @@ nearby:
 
 station:
   lastPickup: Last pickup
+  showOnMap: Show on map
   meta:
     altitude: Altitude
     updated: Updated


### PR DESCRIPTION
Closes #47.

Clicking a station's name now opens that station on the map, zoomed in to it.

## What changed
- The station name in the shared station header ([`station/header.gts`](app/components/station/header.gts)) is now a `LinkTo` to `map.station`, carrying query params that center and zoom the map on the station. This covers both places a name is shown:
  - the map **detail panel / sidebar** ([`station/index.gts`](app/components/station/index.gts)) — clicking the open station's name zooms in to it
  - the **nearby cards** ([`station/nearby-card.gts`](app/components/station/nearby-card.gts)) — clicking a name opens that station on the map
- Promoted the search-result zoom (`10`) into a shared `STATION_FOCUS_ZOOM` constant in [`map-view.ts`](app/utils/map-view.ts), reused by the navbar search and the name link so both focus a station identically.
- Added a `station.showOnMap` translation for the link's `title`.

## Left unchanged (per the issue's "any other places")
- Navbar **search results** already navigate + zoom on select.
- The page `<title>` / favicon are non-interactive.

## Tests
- Nearby route: clicking a card's name lands on `map.station/:id` with the focus zoom query params.
- Map station panel: clicking the open station's name updates the zoom query param.
- Full lint + `test:ember:dev` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)