### PR TITLE
Show the data-freshness colour scale on the Help page

### DIFF
--- a/app/templates/help.gts
+++ b/app/templates/help.gts
@@ -5,6 +5,7 @@ import HelpChangelog from 'winds-mobi-client-web/components/help/changelog';
 import HelpLiveStation from 'winds-mobi-client-web/components/help/live-station';
 import MapLegend from 'winds-mobi-client-web/components/map/legend';
 import StationSectionCard from 'winds-mobi-client-web/components/station/section-card';
+import { readingFreshnessLegendBands } from 'winds-mobi-client-web/utils/reading-freshness';
 import { windLegendBands } from 'winds-mobi-client-web/helpers/wind-to-colour';
 
 interface HelpTemplateSignature {
@@ -31,6 +32,7 @@ export default class HelpTemplate extends Component<HelpTemplateSignature> {
   providers = PROVIDERS;
 
   legendBands = windLegendBands();
+  freshnessLegendBands = readingFreshnessLegendBands();
 
   <template>
     {{pageTitle (t "help.title")}}
@@ -119,7 +121,7 @@ export default class HelpTemplate extends Component<HelpTemplateSignature> {
           </StationSectionCard>
         </div>
 
-        <div class="grid gap-6 lg:grid-cols-2">
+        <div class="grid gap-6 lg:grid-cols-3">
           <StationSectionCard @title={{t "help.colors.title"}}>
             <div class="grid gap-4">
               <p class="text-sm leading-6 text-slate-600">
@@ -131,6 +133,36 @@ export default class HelpTemplate extends Component<HelpTemplateSignature> {
                   @bands={{this.legendBands}}
                   @title={{t "map.legend.windSpeed"}}
                 />
+              </div>
+            </div>
+          </StationSectionCard>
+
+          <StationSectionCard @title={{t "help.freshness.title"}}>
+            <div class="grid gap-4">
+              <p class="text-sm leading-6 text-slate-600">
+                {{t "help.freshness.description"}}
+              </p>
+              <div
+                class="relative min-h-32 rounded-lg bg-slate-50 p-4"
+                data-test-help-freshness-legend
+              >
+                <p
+                  class="mb-2 text-[10px] font-semibold uppercase leading-tight tracking-[0.1em] text-slate-500"
+                >
+                  {{t "station.meta.updated"}}
+                </p>
+                <ul class="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+                  {{#each this.freshnessLegendBands as |band|}}
+                    <li class="flex items-center gap-1.5">
+                      <span
+                        aria-hidden="true"
+                        class="size-3 shrink-0 rounded-full ring-1 ring-black/10
+                          {{band.backgroundClass}}"
+                      ></span>
+                      <span class="text-xs text-slate-600">{{band.label}}</span>
+                    </li>
+                  {{/each}}
+                </ul>
               </div>
             </div>
           </StationSectionCard>

--- a/app/utils/reading-freshness.ts
+++ b/app/utils/reading-freshness.ts
@@ -1,3 +1,8 @@
+export interface ReadingFreshnessLegendBand {
+  backgroundClass: string;
+  label: string;
+}
+
 // Text-colour bands for a reading's "updated" time: glowing gold when just
 // in, through dark gold, fading to grey as the reading ages. The final
 // band's colour matches STALE_STATION_COLOUR (app/utils/station-arrow.ts) so
@@ -6,16 +11,56 @@
 // every 2 minutes, so most readings are well under 10 minutes old — the
 // early thresholds are bunched tightly so the fade is visible at those
 // realistic ages instead of every station landing on the same first band.
-const READING_FRESHNESS_BANDS: { maxAgeMs: number; textClass: string }[] = [
-  { maxAgeMs: 2 * 60 * 1000, textClass: 'text-fresh-0' },
-  { maxAgeMs: 5 * 60 * 1000, textClass: 'text-fresh-1' },
-  { maxAgeMs: 10 * 60 * 1000, textClass: 'text-fresh-2' },
-  { maxAgeMs: 20 * 60 * 1000, textClass: 'text-fresh-3' },
-  { maxAgeMs: 40 * 60 * 1000, textClass: 'text-fresh-4' },
-  { maxAgeMs: 90 * 60 * 1000, textClass: 'text-fresh-5' },
-  { maxAgeMs: 4 * 60 * 60 * 1000, textClass: 'text-fresh-6' },
-  { maxAgeMs: 24 * 60 * 60 * 1000, textClass: 'text-fresh-7' },
-  { maxAgeMs: Infinity, textClass: 'text-fresh-8' },
+const READING_FRESHNESS_BANDS: {
+  maxAgeMs: number;
+  backgroundClass: string;
+  textClass: string;
+}[] = [
+  {
+    maxAgeMs: 2 * 60 * 1000,
+    backgroundClass: 'bg-fresh-0',
+    textClass: 'text-fresh-0',
+  },
+  {
+    maxAgeMs: 5 * 60 * 1000,
+    backgroundClass: 'bg-fresh-1',
+    textClass: 'text-fresh-1',
+  },
+  {
+    maxAgeMs: 10 * 60 * 1000,
+    backgroundClass: 'bg-fresh-2',
+    textClass: 'text-fresh-2',
+  },
+  {
+    maxAgeMs: 20 * 60 * 1000,
+    backgroundClass: 'bg-fresh-3',
+    textClass: 'text-fresh-3',
+  },
+  {
+    maxAgeMs: 40 * 60 * 1000,
+    backgroundClass: 'bg-fresh-4',
+    textClass: 'text-fresh-4',
+  },
+  {
+    maxAgeMs: 90 * 60 * 1000,
+    backgroundClass: 'bg-fresh-5',
+    textClass: 'text-fresh-5',
+  },
+  {
+    maxAgeMs: 4 * 60 * 60 * 1000,
+    backgroundClass: 'bg-fresh-6',
+    textClass: 'text-fresh-6',
+  },
+  {
+    maxAgeMs: 24 * 60 * 60 * 1000,
+    backgroundClass: 'bg-fresh-7',
+    textClass: 'text-fresh-7',
+  },
+  {
+    maxAgeMs: Infinity,
+    backgroundClass: 'bg-fresh-8',
+    textClass: 'text-fresh-8',
+  },
 ];
 
 export function textClassForReadingAge(timestamp: number): string {
@@ -34,4 +79,28 @@ export function textClassForReadingAge(timestamp: number): string {
   }
 
   return lastBand!.textClass;
+}
+
+function formatAgeLabel(ms: number): string {
+  return ms < 60 * 60 * 1000
+    ? `${ms / (60 * 1000)}m`
+    : `${ms / (60 * 60 * 1000)}h`;
+}
+
+export function readingFreshnessLegendBands(): ReadingFreshnessLegendBand[] {
+  return READING_FRESHNESS_BANDS.map((band, index) => {
+    if (Number.isFinite(band.maxAgeMs)) {
+      return {
+        backgroundClass: band.backgroundClass,
+        label: formatAgeLabel(band.maxAgeMs),
+      };
+    }
+
+    const previousMaxAgeMs = READING_FRESHNESS_BANDS[index - 1]?.maxAgeMs ?? 0;
+
+    return {
+      backgroundClass: band.backgroundClass,
+      label: `${formatAgeLabel(previousMaxAgeMs)}+`,
+    };
+  });
 }

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.12 - 2026-06-21
+
+### Added
+
+- The Help page now shows the "Data freshness colours" legend, explaining how the gold-to-grey colour of a station's "updated" time maps to how old the reading is.
+
 ## v0.7.11 - 2026-06-21
 
 ### Changed

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -78,6 +78,9 @@ help:
   colors:
     title: Map marker colours
     description: Winds.mobi reuses this shared wind palette for wind speed and gusts across station markers, the last-hour wind rose, and the wind history chart so stronger conditions stay easy to read everywhere.
+  freshness:
+    title: Data freshness colours
+    description: The "updated" time in a station's header and nearby cards fades from glowing gold to grey as a reading ages, so you can tell at a glance how recent the data is.
   providers:
     title: Data providers
     description: Winds.mobi aggregates station data from multiple provider networks. The provider name in each station header links back to the original source when available.


### PR DESCRIPTION
## Summary
- Added `readingFreshnessLegendBands()` to `app/utils/reading-freshness.ts`, exposing each band's `bg-fresh-*` class and a short age label (`2m`, `5m`, `10m`, `20m`, `40m`, `1.5h`, `4h`, `24h`, `24h+`).
- Added a "Data freshness colours" card to the Help page (`app/templates/help.gts`), next to the existing wind-speed legend, rendering a row of small colour-dot + label swatches.
- Deliberately did **not** reuse `MapLegend`'s filled-chip-with-white-text styling for this: the freshness scale spans both very bright (glowing gold) and fairly dark (amber-800) colours, so no single label-text colour would have good contrast against every chip. The swatch-dot layout sidesteps that by keeping labels in neutral `text-slate-600` against the card background instead of on top of the colour.
- New `help.freshness.title`/`help.freshness.description` translation keys.
- Bumps the changelog to v0.7.12.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean
- [x] `pnpm test:ember:dev` passes (70/70)