### PR TITLE
Simplify compact-card wind readings and peak icon

### DIFF
--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -87,6 +87,18 @@ export default class StationCompactCard extends Component<StationCompactCardSign
           </dl>
         </div>
 
+        <dl class="m-0">
+          <StationMetaItem
+            @icon={{ClockCounterClockwise}}
+            @label={{t "station.meta.updated"}}
+            class="text-[11px] text-slate-500"
+          >
+            <span>{{timeAgo this.lastReadingRelativeSeconds}}</span>
+          </StationMetaItem>
+        </dl>
+      </div>
+
+      <div class="flex min-h-0 min-w-0 flex-1 flex-col items-center gap-1">
         <dl class="m-0 flex items-baseline gap-1">
           <dt class="sr-only">{{t "wind.speed"}}</dt>
           <dd
@@ -109,22 +121,12 @@ export default class StationCompactCard extends Component<StationCompactCardSign
           <dd class="m-0 text-xs text-slate-500">km/h</dd>
         </dl>
 
-        <dl class="m-0">
-          <StationMetaItem
-            @icon={{ClockCounterClockwise}}
-            @label={{t "station.meta.updated"}}
-            class="text-[11px] text-slate-500"
-          >
-            <span>{{timeAgo this.lastReadingRelativeSeconds}}</span>
-          </StationMetaItem>
-        </dl>
-      </div>
-
-      <div class="flex min-h-0 min-w-0 flex-1 items-center justify-center">
-        <StationWindDirectionThumbnail
-          @stationId={{@station.id}}
-          class="aspect-square h-full max-h-full max-w-full"
-        />
+        <div class="flex min-h-0 w-full flex-1 items-center justify-center">
+          <StationWindDirectionThumbnail
+            @stationId={{@station.id}}
+            class="aspect-square h-full max-h-full max-w-full"
+          />
+        </div>
       </div>
     </article>
   </template>

--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -6,7 +6,6 @@ import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
 import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
-import MapPin from 'ember-phosphor-icons/components/ph-map-pin';
 import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
@@ -78,7 +77,7 @@ export default class StationCompactCard extends Component<StationCompactCardSign
 
           <dl class="m-0">
             <StationMetaItem
-              @icon={{if @station.isPeak Mountains MapPin}}
+              @icon={{if @station.isPeak Mountains}}
               @label={{t "station.meta.altitude"}}
               class="text-xs text-slate-500"
             >
@@ -88,26 +87,26 @@ export default class StationCompactCard extends Component<StationCompactCardSign
           </dl>
         </div>
 
-        <dl class="m-0 flex flex-col gap-1">
-          <div class="flex items-baseline gap-1.5">
-            <dt class="text-[11px] text-slate-500">{{t "wind.speed"}}</dt>
-            <dd
-              class="m-0 text-base font-semibold leading-none
-                {{this.speedValueClass}}"
-            >
-              {{this.windSpeedLabel}}
-            </dd>
-          </div>
+        <dl class="m-0 flex items-baseline gap-1">
+          <dt class="sr-only">{{t "wind.speed"}}</dt>
+          <dd
+            class="m-0 text-[1.5rem] font-semibold leading-none
+              {{this.speedValueClass}}"
+          >
+            {{this.windSpeedLabel}}
+          </dd>
 
-          <div class="flex items-baseline gap-1.5">
-            <dt class="text-[11px] text-slate-500">{{t "wind.gusts"}}</dt>
-            <dd
-              class="m-0 text-base font-semibold leading-none
-                {{this.gustsValueClass}}"
-            >
-              {{this.gustsLabel}}
-            </dd>
-          </div>
+          <span aria-hidden="true" class="text-slate-400">/</span>
+
+          <dt class="sr-only">{{t "wind.gusts"}}</dt>
+          <dd
+            class="m-0 text-base font-semibold leading-none
+              {{this.gustsValueClass}}"
+          >
+            {{this.gustsLabel}}
+          </dd>
+
+          <dd class="m-0 text-xs text-slate-500">km/h</dd>
         </dl>
 
         <dl class="m-0">

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -5,7 +5,6 @@ import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
 import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
-import MapPin from 'ember-phosphor-icons/components/ph-map-pin';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
 import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
@@ -63,9 +62,9 @@ export default class StationHeader extends Component<StationHeaderSignature> {
         class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] font-medium text-slate-500"
       >
         {{! Peaks (free-flight take-off sites) get the mountain glyph; other }}
-        {{! stations get a plain location pin, mirroring the map-marker shape. }}
+        {{! stations show altitude with no icon. }}
         <StationMetaItem
-          @icon={{if @station.isPeak Mountains MapPin}}
+          @icon={{if @station.isPeak Mountains}}
           @label={{t "station.meta.altitude"}}
         >
           <span>{{formatNumber @station.altitude maximumFractionDigits=0}}

--- a/app/components/station/meta-item.gts
+++ b/app/components/station/meta-item.gts
@@ -2,7 +2,7 @@ import type { ComponentLike } from '@glint/template';
 
 export interface StationMetaItemSignature {
   Args: {
-    icon: ComponentLike<{
+    icon?: ComponentLike<{
       Args: {
         size?: number;
       };
@@ -19,7 +19,9 @@ export interface StationMetaItemSignature {
   <div class="flex items-center gap-1.5">
     <dt class="sr-only">{{@label}}</dt>
     <dd class="m-0 inline-flex items-center gap-1.5" ...attributes>
-      <@icon @size={{14}} class="text-slate-400" />
+      {{#if @icon}}
+        <@icon @size={{14}} class="text-slate-400" />
+      {{/if}}
       {{yield}}
     </dd>
   </div>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.1 - 2026-06-21
+
+### Changed
+
+- Compact nearby cards now show wind speed and gusts as a single "speed / gusts km/h" line (speed shown larger) instead of two separate labeled rows, and only peak (take-off site) stations show a mountain icon next to their altitude — other stations show altitude with no icon, on both the compact cards and the station header.
+
 ## v0.7.0 - 2026-06-21
 
 ### Added

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -66,7 +66,7 @@ help:
     legendTitle: What you are looking at
     items:
       headerTitle: Station header
-      headerDescription: The header shows the station name, altitude, relative update time, provider, and the distance from you when your location is available.
+      headerDescription: The header shows the station name, altitude, relative update time, provider, and the distance from you when your location is available. A mountain icon next to the altitude marks a free-flight take-off site (peak); other stations show altitude with no icon.
       nowTitle: Now
       nowDescription: The left summary card shows the latest reported values for wind, gusts, direction, temperature, humidity, pressure, and rain.
       lastHourTitle: Last hour


### PR DESCRIPTION
## Summary
- Compact nearby cards now show wind speed and gusts as a single `[speed] / [gusts] km/h` line (speed at 1.5rem, gusts at the base 1rem) instead of two separate labeled rows — `sr-only` labels are kept for screen readers.
- `StationMetaItem`'s `@icon` argument is now optional. Both the compact card and the station header now only show the mountain glyph for peak (take-off site) stations — non-peak stations show altitude with no icon at all (dropping the previous location-pin fallback).
- Documented the mountain icon's meaning in the Help page's station-header legend text.
- Bumps `CHANGELOG.md` to v0.7.1.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test:ember:dev` — full suite (63/63) passes
- [x] Manually checked a peak and a non-peak station in both card and compact-card view