### PR TITLE
Drop the minute-text override in time-ago

### DIFF
--- a/app/helpers/time-ago.ts
+++ b/app/helpers/time-ago.ts
@@ -38,11 +38,8 @@ export function timeAgoParts(seconds: number) {
 
 export function renderTimeAgoText(intl: IntlService, seconds: number) {
   const { value, unit } = timeAgoParts(seconds);
-  const text = intl.formatRelativeTime(value, { unit, style: 'narrow' });
 
-  // Intl's narrow style abbreviates minutes as "m", which reads too close to
-  // "month" (mo); spell it out as "min" while keeping the other units narrow.
-  return unit === 'minute' ? text.replace(/(\d)m\b/, '$1 min') : text;
+  return intl.formatRelativeTime(value, { unit, style: 'narrow' });
 }
 
 interface TimeAgoSignature {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.5 - 2026-06-21
+
+### Changed
+
+- Relative "last updated" minutes now show as "5m ago" (matching hours/days/etc.) instead of "5 min ago".
+
 ## v0.7.4 - 2026-06-21
 
 ### Changed

--- a/tests/unit/helpers/time-ago-test.ts
+++ b/tests/unit/helpers/time-ago-test.ts
@@ -28,6 +28,6 @@ module('Unit | Helper | time-ago', function (hooks) {
   test('it formats relative text through ember-intl', function (this: TestContext, assert) {
     const intl = this.owner.lookup('service:intl') as IntlService;
 
-    assert.strictEqual(renderTimeAgoText(intl, 600), 'in 10 min');
+    assert.strictEqual(renderTimeAgoText(intl, 600), 'in 10m');
   });
 });


### PR DESCRIPTION
## Summary
- Removes the manual `.replace(/(\d)m\b/, '$1 min')` override added in #71 for the minute unit.
- `renderTimeAgoText` now returns `Intl.RelativeTimeFormat`'s narrow-style output as-is for every unit ("5m ago" instead of "5 min ago"), with no post-processing on top of the library.
- Bumps the changelog to v0.7.5.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:ember:dev -- --filter "time-ago"` passes with the updated "in 10m" assertion