### PR TITLE
Add a compact list view for nearby stations

### DIFF
--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -109,6 +109,32 @@ export default class Polar extends Component<PolarSignature> {
             },
           },
         },
+        {
+          // Thumbnail size (e.g. a compact nearby-list row): the N/E/S/W
+          // labels have no room to render legibly, so drop them entirely and
+          // let the polar pane fill almost the whole box as a plain dot scatter.
+          condition: {
+            maxWidth: 90,
+          },
+          chartOptions: {
+            pane: {
+              size: '98%',
+            },
+            plotOptions: {
+              series: {
+                lineWidth: 1,
+                marker: {
+                  radius: 2,
+                },
+              },
+            },
+            xAxis: {
+              labels: {
+                enabled: false,
+              },
+            },
+          },
+        },
       ],
     },
   };

--- a/app/components/navbar/search.gts
+++ b/app/components/navbar/search.gts
@@ -16,7 +16,7 @@ import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import { searchQuery } from 'winds-mobi-client-web/builders/station';
-import { FOCUS_ZOOM } from 'winds-mobi-client-web/utils/map-view';
+import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
 import {
   type RequestResponse,
   responseData,
@@ -187,11 +187,7 @@ export default class NavbarSearch extends Component<NavbarSearchSignature> {
 
   @action
   selectStation(station: Station) {
-    const queryParams = {
-      latitude: station.latitude,
-      longitude: station.longitude,
-      zoom: FOCUS_ZOOM,
-    };
+    const queryParams = focusQueryParamsFor(station);
 
     this.resetSearch();
 

--- a/app/components/settings/showcase/nearby-compact-list.gts
+++ b/app/components/settings/showcase/nearby-compact-list.gts
@@ -1,0 +1,57 @@
+import { array } from '@ember/helper';
+
+export interface SettingsShowcaseNearbyCompactListSignature {
+  Args: {
+    enabled: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+// A schematic (not real station data) comparing one big landscape card
+// against a 2x2 grid of the same card shrunk down, mirroring the actual
+// big/small toggle on /nearby (a name+time header, then a stat pair and a
+// round thumbnail) without rendering real stations. Whichever size matches
+// the current preference is highlighted; the other stays dim.
+<template>
+  <div
+    class="flex items-center justify-center gap-3 rounded-lg bg-slate-100 p-4"
+    ...attributes
+  >
+    <div
+      class="flex aspect-[3/2] w-28 flex-col justify-between rounded-md bg-white p-2 ring-1 ring-slate-200 transition
+        {{if @enabled 'opacity-40' 'opacity-100'}}"
+    >
+      <div class="flex items-start justify-between gap-1">
+        <div class="h-2 w-2/3 rounded-full bg-slate-300"></div>
+        <div class="h-1.5 w-3 rounded-full bg-slate-300"></div>
+      </div>
+      <div class="flex items-end justify-between gap-1">
+        <div class="flex flex-col gap-1">
+          <div class="h-1.5 w-6 rounded-full bg-slate-300"></div>
+          <div class="h-1.5 w-6 rounded-full bg-slate-300"></div>
+        </div>
+        <div class="size-5 rounded-full bg-slate-300"></div>
+      </div>
+    </div>
+
+    <div
+      class="grid grid-cols-2 gap-1 transition
+        {{if @enabled 'opacity-100' 'opacity-40'}}"
+    >
+      {{#each (array 1 2 3 4)}}
+        <div
+          class="flex aspect-[3/2] w-13 flex-col justify-between rounded bg-white p-1 ring-1 ring-slate-200"
+        >
+          <div class="flex items-start justify-between gap-0.5">
+            <div class="h-1 w-2/3 rounded-full bg-slate-300"></div>
+            <div class="h-1 w-1.5 rounded-full bg-slate-300"></div>
+          </div>
+          <div class="flex items-end justify-between gap-0.5">
+            <div class="h-1 w-3 rounded-full bg-slate-300"></div>
+            <div class="size-2.5 rounded-full bg-slate-300"></div>
+          </div>
+        </div>
+      {{/each}}
+    </div>
+  </div>
+</template>

--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -1,0 +1,132 @@
+import Component from '@glimmer/component';
+import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import { formatNumber } from 'ember-intl';
+import { t } from 'ember-intl';
+import type { IntlService } from 'ember-intl';
+import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
+import Mountains from 'ember-phosphor-icons/components/ph-mountains';
+import MapPin from 'ember-phosphor-icons/components/ph-map-pin';
+import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
+import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
+import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
+import StationMetaItem from './meta-item';
+import StationWindDirectionThumbnail from './wind-direction-thumbnail';
+import type { Station } from 'winds-mobi-client-web/services/store.js';
+
+export interface StationCompactCardSignature {
+  Args: {
+    station: Station;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDivElement;
+}
+
+export default class StationCompactCard extends Component<StationCompactCardSignature> {
+  @service declare intl: IntlService;
+
+  get reading() {
+    return this.args.station.last;
+  }
+
+  get speedValueClass() {
+    return windToTextClass(this.reading.speed);
+  }
+
+  get gustsValueClass() {
+    return windToTextClass(this.reading.gusts);
+  }
+
+  get lastReadingRelativeSeconds() {
+    return Math.round(
+      this.args.station.last.timestamp / 1000 - Date.now() / 1000
+    );
+  }
+
+  get focusQueryParams() {
+    return focusQueryParamsFor(this.args.station);
+  }
+
+  get windSpeedLabel() {
+    return this.intl.formatNumber(this.reading.speed, { format: 'integer' });
+  }
+
+  get gustsLabel() {
+    return this.intl.formatNumber(this.reading.gusts, { format: 'integer' });
+  }
+
+  <template>
+    <article
+      ...attributes
+      class="flex aspect-[3/2] min-h-0 gap-3 overflow-hidden rounded-xl border border-slate-200 bg-white p-3 shadow-md shadow-slate-900/12"
+      data-test-nearby-station-card-compact={{@station.id}}
+    >
+      <div class="flex min-h-0 min-w-0 flex-1 flex-col justify-between">
+        <div class="min-w-0">
+          <LinkTo
+            data-test-station-title
+            @route="map.station"
+            @model={{@station.id}}
+            @query={{this.focusQueryParams}}
+            title={{t "station.showOnMap"}}
+            class="block truncate text-sm font-semibold text-slate-950 underline decoration-transparent underline-offset-3 transition hover:decoration-slate-300"
+          >
+            {{@station.name}}
+          </LinkTo>
+
+          <dl class="m-0">
+            <StationMetaItem
+              @icon={{if @station.isPeak Mountains MapPin}}
+              @label={{t "station.meta.altitude"}}
+              class="text-xs text-slate-500"
+            >
+              <span>{{formatNumber @station.altitude maximumFractionDigits=0}}
+                m</span>
+            </StationMetaItem>
+          </dl>
+        </div>
+
+        <dl class="m-0 flex flex-col gap-1">
+          <div class="flex items-baseline gap-1.5">
+            <dt class="text-[11px] text-slate-500">{{t "wind.speed"}}</dt>
+            <dd
+              class="m-0 text-base font-semibold leading-none
+                {{this.speedValueClass}}"
+            >
+              {{this.windSpeedLabel}}
+            </dd>
+          </div>
+
+          <div class="flex items-baseline gap-1.5">
+            <dt class="text-[11px] text-slate-500">{{t "wind.gusts"}}</dt>
+            <dd
+              class="m-0 text-base font-semibold leading-none
+                {{this.gustsValueClass}}"
+            >
+              {{this.gustsLabel}}
+            </dd>
+          </div>
+        </dl>
+
+        <dl class="m-0">
+          <StationMetaItem
+            @icon={{ClockCounterClockwise}}
+            @label={{t "station.meta.updated"}}
+            class="text-[11px] text-slate-500"
+          >
+            <span>{{timeAgo this.lastReadingRelativeSeconds}}</span>
+          </StationMetaItem>
+        </dl>
+      </div>
+
+      <div class="flex min-h-0 min-w-0 flex-1 items-center justify-center">
+        <StationWindDirectionThumbnail
+          @stationId={{@station.id}}
+          class="aspect-square h-full max-h-full max-w-full"
+        />
+      </div>
+    </article>
+  </template>
+}

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -12,7 +12,7 @@ import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
 import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
-import { FOCUS_ZOOM } from 'winds-mobi-client-web/utils/map-view';
+import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
 import StationMetaItem from './meta-item';
 
 export interface StationHeaderSignature {
@@ -40,14 +40,8 @@ export default class StationHeader extends Component<StationHeaderSignature> {
     );
   }
 
-  // Query params that focus the map on this station — shared with the navbar
-  // search so clicking a name behaves like selecting a search result (#47).
   get focusQueryParams() {
-    return {
-      latitude: this.args.station.latitude,
-      longitude: this.args.station.longitude,
-      zoom: FOCUS_ZOOM,
-    };
+    return focusQueryParamsFor(this.args.station);
   }
 
   <template>

--- a/app/components/station/wind-direction-thumbnail.gts
+++ b/app/components/station/wind-direction-thumbnail.gts
@@ -1,0 +1,70 @@
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { Request } from '@warp-drive/ember';
+import { historyQuery } from 'winds-mobi-client-web/builders/history';
+import WindDirection from './wind-direction';
+import type { History } from 'winds-mobi-client-web/services/store.js';
+import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
+
+export interface StationWindDirectionThumbnailSignature {
+  Args: {
+    stationId: string;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDivElement;
+}
+
+const DURATION = 1 * 60 * 60;
+const EMPTY_HISTORY: History[] = [];
+const HISTORY_KEYS = ['w-dir', 'w-avg', 'w-max'];
+
+// A shrunk version of `station/last-hour`'s polar graph, for rows where there
+// is no room for a full section card with min/mean/max stats (e.g. the
+// compact nearby list, #64). Fetches the same 1-hour history independently
+// rather than sharing `StationLastHour`'s request, since the two render in
+// different contexts and never appear together for the same station.
+export default class StationWindDirectionThumbnail extends Component<StationWindDirectionThumbnailSignature> {
+  @service
+  declare store: typeof import('winds-mobi-client-web/services/store').default;
+  @service declare mapRefresh: MapRefreshService;
+
+  @cached
+  get historyRequest() {
+    this.mapRefresh.lastRefresh;
+
+    return this.store.request<{ data: History[] }>(
+      historyQuery<History>(
+        'history',
+        this.args.stationId,
+        {
+          duration: DURATION,
+          keys: HISTORY_KEYS,
+        },
+        {
+          backgroundReload: true,
+        }
+      )
+    );
+  }
+
+  <template>
+    <div class="min-h-0 min-w-0" ...attributes>
+      <Request @request={{this.historyRequest}}>
+        <:content as |result|>
+          <WindDirection @data={{result.data}} @hideAxisLabels={{true}} />
+        </:content>
+
+        <:loading>
+          <WindDirection @data={{EMPTY_HISTORY}} @hideAxisLabels={{true}} />
+        </:loading>
+
+        <:error>
+          <WindDirection @data={{EMPTY_HISTORY}} @hideAxisLabels={{true}} />
+        </:error>
+      </Request>
+    </div>
+  </template>
+}

--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -8,6 +8,7 @@ import windToColour from 'winds-mobi-client-web/helpers/wind-to-colour';
 export interface WindDirectionGraphSignature {
   Args: {
     data: History[];
+    hideAxisLabels?: boolean;
   };
   Blocks: {
     default: [];
@@ -46,6 +47,12 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
       pane: {
         size: '99%',
       },
+      // Omit `xAxis` entirely rather than setting it to `undefined` — Polar's
+      // shallow merge spreads override keys over defaults, so an explicit
+      // `undefined` would clobber the default xAxis instead of falling back to it.
+      ...(this.args.hideAxisLabels
+        ? { xAxis: { labels: { enabled: false } } }
+        : {}),
       yAxis: {
         min: minTimestamp,
         max: now,

--- a/app/components/station/wind-direction/index.gts
+++ b/app/components/station/wind-direction/index.gts
@@ -5,6 +5,7 @@ import WindDirectionGraph from './graph';
 export interface WindDirectionSignature {
   Args: {
     data: History[];
+    hideAxisLabels?: boolean;
   };
   Blocks: {
     default: [];
@@ -12,5 +13,7 @@ export interface WindDirectionSignature {
   Element: null;
 }
 export default class WindDirection extends Component<WindDirectionSignature> {
-  <template><WindDirectionGraph @data={{@data}} /></template>
+  <template>
+    <WindDirectionGraph @data={{@data}} @hideAxisLabels={{@hideAxisLabels}} />
+  </template>
 }

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -24,6 +24,11 @@ export default class SettingsService extends Service {
   // synced. The per-panel switch remains the live override for that session.
   @trackedInLocalStorage({ keyName: 'settings.syncGraphsByDefault' })
   syncGraphsByDefault = true;
+
+  // Show the /nearby stations list as dense rows instead of full cards, so
+  // more stations fit on screen without scrolling (#64).
+  @trackedInLocalStorage({ keyName: 'settings.nearbyCompactList' })
+  nearbyCompactList = false;
 }
 
 // The boolean preferences, named so the settings UI can drive each one through a
@@ -34,7 +39,8 @@ export type BooleanSettingKey =
   | 'faviconFollowsStation'
   | 'showGustsOutline'
   | 'shrinkOldData'
-  | 'syncGraphsByDefault';
+  | 'syncGraphsByDefault'
+  | 'nearbyCompactList';
 
 declare module '@ember/service' {
   interface Registry {

--- a/app/templates/nearby.gts
+++ b/app/templates/nearby.gts
@@ -5,14 +5,19 @@ import type { Future } from '@warp-drive/core/request';
 import { Request } from '@warp-drive/ember';
 import { pageTitle } from 'ember-page-title';
 import { action } from '@ember/object';
+import { fn } from '@ember/helper';
 import { Button } from '@frontile/buttons';
 import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
+import GridFour from 'ember-phosphor-icons/components/ph-grid-four';
+import GridNine from 'ember-phosphor-icons/components/ph-grid-nine';
 import { nearbyQuery } from 'winds-mobi-client-web/builders/station';
 import StationSectionCard from 'winds-mobi-client-web/components/station/section-card';
 import StationNearbyCard from 'winds-mobi-client-web/components/station/nearby-card';
+import StationCompactCard from 'winds-mobi-client-web/components/station/compact-card';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import { locationErrorTranslationKey } from 'winds-mobi-client-web/utils/location-error-translation-key';
 
@@ -30,6 +35,7 @@ export default class NearbyTemplate extends Component<NearbyTemplateSignature> {
   @service declare intl: IntlService;
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
   @service declare mapRefresh: MapRefreshService;
+  @service declare settings: SettingsService;
   @service
   declare store: typeof import('winds-mobi-client-web/services/store').default;
 
@@ -93,22 +99,70 @@ export default class NearbyTemplate extends Component<NearbyTemplateSignature> {
     await this.nearbyLocation.requestCurrentPosition();
   }
 
+  @action
+  setCompactList(compact: boolean) {
+    this.settings.nearbyCompactList = compact;
+  }
+
   <template>
     {{pageTitle (t "nearby.title")}}
 
     <section class="min-h-0 flex-1 overflow-y-auto bg-slate-200">
       <div class="flex w-full flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         {{#if this.nearbyLocation.hasCoordinates}}
+          <div class="flex justify-end gap-2">
+            <Button
+              aria-label={{t "nearby.view.card"}}
+              aria-pressed={{if this.settings.nearbyCompactList "false" "true"}}
+              data-test-nearby-view-toggle="card"
+              @appearance={{if
+                this.settings.nearbyCompactList
+                "outlined"
+                "default"
+              }}
+              @size="sm"
+              @onPress={{fn this.setCompactList false}}
+            >
+              <GridFour @size={{16}} />
+            </Button>
+
+            <Button
+              aria-label={{t "nearby.view.compact"}}
+              aria-pressed={{if this.settings.nearbyCompactList "true" "false"}}
+              data-test-nearby-view-toggle="compact"
+              @appearance={{if
+                this.settings.nearbyCompactList
+                "default"
+                "outlined"
+              }}
+              @size="sm"
+              @onPress={{fn this.setCompactList true}}
+            >
+              <GridNine @size={{16}} />
+            </Button>
+          </div>
+
           <Request @request={{this.stationsRequest}}>
             <:content as |result|>
-              <div
-                class="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(22rem,1fr))]"
-                data-test-nearby-stations
-              >
-                {{#each result.data as |station|}}
-                  <StationNearbyCard @station={{station}} />
-                {{/each}}
-              </div>
+              {{#if this.settings.nearbyCompactList}}
+                <div
+                  class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(11rem,1fr))]"
+                  data-test-nearby-stations-compact
+                >
+                  {{#each result.data as |station|}}
+                    <StationCompactCard @station={{station}} />
+                  {{/each}}
+                </div>
+              {{else}}
+                <div
+                  class="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(22rem,1fr))]"
+                  data-test-nearby-stations
+                >
+                  {{#each result.data as |station|}}
+                    <StationNearbyCard @station={{station}} />
+                  {{/each}}
+                </div>
+              {{/if}}
             </:content>
 
             <:loading>

--- a/app/templates/settings.gts
+++ b/app/templates/settings.gts
@@ -8,6 +8,7 @@ import SettingsShowcaseFavicon from 'winds-mobi-client-web/components/settings/s
 import SettingsShowcaseGusts from 'winds-mobi-client-web/components/settings/showcase/gusts';
 import SettingsShowcaseShrink from 'winds-mobi-client-web/components/settings/showcase/shrink';
 import SettingsShowcaseGraphSync from 'winds-mobi-client-web/components/settings/showcase/graph-sync';
+import SettingsShowcaseNearbyCompactList from 'winds-mobi-client-web/components/settings/showcase/nearby-compact-list';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 
 interface SettingsTemplateSignature {
@@ -61,6 +62,12 @@ export default class SettingsTemplate extends Component<SettingsTemplateSignatur
               <SettingsShowcaseGraphSync
                 @enabled={{row.enabled}}
                 @onChange={{row.update}}
+              />
+            </SettingsRow>
+
+            <SettingsRow @settings={{this.settings}} @name="nearbyCompactList">
+              <SettingsShowcaseNearbyCompactList
+                @enabled={{this.settings.nearbyCompactList}}
               />
             </SettingsRow>
           </dl>

--- a/app/utils/map-view.ts
+++ b/app/utils/map-view.ts
@@ -11,6 +11,20 @@ export const DEFAULT_MAP_ZOOM = 7;
 // station name, nearby card). A comfortable regional area rather than a wide
 // country-level or street-level view (see issues #32, #47).
 export const FOCUS_ZOOM = 10;
+// Query params that focus the map on a single station — shared by every
+// station-focusing entry point (search result, station name, nearby card/row)
+// so they all land on the same zoom (#47).
+export function focusQueryParamsFor(station: {
+  latitude: number;
+  longitude: number;
+}) {
+  return {
+    latitude: station.latitude,
+    longitude: station.longitude,
+    zoom: FOCUS_ZOOM,
+  };
+}
+
 const MAP_REQUEST_COORDINATE_THRESHOLD = 0.01;
 const MAP_REQUEST_ZOOM_THRESHOLD = 0.25;
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.4 - 2026-06-21
+
+### Added
+
+- The Nearby stations view now has a "Smaller cards" toggle (also available in Settings) that shows a denser grid of compact cards — name, altitude, wind, gusts, last update, and a small wind-direction thumbnail — so more stations fit on screen without scrolling.
+
 ## v0.6.3 - 2026-06-21
 
 ### Changed

--- a/tests/acceptance/nearby-route-test.ts
+++ b/tests/acceptance/nearby-route-test.ts
@@ -163,6 +163,11 @@ module('Acceptance | nearby route', function (hooks) {
 
   hooks.beforeEach(function () {
     this.owner.register('service:store', FakeStoreService);
+    window.localStorage.removeItem('settings.nearbyCompactList');
+  });
+
+  hooks.afterEach(function () {
+    window.localStorage.removeItem('settings.nearbyCompactList');
   });
 
   test('it shows the explainer and waits for the nearby location button when access is not granted yet', async function (assert) {
@@ -240,6 +245,39 @@ module('Acceptance | nearby route', function (hooks) {
     assert.strictEqual(params.get('latitude'), '46.521');
     assert.strictEqual(params.get('longitude'), '6.632');
     assert.strictEqual(params.get('zoom'), '10');
+  });
+
+  test('it switches to the compact list view and back', async function (assert) {
+    const nearbyLocation = this.owner.lookup(
+      'service:nearby-location'
+    ) as NearbyLocationService;
+
+    stubGrantedPermission(nearbyLocation);
+
+    await visit('/nearby');
+    await waitForNearbyStations();
+
+    assert.dom('[data-test-nearby-stations-compact]').doesNotExist();
+    assert
+      .dom('[data-test-nearby-station-card-compact]')
+      .doesNotExist('compact cards are not rendered in card view');
+
+    await click('[data-test-nearby-view-toggle="compact"]');
+
+    assert
+      .dom(NEARBY_STATION_CARD_SELECTOR)
+      .doesNotExist('full cards are not rendered in compact view');
+    assert
+      .dom('[data-test-nearby-station-card-compact]')
+      .exists({ count: STATION_FIXTURES.length });
+    assert
+      .dom('[data-test-nearby-station-card-compact="holfuy-1804"]')
+      .includesText('Holfuy 1804');
+
+    await click('[data-test-nearby-view-toggle="card"]');
+
+    assert.dom(NEARBY_STATION_CARD_SELECTOR).exists({ count: 2 });
+    assert.dom('[data-test-nearby-station-card-compact]').doesNotExist();
   });
 
   test('it keeps the refresh button visible and refreshes nearby stations', async function (assert) {

--- a/tests/acceptance/settings-route-test.ts
+++ b/tests/acceptance/settings-route-test.ts
@@ -16,6 +16,7 @@ const STORAGE_KEYS = [
   'settings.showGustsOutline',
   'settings.shrinkOldData',
   'settings.syncGraphsByDefault',
+  'settings.nearbyCompactList',
 ];
 
 module('Acceptance | settings route', function (hooks) {
@@ -30,7 +31,7 @@ module('Acceptance | settings route', function (hooks) {
     STORAGE_KEYS.forEach((key) => window.localStorage.removeItem(key));
   });
 
-  test('it shows the four preferences, on by default', async function (assert) {
+  test('it shows the five preferences, on by default except the compact nearby list', async function (assert) {
     await visit('/settings');
 
     assert.dom('[data-test-navbar-link="settings"]').hasText('Settings');
@@ -38,6 +39,7 @@ module('Acceptance | settings route', function (hooks) {
     assert.dom('[data-test-setting="showGustsOutline"]').isChecked();
     assert.dom('[data-test-setting="shrinkOldData"]').isChecked();
     assert.dom('[data-test-setting="syncGraphsByDefault"]').isChecked();
+    assert.dom('[data-test-setting="nearbyCompactList"]').isNotChecked();
   });
 
   test('toggling a preference persists it to local storage', async function (assert) {
@@ -58,6 +60,28 @@ module('Acceptance | settings route', function (hooks) {
     assert.dom('[data-test-setting="showGustsOutline"]').isChecked();
     assert.strictEqual(
       window.localStorage.getItem('settings.showGustsOutline'),
+      null,
+      'restoring the default clears the stored override'
+    );
+  });
+
+  test('toggling the compact nearby list preference persists it to local storage', async function (assert) {
+    await visit('/settings');
+
+    await click('[data-test-setting="nearbyCompactList"]');
+
+    assert.dom('[data-test-setting="nearbyCompactList"]').isChecked();
+    assert.strictEqual(
+      window.localStorage.getItem('settings.nearbyCompactList'),
+      'true',
+      'the non-default preference is written to local storage'
+    );
+
+    await click('[data-test-setting="nearbyCompactList"]');
+
+    assert.dom('[data-test-setting="nearbyCompactList"]').isNotChecked();
+    assert.strictEqual(
+      window.localStorage.getItem('settings.nearbyCompactList'),
       null,
       'restoring the default clears the stored override'
     );

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -44,6 +44,12 @@ settings:
       Open station panels with the wind and air graphs sharing one time range,
       so zooming or panning one moves the other. You can still unlink them per
       station.
+  nearbyCompactList:
+    label: Smaller nearby cards
+    description: >-
+      Show nearby stations as smaller cards (name, altitude, wind, gusts, last
+      update, and a small wind-direction thumbnail) instead of full-size
+      cards, so more stations fit on screen without scrolling.
   preview:
     graphWind: Wind
     graphAir: Air
@@ -108,6 +114,9 @@ nearby:
   description: Use your location to find the closest stations around your current position and compare the live reading with the last hour at a glance.
   loading: Looking up the closest stations…
   requestError: Nearby stations could not be loaded right now.
+  view:
+    card: Bigger cards
+    compact: Smaller cards
   location:
     checking: Checking location access…
     locatingDescription: Trying to determine your current location…


### PR DESCRIPTION
Closes #64

## Summary
- Pilots use `/nearby` mid-flight to glance at several stations at once, but each station rendered as a full card (header + 7-metric grid + full-size polar chart), so only one or two fit on screen and users had to scroll.
- Adds a `settings.nearbyCompactList` preference (off by default), toggled via a card/grid icon-button pair on `/nearby` (and also editable from `/settings`, following the existing preference pattern there).
- Compact mode renders a denser grid of landscape cards — name, altitude, wind speed, gusts, last-update, and a small wind-direction thumbnail — instead of the full `StationNearbyCard`.
- The thumbnail reuses the same 1-hour history fetch `StationLastHour` already makes for every visible card, so it adds no new network cost. Added an explicit `@hideAxisLabels` passthrough to `WindDirection`/`Polar` so the thumbnail's compass never shows clipped N/E/S/W labels regardless of its rendered size.
- Extracted `focusQueryParamsFor()` to `utils/map-view.ts` to stop re-deriving the station-focus query params (`{latitude, longitude, zoom: FOCUS_ZOOM}`) in three separate places.
- Bumps `CHANGELOG.md` to v0.6.3.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test:ember:dev` — full suite (63/63) passes
- [x] Manually exercised the card/compact toggle on `/nearby` and `/settings` in the browser