### PR TITLE
Spread Last hour min/mean/max apart and match value styling

### DIFF
--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -105,37 +105,30 @@ export default class StationLastHourContent extends Component<StationLastHourCon
 
       {{#if this.hasHistory}}
         <dl
-          class="m-0 flex items-baseline justify-center gap-1 text-sm font-semibold"
+          class="m-0 flex items-baseline justify-between text-base font-semibold md:text-lg"
         >
           <dt class="sr-only">{{t "wind.minimum"}}</dt>
-          <dd
-            class="m-0 flex items-center gap-0.5
-              {{this.lastHourMinimumValueClass}}"
-          >
-            <ArrowLineDown @size={{14}} />
-            <span>{{this.lastHourMinimumLabel}}</span>
+          <dd class="m-0 flex items-center gap-0.5">
+            <ArrowLineDown @size={{14}} class="text-slate-400" />
+            <span
+              class={{this.lastHourMinimumValueClass}}
+            >{{this.lastHourMinimumLabel}}</span>
           </dd>
-
-          <span aria-hidden="true" class="text-slate-400">/</span>
 
           <dt class="sr-only">{{t "wind.mean"}}</dt>
-          <dd
-            class="m-0 flex items-center gap-0.5
-              {{this.lastHourMeanValueClass}}"
-          >
-            <ArrowsInLineVertical @size={{14}} />
-            <span>{{this.lastHourMeanLabel}}</span>
+          <dd class="m-0 flex items-center gap-0.5">
+            <ArrowsInLineVertical @size={{14}} class="text-slate-400" />
+            <span
+              class={{this.lastHourMeanValueClass}}
+            >{{this.lastHourMeanLabel}}</span>
           </dd>
 
-          <span aria-hidden="true" class="text-slate-400">/</span>
-
           <dt class="sr-only">{{t "wind.maximum"}}</dt>
-          <dd
-            class="m-0 flex items-center gap-0.5
-              {{this.lastHourMaximumValueClass}}"
-          >
-            <ArrowLineUp @size={{14}} />
-            <span>{{this.lastHourMaximumLabel}}</span>
+          <dd class="m-0 flex items-center gap-0.5">
+            <ArrowLineUp @size={{14}} class="text-slate-400" />
+            <span
+              class={{this.lastHourMaximumValueClass}}
+            >{{this.lastHourMaximumLabel}}</span>
           </dd>
 
           <dd class="m-0 text-xs text-slate-500">km/h</dd>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.18 - 2026-06-21
+
+### Changed
+
+- The "Last hour" min/mean/max row now spreads its values evenly across the card's width instead of clustering them in the centre, only the numbers are coloured by wind speed (the icons stay a neutral grey), and the value text now matches the size used in the "Now" card's speed/gusts/direction values.
+
 ## v0.7.17 - 2026-06-21
 
 ### Removed


### PR DESCRIPTION
## Summary
- Changed the min/mean/max row in `app/components/station/last-hour/presenter.gts` from `justify-center` with "/" separators to `justify-between`, spreading the three values evenly across the card's width.
- Moved the wind-speed colour class off the `<dd>` (which also covered the icon) onto just the value `<span>`, so icons render in a neutral `text-slate-400` and only the numbers are coloured.
- Bumped the value text from `text-sm` to `text-base md:text-lg`, matching `StationMetricCard`'s value styling used by the "Now" card's speed/gusts/direction values.
- Bumps the changelog to v0.7.18.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on the touched file is clean
- [x] `pnpm test:ember:dev -- --filter "last-hour/presenter"` passes (66/66)