### PR TITLE
🗺️ Draw initial map directly at user location without animation

### DIFF
--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -120,7 +120,11 @@ export default class Map extends Component<MapSignature> {
   });
   private geolocateControl = new GeolocateControl({
     positionOptions: DEFAULT_POSITION_OPTIONS,
-    fitBoundsOptions: { maxZoom: INITIAL_LOCATION_ZOOM },
+    // The control's own `_updateCamera` runs `fitBounds(..., fitBoundsOptions)`
+    // on every fix. `animate: false` makes it settle instantly so the initial
+    // auto-center (and any later manual click) draws straight at the user's
+    // location rather than animating a pan/zoom in from the default view (#55).
+    fitBoundsOptions: { maxZoom: INITIAL_LOCATION_ZOOM, animate: false },
     showAccuracyCircle: true,
     showUserLocation: true,
     // Locate on demand rather than continuously tracking — we recenter the routed

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- When the map opens centered on your location, it now draws straight there instead of animating a pan and zoom in from the country-wide view.
+
 ## v0.4.0 - 2026-06-17
 
 ### Added


### PR DESCRIPTION
Fixes #55.

## Problem

On a fresh load with location permission granted, the map opened on the whole-Switzerland default view and then **animated** a pan and zoom in to the user's location. That animation is the `GeolocateControl`'s own `_updateCamera`, which runs an animated `fitBounds(...)` on every fix — distracting on initial load.

## Fix

Set `fitBoundsOptions.animate = false` on the `GeolocateControl` so its camera settles instantly. The map now draws straight at the user's location instead of animating in from the country-wide view. The shared declarative `flyTo` (search-result selection, logo reset) stays animated.

## Notes

- `jumpTo` can't apply here: the control only ever does `fitBounds` and has no option to disable its camera move — its only knob is `animate`.
- Geolocation is async, so one frame may still paint at the default view before the instant jump; it no longer animates, which is what the issue asked for.
- The geolocate path is guarded off in the test env, so no acceptance test exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)