### PR TITLE
Resolve the freshness gradient within the first hour

### DIFF
--- a/app/utils/reading-freshness.ts
+++ b/app/utils/reading-freshness.ts
@@ -4,55 +4,55 @@ export interface ReadingFreshnessLegendBand {
 }
 
 // Text-colour bands for a reading's "updated" time: glowing gold when just
-// in, through dark gold, fading to grey as the reading ages. The final
-// band's colour matches STALE_STATION_COLOUR (app/utils/station-arrow.ts) so
-// stale text and stale map markers agree on what "grey" means. Classes come
-// from the --color-fresh-* tokens in app/styles/app.css. The map refreshes
-// every 2 minutes, so most readings are well under 10 minutes old — the
-// early thresholds are bunched tightly so the fade is visible at those
-// realistic ages instead of every station landing on the same first band.
+// in, through dark gold, fading to grey as the reading ages. Everything
+// past 1 hour is flat grey (matching STALE_STATION_COLOUR in
+// app/utils/station-arrow.ts, so stale text and stale map markers agree on
+// what "grey" means) -- a hand-collected reading an hour old is just stale,
+// so the gradient's resolution is spent entirely on the first hour, where
+// the map's 2-minute refresh cycle means there's real variation to show.
+// Classes come from the --color-fresh-* tokens in app/styles/app.css.
 const READING_FRESHNESS_BANDS: {
   maxAgeMs: number;
   backgroundClass: string;
   textClass: string;
 }[] = [
   {
-    maxAgeMs: 2 * 60 * 1000,
+    maxAgeMs: 1 * 60 * 1000,
     backgroundClass: 'bg-fresh-0',
     textClass: 'text-fresh-0',
   },
   {
-    maxAgeMs: 5 * 60 * 1000,
+    maxAgeMs: 2 * 60 * 1000,
     backgroundClass: 'bg-fresh-1',
     textClass: 'text-fresh-1',
   },
   {
-    maxAgeMs: 10 * 60 * 1000,
+    maxAgeMs: 4 * 60 * 1000,
     backgroundClass: 'bg-fresh-2',
     textClass: 'text-fresh-2',
   },
   {
-    maxAgeMs: 20 * 60 * 1000,
+    maxAgeMs: 7 * 60 * 1000,
     backgroundClass: 'bg-fresh-3',
     textClass: 'text-fresh-3',
   },
   {
-    maxAgeMs: 40 * 60 * 1000,
+    maxAgeMs: 12 * 60 * 1000,
     backgroundClass: 'bg-fresh-4',
     textClass: 'text-fresh-4',
   },
   {
-    maxAgeMs: 90 * 60 * 1000,
+    maxAgeMs: 20 * 60 * 1000,
     backgroundClass: 'bg-fresh-5',
     textClass: 'text-fresh-5',
   },
   {
-    maxAgeMs: 4 * 60 * 60 * 1000,
+    maxAgeMs: 35 * 60 * 1000,
     backgroundClass: 'bg-fresh-6',
     textClass: 'text-fresh-6',
   },
   {
-    maxAgeMs: 24 * 60 * 60 * 1000,
+    maxAgeMs: 60 * 60 * 1000,
     backgroundClass: 'bg-fresh-7',
     textClass: 'text-fresh-7',
   },

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.13 - 2026-06-21
+
+### Changed
+
+- The "last updated" colour fade now resolves entirely within the first hour (steps at 1/2/4/7/12/20/35/60 minutes), with anything older than an hour shown as flat grey, instead of stretching the gradient out to 24 hours.
+
 ## v0.7.12 - 2026-06-21
 
 ### Added

--- a/tests/unit/utils/reading-freshness-test.ts
+++ b/tests/unit/utils/reading-freshness-test.ts
@@ -11,44 +11,44 @@ module('Unit | Utility | reading-freshness', function () {
       'just-in readings get the darkest gold'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 4 * 60 * 1000),
+      textClassForReadingAge(now - 1.5 * 60 * 1000),
       'text-fresh-1',
-      '4 minutes old'
+      '1.5 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 8 * 60 * 1000),
+      textClassForReadingAge(now - 3 * 60 * 1000),
       'text-fresh-2',
-      '8 minutes old'
+      '3 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 5 * 60 * 1000),
+      'text-fresh-3',
+      '5 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 10 * 60 * 1000),
+      'text-fresh-4',
+      '10 minutes old'
     );
     assert.strictEqual(
       textClassForReadingAge(now - 15 * 60 * 1000),
-      'text-fresh-3',
+      'text-fresh-5',
       '15 minutes old'
     );
     assert.strictEqual(
       textClassForReadingAge(now - 30 * 60 * 1000),
-      'text-fresh-4',
+      'text-fresh-6',
       '30 minutes old'
     );
     assert.strictEqual(
       textClassForReadingAge(now - 60 * 60 * 1000),
-      'text-fresh-5',
-      '1 hour old'
-    );
-    assert.strictEqual(
-      textClassForReadingAge(now - 2 * 60 * 60 * 1000),
-      'text-fresh-6',
-      '2 hours old'
-    );
-    assert.strictEqual(
-      textClassForReadingAge(now - 12 * 60 * 60 * 1000),
       'text-fresh-7',
-      '12 hours old'
+      'exactly 1 hour old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 25 * 60 * 60 * 1000),
+      textClassForReadingAge(now - 90 * 60 * 1000),
       'text-fresh-8',
-      'stale (24h+) readings get the same grey as stale map markers'
+      'data older than 1 hour is flat grey'
     );
   });
 


### PR DESCRIPTION
## Summary
- Retuned `READING_FRESHNESS_BANDS` thresholds in `app/utils/reading-freshness.ts` to 1/2/4/7/12/20/35/60 minutes, with anything older than 60 minutes landing on the flat grey final band.
- The `--color-fresh-0..8` colour stops in `app/styles/app.css` are unchanged — the gradient is index-based (9 stops regardless of where the time boundaries sit), so retuning thresholds didn't require recomputing colours.
- Updated `tests/unit/utils/reading-freshness-test.ts` for the new boundaries.
- Bumps the changelog to v0.7.13.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean
- [x] `pnpm test:ember:dev` passes (70/70)