### PR TITLE
Swap Last hour icons for line-style arrows

### DIFF
--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -3,9 +3,9 @@ import { cached } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
-import ArrowDown from 'ember-phosphor-icons/components/ph-arrow-down';
-import ArrowUp from 'ember-phosphor-icons/components/ph-arrow-up';
-import Crosshair from 'ember-phosphor-icons/components/ph-crosshair';
+import ArrowLineDown from 'ember-phosphor-icons/components/ph-arrow-line-down';
+import ArrowLineUp from 'ember-phosphor-icons/components/ph-arrow-line-up';
+import ArrowsInLineVertical from 'ember-phosphor-icons/components/ph-arrows-in-line-vertical';
 import type { History } from 'winds-mobi-client-web/services/store.js';
 import WindDirection from '../wind-direction';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
@@ -112,7 +112,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
             class="m-0 flex items-center gap-0.5
               {{this.lastHourMinimumValueClass}}"
           >
-            <ArrowDown @size={{14}} />
+            <ArrowLineDown @size={{14}} />
             <span>{{this.lastHourMinimumLabel}}</span>
           </dd>
 
@@ -123,7 +123,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
             class="m-0 flex items-center gap-0.5
               {{this.lastHourMeanValueClass}}"
           >
-            <Crosshair @size={{14}} />
+            <ArrowsInLineVertical @size={{14}} />
             <span>{{this.lastHourMeanLabel}}</span>
           </dd>
 
@@ -134,7 +134,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
             class="m-0 flex items-center gap-0.5
               {{this.lastHourMaximumValueClass}}"
           >
-            <ArrowUp @size={{14}} />
+            <ArrowLineUp @size={{14}} />
             <span>{{this.lastHourMaximumLabel}}</span>
           </dd>
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.16 - 2026-06-21
+
+### Changed
+
+- The "Last hour" min/mean/max row now uses clearer line-style arrow icons (arrow-line-down, arrows-in-line-vertical, arrow-line-up) instead of plain arrows and a crosshair.
+
 ## v0.7.15 - 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Swapped the min/mean/max icons in `app/components/station/last-hour/presenter.gts` from `ArrowDown`/`Crosshair`/`ArrowUp` to `ArrowLineDown`/`ArrowsInLineVertical`/`ArrowLineUp`.
- Bumps the changelog to v0.7.16.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on the touched file is clean
- [x] `pnpm test:ember:dev -- --filter "last-hour"` passes (70/70)