### PR TITLE
Colour the "updated" time by reading age

### DIFF
--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -8,6 +8,7 @@ import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
+import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
 import StationMetaItem from './meta-item';
 import StationWindDirectionThumbnail from './wind-direction-thumbnail';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
@@ -41,6 +42,10 @@ export default class StationCompactCard extends Component<StationCompactCardSign
     return Math.round(
       this.args.station.last.timestamp / 1000 - Date.now() / 1000
     );
+  }
+
+  get lastReadingFreshnessClass() {
+    return textClassForReadingAge(this.args.station.last.timestamp);
   }
 
   get focusQueryParams() {
@@ -91,7 +96,9 @@ export default class StationCompactCard extends Component<StationCompactCardSign
             @label={{t "station.meta.updated"}}
             class="text-[11px] text-slate-500"
           >
-            <span>{{timeAgo this.lastReadingRelativeSeconds}}</span>
+            <span class={{this.lastReadingFreshnessClass}}>{{timeAgo
+                this.lastReadingRelativeSeconds
+              }}</span>
           </StationMetaItem>
         </dl>
       </div>

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -11,6 +11,7 @@ import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
+import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
 import StationMetaItem from './meta-item';
 
 export interface StationHeaderSignature {
@@ -36,6 +37,10 @@ export default class StationHeader extends Component<StationHeaderSignature> {
     return Math.round(
       this.args.station.last.timestamp / 1000 - Date.now() / 1000
     );
+  }
+
+  get lastReadingFreshnessClass() {
+    return textClassForReadingAge(this.args.station.last.timestamp);
   }
 
   get focusQueryParams() {
@@ -71,7 +76,9 @@ export default class StationHeader extends Component<StationHeaderSignature> {
         </StationMetaItem>
 
         <StationMetaItem @label={{t "station.meta.updated"}}>
-          <span>{{timeAgo this.lastReadingRelativeSeconds}}</span>
+          <span class={{this.lastReadingFreshnessClass}}>{{timeAgo
+              this.lastReadingRelativeSeconds
+            }}</span>
         </StationMetaItem>
 
         {{#let this.nearbyLocation.coordinates as |coordinates|}}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -30,6 +30,16 @@
   --color-wind-40: rgb(179 0 161);
   --color-wind-45: rgb(179 0 80);
   --color-wind-50: rgb(179 0 0);
+
+  /* Fades a reading's "updated" text from dark gold (just in) to grey, ending
+     at the same grey used for stale (24h+) map markers (see
+     STALE_STATION_COLOUR in app/utils/station-arrow.ts). */
+  --color-fresh-0: rgb(146 64 14);
+  --color-fresh-1: rgb(146 84 48);
+  --color-fresh-2: rgb(147 104 82);
+  --color-fresh-3: rgb(147 123 116);
+  --color-fresh-4: rgb(148 143 150);
+  --color-fresh-5: rgb(148 163 184);
 }
 
 /* stylelint-enable */

--- a/app/utils/reading-freshness.ts
+++ b/app/utils/reading-freshness.ts
@@ -1,0 +1,31 @@
+// Text-colour bands for a reading's "updated" time: dark gold when just in,
+// fading to grey as the reading ages. The final band's colour matches
+// STALE_STATION_COLOUR (app/utils/station-arrow.ts) so stale text and stale
+// map markers agree on what "grey" means. Classes come from the
+// --color-fresh-* tokens in app/styles/app.css.
+const READING_FRESHNESS_BANDS: { maxAgeMs: number; textClass: string }[] = [
+  { maxAgeMs: 10 * 60 * 1000, textClass: 'text-fresh-0' },
+  { maxAgeMs: 30 * 60 * 1000, textClass: 'text-fresh-1' },
+  { maxAgeMs: 60 * 60 * 1000, textClass: 'text-fresh-2' },
+  { maxAgeMs: 4 * 60 * 60 * 1000, textClass: 'text-fresh-3' },
+  { maxAgeMs: 12 * 60 * 60 * 1000, textClass: 'text-fresh-4' },
+  { maxAgeMs: Infinity, textClass: 'text-fresh-5' },
+];
+
+export function textClassForReadingAge(timestamp: number): string {
+  const lastBand = READING_FRESHNESS_BANDS[READING_FRESHNESS_BANDS.length - 1];
+
+  if (!Number.isFinite(timestamp)) {
+    return lastBand!.textClass;
+  }
+
+  const age = Date.now() - timestamp;
+
+  for (const band of READING_FRESHNESS_BANDS) {
+    if (age <= band.maxAgeMs) {
+      return band.textClass;
+    }
+  }
+
+  return lastBand!.textClass;
+}

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.7 - 2026-06-21
+
+### Added
+
+- The "last updated" relative time in the station header and compact nearby cards is now coloured from dark gold (just updated) fading to grey as the reading ages, matching the grey already used for stale (24h+) map markers.
+
 ## v0.7.6 - 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Added six `--color-fresh-0`..`--color-fresh-5` Tailwind theme tokens in `app/styles/app.css`, interpolating from dark gold (amber-800) to the same grey already used for stale (24h+) map markers (`STALE_STATION_COLOUR` in `app/utils/station-arrow.ts`).
- Added `textClassForReadingAge()` in `app/utils/reading-freshness.ts`, bucketing a reading's age into 6 bands (10min/30min/1h/4h/12h/24h+) mapped to the `text-fresh-*` classes — no inline `style=` bindings, since `ember-template-lint`'s `recommended` config forbids those (`no-inline-styles`).
- Applied the resulting class to the "updated" value `<span>` in `compact-card.gts` and `header.gts`.
- Bumps the changelog to v0.7.7.

## Test plan
- [x] `pnpm lint` passes (including `lint:hbs`, confirming no inline-style violations)
- [x] `pnpm exec eslint` on the touched files is clean
- [x] `pnpm test:ember:dev -- --filter "header"` passes (63/63)