### PR TITLE
Combine Last hour min/mean/max into one icon row

### DIFF
--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -1,7 +1,11 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
 import { t } from 'ember-intl';
-import StationMetricCard from '../metric-card';
+import type { IntlService } from 'ember-intl';
+import ArrowDown from 'ember-phosphor-icons/components/ph-arrow-down';
+import ArrowUp from 'ember-phosphor-icons/components/ph-arrow-up';
+import Crosshair from 'ember-phosphor-icons/components/ph-crosshair';
 import type { History } from 'winds-mobi-client-web/services/store.js';
 import WindDirection from '../wind-direction';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
@@ -17,6 +21,8 @@ export interface StationLastHourContentSignature {
 }
 
 export default class StationLastHourContent extends Component<StationLastHourContentSignature> {
+  @service declare intl: IntlService;
+
   @cached
   get lastHourHistory() {
     return this.args.history;
@@ -69,34 +75,72 @@ export default class StationLastHourContent extends Component<StationLastHourCon
       : undefined;
   }
 
+  get lastHourMinimumLabel() {
+    return this.hasHistory
+      ? this.intl.formatNumber(this.lastHourMinimumSpeed, {
+          format: 'integer',
+        })
+      : undefined;
+  }
+
+  get lastHourMeanLabel() {
+    return this.hasHistory
+      ? this.intl.formatNumber(this.lastHourMeanSpeed, { format: 'integer' })
+      : undefined;
+  }
+
+  get lastHourMaximumLabel() {
+    return this.hasHistory
+      ? this.intl.formatNumber(this.lastHourMaximumSpeed, {
+          format: 'integer',
+        })
+      : undefined;
+  }
+
   <template>
     <div class="grid gap-2 md:gap-3">
       <div class="min-w-0 w-full aspect-square">
         <WindDirection @data={{this.lastHourHistory}} />
       </div>
 
-      <dl class="m-0 grid gap-1 md:gap-2">
-        <StationMetricCard
-          @format="windSpeed"
-          @label={{t "wind.maximum"}}
-          @value={{this.lastHourMaximumSpeed}}
-          @valueClass={{this.lastHourMaximumValueClass}}
-        />
+      {{#if this.hasHistory}}
+        <dl
+          class="m-0 flex items-baseline justify-center gap-1 text-sm font-semibold"
+        >
+          <dt class="sr-only">{{t "wind.minimum"}}</dt>
+          <dd
+            class="m-0 flex items-center gap-0.5
+              {{this.lastHourMinimumValueClass}}"
+          >
+            <ArrowDown @size={{14}} />
+            <span>{{this.lastHourMinimumLabel}}</span>
+          </dd>
 
-        <StationMetricCard
-          @format="windSpeed"
-          @label={{t "wind.mean"}}
-          @value={{this.lastHourMeanSpeed}}
-          @valueClass={{this.lastHourMeanValueClass}}
-        />
+          <span aria-hidden="true" class="text-slate-400">/</span>
 
-        <StationMetricCard
-          @format="windSpeed"
-          @label={{t "wind.minimum"}}
-          @value={{this.lastHourMinimumSpeed}}
-          @valueClass={{this.lastHourMinimumValueClass}}
-        />
-      </dl>
+          <dt class="sr-only">{{t "wind.mean"}}</dt>
+          <dd
+            class="m-0 flex items-center gap-0.5
+              {{this.lastHourMeanValueClass}}"
+          >
+            <Crosshair @size={{14}} />
+            <span>{{this.lastHourMeanLabel}}</span>
+          </dd>
+
+          <span aria-hidden="true" class="text-slate-400">/</span>
+
+          <dt class="sr-only">{{t "wind.maximum"}}</dt>
+          <dd
+            class="m-0 flex items-center gap-0.5
+              {{this.lastHourMaximumValueClass}}"
+          >
+            <ArrowUp @size={{14}} />
+            <span>{{this.lastHourMaximumLabel}}</span>
+          </dd>
+
+          <dd class="m-0 text-xs text-slate-500">km/h</dd>
+        </dl>
+      {{/if}}
     </div>
   </template>
 }

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.15 - 2026-06-21
+
+### Changed
+
+- The "Last hour" card's minimum/mean/maximum wind speeds are now a single compact row (min / mean / max, each marked with a small icon instead of a text label) rather than three separate labelled rows, with the km/h unit shown once at the end.
+
 ## v0.7.14 - 2026-06-21
 
 ### Changed

--- a/tests/integration/components/station/last-hour/presenter-test.ts
+++ b/tests/integration/components/station/last-hour/presenter-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render, settled } from '@ember/test-helpers';
+import { findAll, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { Type } from '@warp-drive/core/types/symbols';
 import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
@@ -56,12 +56,18 @@ module(
       );
       await settled();
 
-      assert.dom(this.element).includesText('Maximum');
-      assert.dom(this.element).includesText('18 km/h');
-      assert.dom(this.element).includesText('Mean');
-      assert.dom(this.element).includesText('12 km/h');
-      assert.dom(this.element).includesText('Minimum');
-      assert.dom(this.element).includesText('7 km/h');
+      const valueText = findAll('dl dd')
+        .map((element) => element.textContent?.trim())
+        .filter(Boolean);
+
+      assert.deepEqual(
+        valueText,
+        ['7', '12', '18', 'km/h'],
+        'shows minimum, mean, and maximum in that order, with the unit shown once at the end'
+      );
+      assert.dom('dl dt:nth-of-type(1)').hasText('Minimum');
+      assert.dom('dl dt:nth-of-type(2)').hasText('Mean');
+      assert.dom('dl dt:nth-of-type(3)').hasText('Maximum');
     });
   }
 );

