### PR TITLE
Shorten relative time-ago units

### DIFF
--- a/app/helpers/time-ago.ts
+++ b/app/helpers/time-ago.ts
@@ -38,8 +38,11 @@ export function timeAgoParts(seconds: number) {
 
 export function renderTimeAgoText(intl: IntlService, seconds: number) {
   const { value, unit } = timeAgoParts(seconds);
+  const text = intl.formatRelativeTime(value, { unit, style: 'narrow' });
 
-  return intl.formatRelativeTime(value, { unit });
+  // Intl's narrow style abbreviates minutes as "m", which reads too close to
+  // "month" (mo); spell it out as "min" while keeping the other units narrow.
+  return unit === 'minute' ? text.replace(/(\d)m\b/, '$1 min') : text;
 }
 
 interface TimeAgoSignature {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.4 - 2026-06-21
+
+### Changed
+
+- Relative "last updated" times (in the station detail header and compact nearby cards) now use shorter unit abbreviations, e.g. "5 min ago" and "2h ago" instead of "5 minutes ago" and "2 hours ago".
+
 ## v0.7.3 - 2026-06-21
 
 ### Changed

--- a/tests/unit/helpers/time-ago-test.ts
+++ b/tests/unit/helpers/time-ago-test.ts
@@ -28,6 +28,6 @@ module('Unit | Helper | time-ago', function (hooks) {
   test('it formats relative text through ember-intl', function (this: TestContext, assert) {
     const intl = this.owner.lookup('service:intl') as IntlService;
 
-    assert.strictEqual(renderTimeAgoText(intl, 600), 'in 10 minutes');
+    assert.strictEqual(renderTimeAgoText(intl, 600), 'in 10 min');
   });
 });


### PR DESCRIPTION
## Summary
- `renderTimeAgoText` in `app/helpers/time-ago.ts` now formats with `Intl.RelativeTimeFormat`'s `narrow` style instead of the default `long` style, giving "5m ago", "2h ago", "3d ago", etc. instead of "5 minutes ago", "2 hours ago".
- Minutes are special-cased to "min" (instead of narrow's "m") since "5m" reads too close to month's "mo" abbreviation.
- Bumps the changelog to v0.7.4.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:ember:dev -- --filter "time-ago"` passes, including updated assertion for the new wording