### PR TITLE
Make the freshest "updated" colour glow

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -31,20 +31,21 @@
   --color-wind-45: rgb(179 0 80);
   --color-wind-50: rgb(179 0 0);
 
-  /* Fades a reading's "updated" text from dark gold (just in) to grey, ending
-     at the same grey used for stale (24h+) map markers (see
-     STALE_STATION_COLOUR in app/utils/station-arrow.ts). Most readings are
-     under 10 minutes old (the map refreshes every 2 minutes), so the early
-     stops are bunched tightly to keep the fade visible at realistic ages
-     instead of everything landing on --color-fresh-0. */
-  --color-fresh-0: rgb(146 64 14);
-  --color-fresh-1: rgb(146 76 35);
-  --color-fresh-2: rgb(147 89 57);
-  --color-fresh-3: rgb(147 101 78);
-  --color-fresh-4: rgb(147 114 99);
-  --color-fresh-5: rgb(147 126 120);
-  --color-fresh-6: rgb(147 138 142);
-  --color-fresh-7: rgb(148 151 163);
+  /* Fades a reading's "updated" text through three anchors: glowing amber-400
+     (just in) through dark amber-800 (still fresh-ish) to slate-400, the same
+     grey used for stale (24h+) map markers (see STALE_STATION_COLOUR in
+     app/utils/station-arrow.ts). Most readings are under 10 minutes old (the
+     map refreshes every 2 minutes), so the early stops are bunched tightly to
+     keep the fade visible at realistic ages instead of everything landing on
+     --color-fresh-0. */
+  --color-fresh-0: rgb(251 191 36);
+  --color-fresh-1: rgb(216 149 29);
+  --color-fresh-2: rgb(181 106 21);
+  --color-fresh-3: rgb(146 64 14);
+  --color-fresh-4: rgb(146 84 48);
+  --color-fresh-5: rgb(147 104 82);
+  --color-fresh-6: rgb(147 123 116);
+  --color-fresh-7: rgb(148 143 150);
   --color-fresh-8: rgb(148 163 184);
 }
 

--- a/app/utils/reading-freshness.ts
+++ b/app/utils/reading-freshness.ts
@@ -1,11 +1,11 @@
-// Text-colour bands for a reading's "updated" time: dark gold when just in,
-// fading to grey as the reading ages. The final band's colour matches
-// STALE_STATION_COLOUR (app/utils/station-arrow.ts) so stale text and stale
-// map markers agree on what "grey" means. Classes come from the
-// --color-fresh-* tokens in app/styles/app.css. The map refreshes every 2
-// minutes, so most readings are well under 10 minutes old — the early
-// thresholds are bunched tightly so the fade is visible at those realistic
-// ages instead of every station landing on the same first band.
+// Text-colour bands for a reading's "updated" time: glowing gold when just
+// in, through dark gold, fading to grey as the reading ages. The final
+// band's colour matches STALE_STATION_COLOUR (app/utils/station-arrow.ts) so
+// stale text and stale map markers agree on what "grey" means. Classes come
+// from the --color-fresh-* tokens in app/styles/app.css. The map refreshes
+// every 2 minutes, so most readings are well under 10 minutes old — the
+// early thresholds are bunched tightly so the fade is visible at those
+// realistic ages instead of every station landing on the same first band.
 const READING_FRESHNESS_BANDS: { maxAgeMs: number; textClass: string }[] = [
   { maxAgeMs: 2 * 60 * 1000, textClass: 'text-fresh-0' },
   { maxAgeMs: 5 * 60 * 1000, textClass: 'text-fresh-1' },

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.11 - 2026-06-21
+
+### Changed
+
+- The "last updated" colour fade now starts with a brighter, more vivid gold for just-in readings, instead of the previous muted dark gold.
+
 ## v0.7.10 - 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Re-anchored the `--color-fresh-*` gradient in `app/styles/app.css` on three colours instead of a flat two-point fade: glowing `amber-400` (rgb(251,191,36)) for just-in readings, through dark `amber-800` (rgb(146,64,14)) for still-fresh-ish readings, fading to `slate-400` (rgb(148,163,184)) for stale — same final grey as stale map markers.
- Recomputed all 9 interpolated stops accordingly; thresholds in `app/utils/reading-freshness.ts` are unchanged.
- Bumps the changelog to v0.7.11.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:ember:dev -- --filter "reading-freshness"` passes (band-name assertions unaffected by the colour-only change)