--- a/tests/unit/utils/reading-freshness-test.ts
+++ b/tests/unit/utils/reading-freshness-test.ts
@@ -5,50 +5,56 @@ module('Unit | Utility | reading-freshness', function () {
   test('it fades from dark gold to grey as the reading ages', function (assert) {
     const now = Date.now();
 
+    // Ages are kept a few seconds inside each band's upper bound (rather than
+    // exactly on the boundary) so the assertions stay stable even though
+    // textClassForReadingAge() re-reads Date.now() on every call and a test
+    // run accumulates a little real elapsed time between assertions.
+    const buffer = 5 * 1000;
+
     assert.strictEqual(
       textClassForReadingAge(now),
       'text-fresh-0',
       'just-in readings get the brightest gold'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 2 * 60 * 1000),
+      textClassForReadingAge(now - (2 * 60 * 1000 - buffer)),
       'text-fresh-1',
-      '2 minutes old'
+      'just under 2 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 3 * 60 * 1000),
+      textClassForReadingAge(now - (3 * 60 * 1000 - buffer)),
       'text-fresh-2',
-      '3 minutes old'
+      'just under 3 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 5 * 60 * 1000),
+      textClassForReadingAge(now - (5 * 60 * 1000 - buffer)),
       'text-fresh-3',
-      '5 minutes old'
+      'just under 5 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 8 * 60 * 1000),
+      textClassForReadingAge(now - (8 * 60 * 1000 - buffer)),
       'text-fresh-4',
-      '8 minutes old'
+      'just under 8 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 13 * 60 * 1000),
+      textClassForReadingAge(now - (13 * 60 * 1000 - buffer)),
       'text-fresh-5',
-      '13 minutes old'
+      'just under 13 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 21 * 60 * 1000),
+      textClassForReadingAge(now - (21 * 60 * 1000 - buffer)),
       'text-fresh-6',
-      '21 minutes old'
+      'just under 21 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 34 * 60 * 1000),
+      textClassForReadingAge(now - (34 * 60 * 1000 - buffer)),
       'text-fresh-7',
-      '34 minutes old'
+      'just under 34 minutes old'
     );
     assert.strictEqual(
-      textClassForReadingAge(now - 55 * 60 * 1000),
+      textClassForReadingAge(now - (55 * 60 * 1000 - buffer)),
       'text-fresh-8',
-      '55 minutes old'
+      'just under 55 minutes old'
     );
     assert.strictEqual(
       textClassForReadingAge(now - 90 * 60 * 1000),


### PR DESCRIPTION
## Summary
- Replaced the three separately-labelled `StationMetricCard` rows (Maximum/Mean/Minimum) in `app/components/station/last-hour/presenter.gts` with one compact row, ordered min, mean, max.
- Each value is prefixed with a representative icon instead of a visible text label: `ArrowDown` (min), `Crosshair` (mean), `ArrowUp` (max). `sr-only` `<dt>` labels are kept for screen readers.
- The `km/h` unit is now shown once at the end of the row instead of repeated per value.
- Bumps the changelog to v0.7.15.

## Side fix
- While updating `tests/unit/utils/reading-freshness-test.ts` boundaries (unrelated file, but it broke under test-run latency), fixed a latent flaky-boundary issue: asserting at the *exact* threshold of a band is fragile because `textClassForReadingAge()` re-reads `Date.now()` on every call, and accumulated real elapsed time across a test run can tip an exact-boundary assertion into the next band. Assertions now sit a few seconds inside each band instead of exactly on the boundary.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean (one pre-existing, unrelated `no-settled-after-test-helper` warning in the integration test file, present before this change)
- [x] `pnpm test:ember:dev` passes (70/70)