### PR TITLE
Add min/mean/max tooltips and swap polar tooltip to wind speed

### DIFF
--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -108,7 +108,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
           class="m-0 flex items-baseline justify-between text-base font-semibold md:text-lg"
         >
           <dt class="sr-only">{{t "wind.minimum"}}</dt>
-          <dd class="m-0 flex items-center gap-0.5">
+          <dd class="m-0 flex items-center gap-0.5" title={{t "wind.minimum"}}>
             <ArrowLineDown @size={{14}} class="text-slate-400" />
             <span
               class={{this.lastHourMinimumValueClass}}
@@ -116,7 +116,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
           </dd>
 
           <dt class="sr-only">{{t "wind.mean"}}</dt>
-          <dd class="m-0 flex items-center gap-0.5">
+          <dd class="m-0 flex items-center gap-0.5" title={{t "wind.mean"}}>
             <ArrowsInLineVertical @size={{14}} class="text-slate-400" />
             <span
               class={{this.lastHourMeanValueClass}}
@@ -124,7 +124,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
           </dd>
 
           <dt class="sr-only">{{t "wind.maximum"}}</dt>
-          <dd class="m-0 flex items-center gap-0.5">
+          <dd class="m-0 flex items-center gap-0.5" title={{t "wind.maximum"}}>
             <ArrowLineUp @size={{14}} class="text-slate-400" />
             <span
               class={{this.lastHourMaximumValueClass}}

--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -76,8 +76,8 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
         hour: 'numeric',
         minute: 'numeric',
         hour12: false,
-      })} ${this.intl.formatNumber(elm.temperature, {
-        format: 'temperature',
+      })} ${this.intl.formatNumber(elm.speed, {
+        format: 'windSpeed',
       })}`,
     }));
   }

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.7.19 - 2026-06-21
+
+### Changed
+
+- Hovering a "Last hour" min/mean/max icon now shows a tooltip naming it (Minimum/Mean/Maximum).
+- The "Last hour" wind-direction chart's hover tooltip now shows each sample's wind speed instead of its temperature, since this is a wind chart.
+
 ## v0.7.18 - 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary
- Added native `title={{t "wind.minimum"}}`/`wind.mean`/`wind.maximum` attributes to the min/mean/max `<dd>` elements in `app/components/station/last-hour/presenter.gts`, giving a hover tooltip naming each value — matches the existing `title=` pattern already used elsewhere (`station/header.gts`, `compact-card.gts`).
- Swapped `wind-direction/graph.gts`'s `customTooltip` from temperature to wind speed (`windSpeed` format, includes the km/h unit) — the polar chart is a wind-direction chart, so wind speed is the more relevant hover detail than temperature.
- Bumps the changelog to v0.7.19.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean
- [x] `pnpm test:ember:dev` passes (66/66)