### PR TITLE
Simplify navbar search with Frontile Listbox

### DIFF
--- a/app/components/navbar/search-result.gts
+++ b/app/components/navbar/search-result.gts
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import type IntlService from 'ember-intl';
 import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
@@ -9,26 +8,14 @@ import type { Station } from 'winds-mobi-client-web/services/store.js';
 
 export interface NavbarSearchResultSignature {
   Args: {
-    isActive: boolean;
-    onActivate: () => void;
-    onSelect: () => void;
     station: Station;
   };
-  Element: HTMLButtonElement;
+  Element: HTMLDivElement;
 }
 
 export default class NavbarSearchResult extends Component<NavbarSearchResultSignature> {
   @service declare intl: IntlService;
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
-
-  get buttonClass() {
-    return [
-      'flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2.5 text-left transition',
-      this.args.isActive
-        ? 'bg-slate-100 text-slate-950'
-        : 'text-slate-700 hover:bg-slate-50 hover:text-slate-950',
-    ].join(' ');
-  }
 
   get windBand() {
     return windBandForSpeed(this.args.station.last.speed);
@@ -43,15 +30,7 @@ export default class NavbarSearchResult extends Component<NavbarSearchResultSign
   }
 
   <template>
-    <button
-      aria-selected={{if @isActive "true" "false"}}
-      class={{this.buttonClass}}
-      data-test-navbar-search-result={{@station.id}}
-      role="option"
-      type="button"
-      {{on "click" @onSelect}}
-      {{on "mousemove" @onActivate}}
-    >
+    <div ...attributes class="flex w-full items-center justify-between gap-3">
       <span class="min-w-0">
         <span class="block truncate text-sm font-semibold">
           {{@station.name}}
@@ -85,6 +64,6 @@ export default class NavbarSearchResult extends Component<NavbarSearchResultSign
         ></span>
         {{this.windSpeedLabel}}
       </span>
-    </button>
+    </div>
   </template>
 }

--- a/app/components/navbar/search.gts
+++ b/app/components/navbar/search.gts
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
@@ -8,8 +7,10 @@ import { cached, tracked } from '@glimmer/tracking';
 import type { Future } from '@warp-drive/core/request';
 import { getRequestState } from '@warp-drive/core/reactive';
 import { rawTimeout, task } from 'ember-concurrency';
+import { Listbox } from '@frontile/collections';
 import { Input as FrontileInput } from '@frontile/forms';
 import { Popover } from '@frontile/overlays';
+import { ref } from '@frontile/utilities';
 import { t } from 'ember-intl';
 import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
@@ -37,9 +38,11 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
   @service
   declare store: typeof import('winds-mobi-client-web/services/store').default;
 
-  @tracked activeResultIndex = 0;
+  @tracked activeKey?: string;
   @tracked isOpen = false;
   @tracked query = '';
