### PR TITLE
Remove the clock icon from the "updated" time

### DIFF
--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -4,7 +4,6 @@ import { service } from '@ember/service';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
-import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
@@ -89,7 +88,6 @@ export default class StationCompactCard extends Component<StationCompactCardSign
 
         <dl class="m-0">
           <StationMetaItem
-            @icon={{ClockCounterClockwise}}
             @label={{t "station.meta.updated"}}
             class="text-[11px] text-slate-500"
           >

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -4,7 +4,6 @@ import { LinkTo } from '@ember/routing';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
-import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
 import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
@@ -71,10 +70,7 @@ export default class StationHeader extends Component<StationHeaderSignature> {
             m</span>
         </StationMetaItem>
 
-        <StationMetaItem
-          @icon={{ClockCounterClockwise}}
-          @label={{t "station.meta.updated"}}
-        >
+        <StationMetaItem @label={{t "station.meta.updated"}}>
           <span>{{timeAgo this.lastReadingRelativeSeconds}}</span>
         </StationMetaItem>
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.6 - 2026-06-21
+
+### Changed
+
+- Removed the clock icon next to the "last updated" relative time in the station header and compact nearby cards, leaving just the time text.
+
 ## v0.7.5 - 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Drops `@icon={{ClockCounterClockwise}}` from the "updated" `StationMetaItem` in `app/components/station/header.gts` and `app/components/station/compact-card.gts`, leaving just the relative time text.
- Removes the now-unused `ClockCounterClockwise` import from both files.
- Bumps the changelog to v0.7.6.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on the touched files reports no unused-import issues
- [x] `pnpm test:ember:dev -- --filter "header"` passes