### PR TITLE
Colour sidebar temperature and compact the value widgets

### DIFF
--- a/app/components/station/air/presenter.gts
+++ b/app/components/station/air/presenter.gts
@@ -1,18 +1,9 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 import TimeSeries from '../../chart/time-series';
+import { temperatureColourZones } from 'winds-mobi-client-web/helpers/temperature-to-colour';
 import type { History } from 'winds-mobi-client-web/services/store.js';
 import { buildTimeSeriesData } from 'winds-mobi-client-web/utils/chart-series';
-
-const TEMPERATURE_ZONES = [
-  { color: '#c4b5fd', value: -10 },
-  { color: '#7dd3fc', value: 0 },
-  { color: '#1d4ed8', value: 10 },
-  { color: '#16a34a', value: 20 },
-  { color: '#eab308', value: 30 },
-  { color: '#f97316', value: 40 },
-  { color: '#dc2626' },
-];
 
 export interface StationAirContentSignature {
   Args: {
@@ -50,7 +41,7 @@ export default class StationAirContent extends Component<StationAirContentSignat
           valueSuffix: '°C',
         },
         zoneAxis: 'y',
-        zones: TEMPERATURE_ZONES,
+        zones: temperatureColourZones(),
       },
       {
         name: 'Humidity',

--- a/app/components/station/metric-card.gts
+++ b/app/components/station/metric-card.gts
@@ -88,7 +88,7 @@ export default class StationMetricCard extends Component<StationMetricCardSignat
   <template>
     {{#if this.hasValue}}
       <div
-        class="rounded-md bg-slate-50 px-2 py-1.5 ring-1 ring-slate-200/80 md:rounded-xl md:px-3 md:py-2.5"
+        class="flex items-baseline justify-between gap-2 rounded-md bg-slate-50 px-2 py-1.5 ring-1 ring-slate-200/80 md:rounded-xl md:px-3 md:py-2.5"
         ...attributes
       >
         <dt
@@ -98,7 +98,7 @@ export default class StationMetricCard extends Component<StationMetricCardSignat
           {{@label}}
         </dt>
         <dd
-          class="mt-0.5 text-base font-semibold leading-tight md:mt-1.5 md:text-lg
+          class="text-right text-base font-semibold leading-tight md:text-lg
             {{if @valueClass @valueClass}}"
         >
           {{this.formattedValue}}

--- a/app/components/station/summary.gts
+++ b/app/components/station/summary.gts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { t } from 'ember-intl';
+import { temperatureToTextClass } from 'winds-mobi-client-web/helpers/temperature-to-colour';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import StationLastHour from './last-hour';
 import StationMetricCard from './metric-card';
@@ -27,6 +28,10 @@ export default class StationSummary extends Component<StationSummarySignature> {
 
   get gustsValueClass() {
     return windToTextClass(this.reading.gusts);
+  }
+
+  get temperatureValueClass() {
+    return temperatureToTextClass(this.reading.temperature);
   }
 
   <template>
@@ -58,6 +63,7 @@ export default class StationSummary extends Component<StationSummarySignature> {
               @format="temperature"
               @label={{t "air.temperature"}}
               @value={{this.reading.temperature}}
+              @valueClass={{this.temperatureValueClass}}
             />
 
             <StationMetricCard

--- a/app/helpers/temperature-to-colour.ts
+++ b/app/helpers/temperature-to-colour.ts
@@ -1,0 +1,48 @@
+export interface TemperatureColourBand {
+  color: string;
+  max: number;
+  textClass: string;
+}
+
+export interface TemperatureColourZone {
+  color: string;
+  value?: number;
+}
+
+const TEMPERATURE_COLOUR_BANDS: TemperatureColourBand[] = [
+  { color: '#c4b5fd', max: -10, textClass: 'text-violet-300' }, // Violet below -10°C
+  { color: '#7dd3fc', max: 0, textClass: 'text-sky-300' }, // Sky blue for -10 to 0°C
+  { color: '#1d4ed8', max: 10, textClass: 'text-blue-700' }, // Blue for 0-10°C
+  { color: '#16a34a', max: 20, textClass: 'text-green-600' }, // Green for 10-20°C
+  { color: '#eab308', max: 30, textClass: 'text-yellow-500' }, // Yellow for 20-30°C
+  { color: '#f97316', max: 40, textClass: 'text-orange-500' }, // Orange for 30-40°C
+  { color: '#dc2626', max: Infinity, textClass: 'text-red-600' }, // Red for 40°C+
+];
+
+export function temperatureBandFor(value: number): TemperatureColourBand {
+  for (const band of TEMPERATURE_COLOUR_BANDS) {
+    if (value < band.max) {
+      return band;
+    }
+  }
+
+  return TEMPERATURE_COLOUR_BANDS[TEMPERATURE_COLOUR_BANDS.length - 1]!;
+}
+
+export function temperatureToTextClass(value: number): string {
+  return temperatureBandFor(value).textClass;
+}
+
+// Highcharts zones (used by the air chart) need concrete colours, not Tailwind
+// classes, so this shares the same band thresholds/colours as
+// temperatureToTextClass rather than letting the chart and the metric card
+// drift apart.
+export function temperatureColourZones(): TemperatureColourZone[] {
+  return TEMPERATURE_COLOUR_BANDS.map((band) => {
+    if (Number.isFinite(band.max)) {
+      return { color: band.color, value: band.max };
+    }
+
+    return { color: band.color };
+  });
+}

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.7.8 - 2026-06-21
+
+### Changed
+
+- The temperature value in the station detail sidebar's "Now" card is now coloured with the same violet-to-red scale used by the `Air` history chart, instead of plain text.
+- The "Now" card's value widgets (wind speed, gusts, direction, temperature, humidity, pressure, rain) are now single-line and more compact, with the label on the left and the value right-aligned, instead of stacking the label above the value.
+
 ## v0.7.7 - 2026-06-21
 
 ### Added


### PR DESCRIPTION
## Summary
- Extracted the `Air` history chart's hardcoded `TEMPERATURE_ZONES` into a shared `app/helpers/temperature-to-colour.ts` (mirroring the existing `wind-to-colour.ts` pattern), exposing `temperatureColourZones()` for Highcharts and `temperatureToTextClass()` for plain text — same colour scheme, single source of truth.
- Wired `temperatureToTextClass()` into the temperature `StationMetricCard` in `summary.gts`, so the sidebar's "Now" card temperature is now coloured violet→sky→blue→green→yellow→orange→red the same way the Air chart already colours it.
- Restyled `StationMetricCard` from a stacked label/value layout to a single flex row: label left, value right-aligned, more compact.
- Confirmed the "ago" freshness colouring from the previous release already covers every place relative time is shown (`station/header.gts`, reused by both the sidebar and `nearby-card.gts`/`compact-card.gts`), so no further wiring was needed there.
- Bumps the changelog to v0.7.8.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on the touched files is clean
- [x] `pnpm test:ember:dev` passes (63/63)