+
+  triggerRef = ref<HTMLInputElement>();
 
   updateDebouncedQuery = task({ restartable: true }, async (value: string) => {
     const trimmedValue = value.trim();
@@ -88,22 +91,6 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
       : [];
   }
 
-  get clampedActiveResultIndex() {
-    if (this.results.length === 0) {
-      return -1;
-    }
-
-    return Math.min(this.activeResultIndex, this.results.length - 1);
-  }
-
-  get activeStation() {
-    if (this.clampedActiveResultIndex < 0) {
-      return undefined;
-    }
-
-    return this.results[this.clampedActiveResultIndex];
-  }
-
   get isLoading() {
     return (
       this.hasEnoughCharacters &&
@@ -128,19 +115,38 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
     return this.isOpen && this.hasEnoughCharacters;
   }
 
-  isActiveResult = (index: number) => {
-    return index === this.clampedActiveResultIndex;
+  // Schema-record `Station`s throw on access to fields outside their schema
+  // (e.g. `.key`), so Listbox's default key/label derivation can't run
+  // directly against them — wrap each result in a plain object instead.
+  get listboxItems() {
+    return this.results.map((station) => ({
+      key: station.id,
+      label: station.name,
+      station,
+    }));
+  }
+
+  isActiveResult = (key: string) => {
+    return key === this.activeKey;
+  };
+
+  itemClass = (key: string) => {
+    const base = 'rounded-xl px-3 py-2.5 gap-3 transition';
+
+    return this.isActiveResult(key)
+      ? `${base} bg-slate-100 text-slate-950`
+      : `${base} text-slate-700 hover:bg-slate-50 hover:text-slate-950`;
   };
 
   private resetSearch() {
     this.query = '';
     this.isOpen = false;
+    this.activeKey = undefined;
   }
 
   @action
   handleInput(value: string) {
     this.query = value;
-    this.activeResultIndex = 0;
     this.isOpen = this.hasEnoughCharacters;
 
     void this.updateDebouncedQuery.perform(value);
@@ -159,50 +165,23 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
   }
 
   @action
-  activateResult(index: number) {
-    this.activeResultIndex = index;
+  handleEscapeKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      this.isOpen = false;
+    }
   }
 
   @action
-  handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      this.isOpen = false;
-      return;
-    }
+  setActiveKey(key?: string) {
+    this.activeKey = key;
+  }
 
-    if (!this.isPopoverOpen) {
-      return;
-    }
+  @action
+  selectStationByKey(key: string) {
+    const station = this.results.find((result) => result.id === key);
 
-    if (event.key === 'ArrowDown') {
-      if (this.results.length === 0) {
-        return;
-      }
-
-      event.preventDefault();
-      this.activeResultIndex =
-        this.activeResultIndex >= this.results.length - 1
-          ? 0
-          : this.activeResultIndex + 1;
-      return;
-    }
-
-    if (event.key === 'ArrowUp') {
-      if (this.results.length === 0) {
-        return;
-      }
-
-      event.preventDefault();
-      this.activeResultIndex =
-        this.activeResultIndex <= 0
-          ? this.results.length - 1
-          : this.activeResultIndex - 1;
-      return;
-    }
-
-    if (event.key === 'Enter' && this.activeStation) {
-      event.preventDefault();
-      this.selectStation(this.activeStation);
+    if (station) {
+      this.selectStation(station);
     }
   }
 
@@ -243,8 +222,9 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
             @size="sm"
             @type="search"
             @value={{this.query}}
+            {{this.triggerRef.setup}}
             {{on "focus" this.handleFocus}}
-            {{on "keydown" this.handleKeydown}}
+            {{on "keydown" this.handleEscapeKeydown}}
           >
             <:startContent>
               <Binoculars @size={{14}} />
@@ -271,23 +251,30 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
                 {{t "navigation.search.loading"}}
               </p>
             {{else if this.results.length}}
-              <ul
+              <Listbox
+                @items={{this.listboxItems}}
+                @elementToAddKeyboardEvents={{this.triggerRef.current}}
+                @onAction={{this.selectStationByKey}}
+                @onActiveItemChange={{this.setActiveKey}}
                 aria-label={{t "navigation.search.label"}}
                 data-test-navbar-search-results
-                role="listbox"
                 class="max-h-80 overflow-y-auto p-1"
               >
-                {{#each this.results as |station index|}}
-                  <li role="presentation">
-                    <NavbarSearchResult
-                      @isActive={{this.isActiveResult index}}
-                      @onActivate={{fn this.activateResult index}}
-                      @onSelect={{fn this.selectStation station}}
-                      @station={{station}}
-                    />
-                  </li>
-                {{/each}}
-              </ul>
+                <:item as |l|>
+                  <l.Item
+                    @key={{l.key}}
+                    @class={{this.itemClass l.key}}
+                    aria-selected={{if
+                      (this.isActiveResult l.key)
+                      "true"
+                      "false"
+                    }}
+                    data-test-navbar-search-result={{l.key}}
+                  >
+                    <NavbarSearchResult @station={{l.item.station}} />
+                  </l.Item>
+                </:item>
+              </Listbox>
             {{else if this.hasNoResults}}
               <p
                 data-test-navbar-search-empty

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@embroider/vite": "^1.1.2",
     "@eslint/js": "^9.23.0",
     "@frontile/buttons": "0.17.0-beta.25",
+    "@frontile/collections": "0.17.0-beta.25",
     "@frontile/forms": "0.17.0-beta.25",
     "@frontile/notifications": "0.17.0-beta.25",
     "@frontile/overlays": "0.17.0-beta.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@frontile/buttons':
         specifier: 0.17.0-beta.25
         version: 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
+      '@frontile/collections':
+        specifier: 0.17.0-beta.25
+        version: 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
       '@frontile/forms':
         specifier: 0.17.0-beta.25
         version: 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
@@ -11094,11 +11097,28 @@ snapshots:
   '@frontile/collections@0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.5.2)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@embroider/addon-shim': 1.10.0
+      '@embroider/addon-shim': 1.10.2
       '@frontile/buttons': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.5.2)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
       '@frontile/overlays': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
       '@frontile/theme': 0.17.0-beta.25(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)
       '@frontile/utilities': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.5.2)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
+      ember-modifier: 4.2.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))
+      ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+      - tailwindcss
+      - webpack
+
+  '@frontile/collections@0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@embroider/addon-shim': 1.10.2
+      '@frontile/buttons': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
+      '@frontile/overlays': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
+      '@frontile/theme': 0.17.0-beta.25(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)
+      '@frontile/utilities': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))(tailwindcss@4.1.4)(webpack@5.94.0)
       ember-modifier: 4.2.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0))
       ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- `navbar/search.gts` hand-rolled active-index tracking, ARIA roles, and arrow/enter keyboard handling for the search results dropdown. Replaced that with `@frontile/collections`' `Listbox`, which already provides keyboard navigation, hover-activation, and click/Enter selection via its `onAction`/`onActiveItemChange` callbacks (keyboard events are bridged in via `elementToAddKeyboardEvents` pointed at the search input).
- Dropped the index-based active-result state (`activeResultIndex`/`clampedActiveResultIndex`/`activeStation`) in favor of a single `activeKey`, used only for highlight styling.
- `navbar/search-result.gts` is now a pure presenter (`@station` only) since `ListboxItem` owns the interactive `<li role="option">` and its click handling.
- Added `@frontile/collections` as a direct dependency (it was already a transitive dependency of `@frontile/forms`).
- Worked around a real gotcha: Warp Drive schema-record `Station`s throw on access to fields outside their schema, but Frontile's `keyAndLabelForItem` probes `item.key` directly — fixed by wrapping each result in a plain `{key, label, station}` object before handing it to `Listbox`.

No user-visible behavior change — search dropdown keyboard nav, click selection, and rendering are unchanged.

## Test plan
- [x] `pnpm lint` (pre-existing, unrelated formatting/eslint issues in other files left untouched)
- [x] `pnpm test:ember:dev` — full navbar-search acceptance suite (5/5) plus the rest of the filtered suite (61/61) pass
- [x] Manually exercised the search dropdown in the browser (typing, arrow nav, Enter, click, Escape)