### PR TITLE
Tighten selected-station marker circle and sink it below other markers

### DIFF
--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -86,9 +86,10 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     const base =
       'block cursor-pointer rounded-full p-1 transition focus:outline-none';
 
-    // Selected: a grey disc + ring framing the arrow so it stands out on the map.
+    // Selected: a grey disc + ring hugging the arrow so it stands out without
+    // spilling into neighbouring markers' clickable area.
     return this.args.isSelected
-      ? `${base} bg-slate-400/40 ring-2 ring-slate-500/70`
+      ? `${base} bg-slate-400/40 ring-1 ring-inset ring-slate-500/70`
       : base;
   }
 
@@ -102,6 +103,7 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
       type="button"
       aria-label={{@station.name}}
       class={{this.buttonClass}}
+      data-selected={{if @isSelected "true"}}
       data-station-id={{@station.id}}
       data-test-map-station-marker
       {{on "click" this.handleSelect}}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -9,6 +9,13 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Sink the selected station marker's disc below every other marker, so it
+   never paints over — or steals clicks from — a neighbouring station's arrow
+   when markers overlap on the map. */
+.maplibregl-marker:has([data-selected='true']) {
+  z-index: -1;
+}
+
 @theme {
   --color-wind-05: rgb(9 179 0);
   --color-wind-10: rgb(0 179 71);


### PR DESCRIPTION
## Summary
- Selected station's ring is now `ring-1 ring-inset` so it hugs the arrow instead of bleeding outward into a bigger disc.
- The selected marker's `.maplibregl-marker` container is dropped to `z-index: -1` (via a `data-selected` hook), so it never paints over or steals clicks from a neighbouring station's arrow when markers overlap.

## Test plan
- [ ] `pnpm start`, select a station in a tightly-packed cluster, confirm the ring is smaller/closer to the arrow
- [ ] Confirm neighbouring arrows remain clickable when overlapped by a selected marker's disc