### PR TITLE
Force at least two columns in the compact nearby grid

### DIFF
--- a/app/templates/nearby.gts
+++ b/app/templates/nearby.gts
@@ -146,7 +146,7 @@ export default class NearbyTemplate extends Component<NearbyTemplateSignature> {
             <:content as |result|>
               {{#if this.settings.nearbyCompactList}}
                 <div
-                  class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(11rem,1fr))]"
+                  class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(11rem,calc(50%-0.375rem)),1fr))]"
                   data-test-nearby-stations-compact
                 >
                   {{#each result.data as |station|}}

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.3 - 2026-06-21
+
+### Changed
+
+- The compact nearby-stations grid now always shows at least two columns, even on the narrowest phone screens, instead of collapsing to a single column.
+
 ## v0.7.2 - 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- The compact nearby-stations grid (`app/templates/nearby.gts`) used `auto-fit` with a fixed `minmax(11rem, 1fr)` track size, which collapsed to a single column on the narrowest phone screens (container width below ~2x11rem).
- Clamp the minimum track size to `min(11rem, calc(50% - half-gap))` so the grid always keeps at least two columns, while still growing card width/column count on wider screens exactly as before.
- Bumps the changelog to v0.7.3.

## Test plan
- [x] `pnpm lint` passes (css/hbs/format)
- [x] `pnpm test:ember:dev -- --filter "nearby"` passes (63/63)