### PR TITLE
Add finer-grained early freshness bands

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -33,13 +33,19 @@
 
   /* Fades a reading's "updated" text from dark gold (just in) to grey, ending
      at the same grey used for stale (24h+) map markers (see
-     STALE_STATION_COLOUR in app/utils/station-arrow.ts). */
+     STALE_STATION_COLOUR in app/utils/station-arrow.ts). Most readings are
+     under 10 minutes old (the map refreshes every 2 minutes), so the early
+     stops are bunched tightly to keep the fade visible at realistic ages
+     instead of everything landing on --color-fresh-0. */
   --color-fresh-0: rgb(146 64 14);
-  --color-fresh-1: rgb(146 84 48);
-  --color-fresh-2: rgb(147 104 82);
-  --color-fresh-3: rgb(147 123 116);
-  --color-fresh-4: rgb(148 143 150);
-  --color-fresh-5: rgb(148 163 184);
+  --color-fresh-1: rgb(146 76 35);
+  --color-fresh-2: rgb(147 89 57);
+  --color-fresh-3: rgb(147 101 78);
+  --color-fresh-4: rgb(147 114 99);
+  --color-fresh-5: rgb(147 126 120);
+  --color-fresh-6: rgb(147 138 142);
+  --color-fresh-7: rgb(148 151 163);
+  --color-fresh-8: rgb(148 163 184);
 }
 
 /* stylelint-enable */

--- a/app/utils/reading-freshness.ts
+++ b/app/utils/reading-freshness.ts
@@ -2,14 +2,20 @@
 // fading to grey as the reading ages. The final band's colour matches
 // STALE_STATION_COLOUR (app/utils/station-arrow.ts) so stale text and stale
 // map markers agree on what "grey" means. Classes come from the
-// --color-fresh-* tokens in app/styles/app.css.
+// --color-fresh-* tokens in app/styles/app.css. The map refreshes every 2
+// minutes, so most readings are well under 10 minutes old — the early
+// thresholds are bunched tightly so the fade is visible at those realistic
+// ages instead of every station landing on the same first band.
 const READING_FRESHNESS_BANDS: { maxAgeMs: number; textClass: string }[] = [
-  { maxAgeMs: 10 * 60 * 1000, textClass: 'text-fresh-0' },
-  { maxAgeMs: 30 * 60 * 1000, textClass: 'text-fresh-1' },
-  { maxAgeMs: 60 * 60 * 1000, textClass: 'text-fresh-2' },
-  { maxAgeMs: 4 * 60 * 60 * 1000, textClass: 'text-fresh-3' },
-  { maxAgeMs: 12 * 60 * 60 * 1000, textClass: 'text-fresh-4' },
-  { maxAgeMs: Infinity, textClass: 'text-fresh-5' },
+  { maxAgeMs: 2 * 60 * 1000, textClass: 'text-fresh-0' },
+  { maxAgeMs: 5 * 60 * 1000, textClass: 'text-fresh-1' },
+  { maxAgeMs: 10 * 60 * 1000, textClass: 'text-fresh-2' },
+  { maxAgeMs: 20 * 60 * 1000, textClass: 'text-fresh-3' },
+  { maxAgeMs: 40 * 60 * 1000, textClass: 'text-fresh-4' },
+  { maxAgeMs: 90 * 60 * 1000, textClass: 'text-fresh-5' },
+  { maxAgeMs: 4 * 60 * 60 * 1000, textClass: 'text-fresh-6' },
+  { maxAgeMs: 24 * 60 * 60 * 1000, textClass: 'text-fresh-7' },
+  { maxAgeMs: Infinity, textClass: 'text-fresh-8' },
 ];
 
 export function textClassForReadingAge(timestamp: number): string {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.10 - 2026-06-21
+
+### Changed
+
+- The "last updated" gold-to-grey colour fade now has finer steps in the first 10-40 minutes (matching the app's 2-minute refresh cycle), so the fade is visible across nearby stations instead of nearly all of them landing on the same dark-gold colour.
+
 ## v0.7.8 - 2026-06-21
 
 ### Changed

--- a/tests/unit/utils/reading-freshness-test.ts
+++ b/tests/unit/utils/reading-freshness-test.ts
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
+
+module('Unit | Utility | reading-freshness', function () {
+  test('it fades from dark gold to grey as the reading ages', function (assert) {
+    const now = Date.now();
+
+    assert.strictEqual(
+      textClassForReadingAge(now),
+      'text-fresh-0',
+      'just-in readings get the darkest gold'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 4 * 60 * 1000),
+      'text-fresh-1',
+      '4 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 8 * 60 * 1000),
+      'text-fresh-2',
+      '8 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 15 * 60 * 1000),
+      'text-fresh-3',
+      '15 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 30 * 60 * 1000),
+      'text-fresh-4',
+      '30 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 60 * 60 * 1000),
+      'text-fresh-5',
+      '1 hour old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 2 * 60 * 60 * 1000),
+      'text-fresh-6',
+      '2 hours old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 12 * 60 * 60 * 1000),
+      'text-fresh-7',
+      '12 hours old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 25 * 60 * 60 * 1000),
+      'text-fresh-8',
+      'stale (24h+) readings get the same grey as stale map markers'
+    );
+  });
+
+  test('it treats a non-finite timestamp as stale', function (assert) {
+    assert.strictEqual(textClassForReadingAge(NaN), 'text-fresh-8');
+  });
+});


### PR DESCRIPTION
## Summary
- The map refreshes every 2 minutes, so nearly every visible reading is under 10 minutes old. With the previous 6-band scale (first threshold at 10 minutes), almost everything landed on the same `text-fresh-0` darkest-gold band, making the fade invisible in practice.
- Expanded `--color-fresh-*` from 6 to 9 stops in `app/styles/app.css`, and matched thresholds in `app/utils/reading-freshness.ts`: 2/5/10/20/40/90 minutes, then 4h/24h for the long tail to stale grey.
- Added `tests/unit/utils/reading-freshness-test.ts` covering all 9 bands plus the non-finite-timestamp fallback.
- Bumps the changelog to v0.7.10.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean
- [x] `pnpm test:ember:dev` passes (70/70)