### PR TITLE
Space freshness thresholds on the Fibonacci sequence

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -32,21 +32,22 @@
   --color-wind-50: rgb(179 0 0);
 
   /* Fades a reading's "updated" text through three anchors: glowing amber-400
-     (just in) through dark amber-800 (still fresh-ish) to slate-400, the same
-     grey used for stale (24h+) map markers (see STALE_STATION_COLOUR in
-     app/utils/station-arrow.ts). Most readings are under 10 minutes old (the
-     map refreshes every 2 minutes), so the early stops are bunched tightly to
-     keep the fade visible at realistic ages instead of everything landing on
-     --color-fresh-0. */
+     (just in) through dark amber-800 (still fresh-ish, around the 5-minute
+     mark) to slate-400, the same grey used for stale map markers (see
+     STALE_STATION_COLOUR in app/utils/station-arrow.ts). One stop per
+     Fibonacci-spaced age threshold in app/utils/reading-freshness.ts
+     (1/2/3/5/8/13/21/34/55 minutes), plus a final flat-grey stop for
+     anything older than 55 minutes. */
   --color-fresh-0: rgb(251 191 36);
   --color-fresh-1: rgb(216 149 29);
   --color-fresh-2: rgb(181 106 21);
   --color-fresh-3: rgb(146 64 14);
-  --color-fresh-4: rgb(146 84 48);
-  --color-fresh-5: rgb(147 104 82);
-  --color-fresh-6: rgb(147 123 116);
-  --color-fresh-7: rgb(148 143 150);
-  --color-fresh-8: rgb(148 163 184);
+  --color-fresh-4: rgb(146 81 42);
+  --color-fresh-5: rgb(147 97 71);
+  --color-fresh-6: rgb(147 114 99);
+  --color-fresh-7: rgb(147 130 127);
+  --color-fresh-8: rgb(148 147 156);
+  --color-fresh-9: rgb(148 163 184);
 }
 
 /* stylelint-enable */

--- a/app/utils/reading-freshness.ts
+++ b/app/utils/reading-freshness.ts
@@ -4,13 +4,13 @@ export interface ReadingFreshnessLegendBand {
 }
 
 // Text-colour bands for a reading's "updated" time: glowing gold when just
-// in, through dark gold, fading to grey as the reading ages. Everything
-// past 1 hour is flat grey (matching STALE_STATION_COLOUR in
+// in, through dark gold, fading to grey as the reading ages. Thresholds
+// follow the Fibonacci sequence in minutes (1/2/3/5/8/13/21/34/55, skipping
+// the repeated leading 1), with anything older than 55 minutes landing on
+// the final flat-grey band -- matching STALE_STATION_COLOUR in
 // app/utils/station-arrow.ts, so stale text and stale map markers agree on
-// what "grey" means) -- a hand-collected reading an hour old is just stale,
-// so the gradient's resolution is spent entirely on the first hour, where
-// the map's 2-minute refresh cycle means there's real variation to show.
-// Classes come from the --color-fresh-* tokens in app/styles/app.css.
+// what "grey" means. Classes come from the --color-fresh-* tokens in
+// app/styles/app.css.
 const READING_FRESHNESS_BANDS: {
   maxAgeMs: number;
   backgroundClass: string;
@@ -27,39 +27,44 @@ const READING_FRESHNESS_BANDS: {
     textClass: 'text-fresh-1',
   },
   {
-    maxAgeMs: 4 * 60 * 1000,
+    maxAgeMs: 3 * 60 * 1000,
     backgroundClass: 'bg-fresh-2',
     textClass: 'text-fresh-2',
   },
   {
-    maxAgeMs: 7 * 60 * 1000,
+    maxAgeMs: 5 * 60 * 1000,
     backgroundClass: 'bg-fresh-3',
     textClass: 'text-fresh-3',
   },
   {
-    maxAgeMs: 12 * 60 * 1000,
+    maxAgeMs: 8 * 60 * 1000,
     backgroundClass: 'bg-fresh-4',
     textClass: 'text-fresh-4',
   },
   {
-    maxAgeMs: 20 * 60 * 1000,
+    maxAgeMs: 13 * 60 * 1000,
     backgroundClass: 'bg-fresh-5',
     textClass: 'text-fresh-5',
   },
   {
-    maxAgeMs: 35 * 60 * 1000,
+    maxAgeMs: 21 * 60 * 1000,
     backgroundClass: 'bg-fresh-6',
     textClass: 'text-fresh-6',
   },
   {
-    maxAgeMs: 60 * 60 * 1000,
+    maxAgeMs: 34 * 60 * 1000,
     backgroundClass: 'bg-fresh-7',
     textClass: 'text-fresh-7',
   },
   {
-    maxAgeMs: Infinity,
+    maxAgeMs: 55 * 60 * 1000,
     backgroundClass: 'bg-fresh-8',
     textClass: 'text-fresh-8',
+  },
+  {
+    maxAgeMs: Infinity,
+    backgroundClass: 'bg-fresh-9',
+    textClass: 'text-fresh-9',
   },
 ];
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.14 - 2026-06-21
+
+### Changed
+
+- The "last updated" colour fade now steps through Fibonacci-spaced ages (1/2/3/5/8/13/21/34/55 minutes) before going flat grey past 55 minutes, instead of the previous evenly-bunched minute steps.
+
 ## v0.7.13 - 2026-06-21
 
 ### Changed

