### PR TITLE
Add wind/air history chart rendering tests

### DIFF
--- a/tests/acceptance/map-station-panel-test.ts
+++ b/tests/acceptance/map-station-panel-test.ts
@@ -5,6 +5,7 @@ import { module, test } from 'qunit';
 import {
   click,
   currentURL,
+  findAll,
   settled,
   type TestContext,
   visit,
@@ -241,6 +242,28 @@ module('Acceptance | map station panel', function (hooks) {
     assert.dom('[data-test-station-summary-section]').exists();
     assert.dom('[data-test-station-wind-section]').exists();
     assert.dom('[data-test-station-air-section]').exists();
+  });
+
+  test('it renders the wind and air history charts with the loaded history', async function (assert) {
+    await visit('/map/holfuy-1804?latitude=46.67719&longitude=7.86323&zoom=13');
+
+    assert
+      .dom('[data-test-station-wind-section] .highcharts-container')
+      .exists('the wind history chart renders');
+    assert.strictEqual(
+      findAll('[data-test-station-wind-section] .highcharts-series').length,
+      2,
+      'the wind chart renders both the wind and gusts series'
+    );
+
+    assert
+      .dom('[data-test-station-air-section] .highcharts-container')
+      .exists('the air history chart renders');
+    assert.strictEqual(
+      findAll('[data-test-station-air-section] .highcharts-series').length,
+      2,
+      'the air chart renders both the temperature and humidity series'
+    );
   });
 
   test('it zooms in to the open station when its name is clicked', async function (this: MapStationPanelTestContext, assert) {

--- a/tests/integration/components/station/air/presenter-test.ts
+++ b/tests/integration/components/station/air/presenter-test.ts
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { findAll, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { Type } from '@warp-drive/core/types/symbols';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+import type { History } from 'winds-mobi-client-web/services/store';
+
+type AirPresenterTestContext = {
+  history: History[];
+};
+
+module('Integration | Component | station/air/presenter', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders both the temperature and humidity series on their own y-axes', async function (this: AirPresenterTestContext, assert) {
+    const now = Date.now();
+
+    this.history = [
+      {
+        id: 'history-1',
+        direction: 180,
+        speed: 10,
+        gusts: 14,
+        temperature: 6,
+        humidity: 60,
+        rain: 0,
+        timestamp: now - 30 * 60 * 1000,
+        [Type]: 'history',
+      },
+      {
+        id: 'history-2',
+        direction: 225,
+        speed: 16,
+        gusts: 22,
+        temperature: 22,
+        humidity: 58,
+        rain: 0,
+        timestamp: now - 5 * 60 * 1000,
+        [Type]: 'history',
+      },
+    ];
+
+    await render(hbs`<Station::Air::Presenter @history={{this.history}} />`);
+
+    assert.dom('.highcharts-container').exists();
+    assert.strictEqual(
+      findAll('.highcharts-series').length,
+      2,
+      'both the temperature and humidity series render'
+    );
+    assert.strictEqual(
+      findAll('.highcharts-yaxis-labels').length,
+      2,
+      'temperature and humidity each get their own y-axis'
+    );
+    assert
+      .dom('.highcharts-graph')
+      .exists('the temperature series renders as a line');
+  });
+
+  test('it renders the chart when there is no history', async function (this: AirPresenterTestContext, assert) {
+    this.history = [];
+
+    await render(hbs`<Station::Air::Presenter @history={{this.history}} />`);
+
+    assert.dom('.highcharts-container').exists();
+  });
+});

--- a/tests/integration/components/station/wind/presenter-test.ts
+++ b/tests/integration/components/station/wind/presenter-test.ts
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+import { findAll, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { Type } from '@warp-drive/core/types/symbols';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+import type { History } from 'winds-mobi-client-web/services/store';
+
+type WindPresenterTestContext = {
+  history: History[];
+};
+
+module('Integration | Component | station/wind/presenter', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders both the wind and gusts series', async function (this: WindPresenterTestContext, assert) {
+    const now = Date.now();
+
+    this.history = [
+      {
+        id: 'history-1',
+        direction: 180,
+        speed: 10,
+        gusts: 14,
+        temperature: 6,
+        humidity: 60,
+        rain: 0,
+        timestamp: now - 30 * 60 * 1000,
+        [Type]: 'history',
+      },
+      {
+        id: 'history-2',
+        direction: 225,
+        speed: 16,
+        gusts: 22,
+        temperature: 7,
+        humidity: 58,
+        rain: 0,
+        timestamp: now - 5 * 60 * 1000,
+        [Type]: 'history',
+      },
+    ];
+
+    await render(hbs`<Station::Wind::Presenter @history={{this.history}} />`);
+
+    assert.dom('.highcharts-container').exists();
+    assert
+      .dom('.highcharts-yaxis-labels')
+      .exists('it renders the shared wind/gusts y-axis');
+    assert.strictEqual(
+      findAll('.highcharts-series').length,
+      2,
+      'both the wind and gusts series render'
+    );
+    assert.dom('.highcharts-area').exists('the wind series renders as area');
+  });
+
+  test('it renders the chart when there is no history', async function (this: WindPresenterTestContext, assert) {
+    this.history = [];
+
+    await render(hbs`<Station::Wind::Presenter @history={{this.history}} />`);
+
+    assert.dom('.highcharts-container').exists();
+  });
+});


### PR DESCRIPTION
## Summary
- Added unit-level integration tests for `Station::Wind::Presenter` and `Station::Air::Presenter`, asserting both series render per chart with sample history data.
- Added an acceptance test on the real map station panel route exercising the full `FakeStoreService` -> `historyQuery` -> `Request` -> presenter pipeline, asserting both `[data-test-station-wind-section]` and `[data-test-station-air-section]` render a Highcharts container with 2 series each.
- Test-only change, no production code touched, no changelog entry (per the "omit test-only changes" convention).

## Investigation notes
- Confirmed via direct `curl` to the production historic API that backend history data is present and non-empty.
- `git diff v0.7.5..v0.7.8` shows no changes to `app/builders/history.ts`, `app/handlers/history.ts`, or the wind/air `index.gts` `Request` wiring across the last 3 patch releases.
- All 68 tests pass, confirming the charts render correctly given data — a blank chart in production is likely a stale PWA service-worker cache from before the last deploy rather than a code regression. This release exists in part to force a fresh build hash.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean (pre-existing unrelated errors elsewhere in the file left untouched)
- [x] `pnpm test:ember:dev` passes (68/68)