### PR TITLE
🎯 Center the clicked station in the remaining map area

### DIFF
--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -246,9 +246,19 @@ export default class Map extends Component<MapSignature> {
   }
 
   @action
-  stationSelected(stationId: string) {
-    void this.router.transitionTo('map.station', stationId, {
-      queryParams: serializeMapView(this.mapView),
+  stationSelected(station: Station) {
+    // Recenter the routed view on the clicked station (keeping the current zoom,
+    // so it's a smooth pan) — the declarative fly-to then pans the map and the
+    // station ends up centered in the map area that remains beside the detail
+    // panel. Centering on the station's geographic coordinate is resize-robust:
+    // the panel shrinks the map container and MapLibre re-centers on that point
+    // when it resizes, so the station stays centered regardless of timing (#52).
+    void this.router.transitionTo('map.station', station.id, {
+      queryParams: serializeMapView({
+        longitude: station.longitude,
+        latitude: station.latitude,
+        zoom: this.mapView.zoom,
+      }),
     });
   }
 

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -15,7 +15,7 @@ import type { Station } from 'winds-mobi-client-web/services/store';
 export interface MapStationMarkerSignature {
   Args: {
     isSelected?: boolean;
-    onSelect: (stationId: string) => void;
+    onSelect: (station: Station) => void;
     station: Station;
   };
   Element: HTMLButtonElement;
@@ -62,7 +62,7 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
 
   @action
   handleSelect() {
-    this.args.onSelect(this.args.station.id);
+    this.args.onSelect(this.args.station);
   }
 
   <template>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - When the map opens centered on your location, it now draws straight there instead of animating a pan and zoom in from the country-wide view.
+- Clicking a station on the map now smoothly pans so it's centered in the map area beside the detail panel, instead of often staying off to the side.
 
 ## v0.4.0 - 2026-06-17
 


### PR DESCRIPTION
Fixes #52.

> Stacked on top of #56 (base branch `mb/issue-55-instant-initial-center`). Rebase to `main` once #56 merges.

## Problem

A station can be opened three ways, but only two of them recenter the map:

- **Search result** → sets the routed view to the station's coords → centers.
- **Station-name link** → same → centers.
- **Clicking a map marker** → kept the *current* map view unchanged → **never recentered**.

That asymmetry is the intermittent "sometimes centers" behaviour in the issue. Clicking a marker only *looked* like it moved because opening the detail panel shrinks the `flex-1` map container and MapLibre's resize keeps the old geo-center centered — so the clicked station stayed off to the side unless you happened to click near the center.

## Fix

`stationSelected` now sets the routed view to the clicked station's coordinates (keeping the current zoom, so it's a smooth pan). The existing declarative fly-to pans the map, matching the search / name-link paths. The marker passes the whole `Station` so its coordinates are available.

## On the resize concern from the issue comment

The commenter's instinct was right, with a refinement: the panel is a flex **sibling** that shrinks the map container (not an overlay), so centering on the station's **geographic coordinate** is inherently resize-robust. MapLibre's `ResizeObserver` re-centers on that point whenever the container resizes, so the station ends up — and stays — centered in the *remaining* map regardless of resize timing. No pixel/viewport math needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)