--- a/tests/unit/utils/reading-freshness-test.ts
+++ b/tests/unit/utils/reading-freshness-test.ts
@@ -8,12 +8,12 @@ module('Unit | Utility | reading-freshness', function () {
     assert.strictEqual(
       textClassForReadingAge(now),
       'text-fresh-0',
-      'just-in readings get the darkest gold'
+      'just-in readings get the brightest gold'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 1.5 * 60 * 1000),
+      textClassForReadingAge(now - 2 * 60 * 1000),
       'text-fresh-1',
-      '1.5 minutes old'
+      '2 minutes old'
     );
     assert.strictEqual(
       textClassForReadingAge(now - 3 * 60 * 1000),
@@ -26,33 +26,38 @@ module('Unit | Utility | reading-freshness', function () {
       '5 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 10 * 60 * 1000),
+      textClassForReadingAge(now - 8 * 60 * 1000),
       'text-fresh-4',
-      '10 minutes old'
+      '8 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 15 * 60 * 1000),
+      textClassForReadingAge(now - 13 * 60 * 1000),
       'text-fresh-5',
-      '15 minutes old'
+      '13 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 30 * 60 * 1000),
+      textClassForReadingAge(now - 21 * 60 * 1000),
       'text-fresh-6',
-      '30 minutes old'
+      '21 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 60 * 60 * 1000),
+      textClassForReadingAge(now - 34 * 60 * 1000),
       'text-fresh-7',
-      'exactly 1 hour old'
+      '34 minutes old'
+    );
+    assert.strictEqual(
+      textClassForReadingAge(now - 55 * 60 * 1000),
+      'text-fresh-8',
+      '55 minutes old'
     );
     assert.strictEqual(
       textClassForReadingAge(now - 90 * 60 * 1000),
-      'text-fresh-8',
-      'data older than 1 hour is flat grey'
+      'text-fresh-9',
+      'data older than 55 minutes is flat grey'
     );
   });
 
   test('it treats a non-finite timestamp as stale', function (assert) {
-    assert.strictEqual(textClassForReadingAge(NaN), 'text-fresh-8');
+    assert.strictEqual(textClassForReadingAge(NaN), 'text-fresh-9');
   });
 });


### PR DESCRIPTION
## Summary
- Retuned `READING_FRESHNESS_BANDS` to Fibonacci-spaced minute thresholds: 1/2/3/5/8/13/21/34/55, skipping the repeated leading 1, ending exactly at 55 minutes as requested.
- Anything older than 55 minutes now lands on a new 10th flat-grey band (`text-fresh-9`/`bg-fresh-9`), since the previous 9-stop scale didn't have room for both the full Fibonacci sequence and a separate stale band.
- Added `--color-fresh-9` in `app/styles/app.css` and recomputed all 10 stops across the same three-anchor gradient (glowing amber-400 → dark amber-800 → slate-400).
- Bumps the changelog to v0.7.14.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean
- [x] `pnpm test:ember:dev` passes (70/70), including updated boundary assertions for all 10 bands