### PR TITLE
Show gusts on the polar chart and fix an accessibility-module crash

### DIFF
--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -33,6 +33,15 @@ export default class Polar extends Component<PolarSignature> {
     credits: {
       enabled: false,
     },
+    // ember-highcharts always imports the accessibility module, but its
+    // keyboard-navigation point proxies can throw ("Invalid value for <rect>
+    // attribute y=NaN") on sparse scatter series (e.g. a station that only
+    // reports every 30 minutes may have just one point in the last-hour
+    // window). This chart's data is also available via the metric cards and
+    // tooltips, so the a11y module isn't adding real value here.
+    accessibility: {
+      enabled: false,
+    },
     chart: {
       polar: true,
       reflow: true,

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -36,6 +36,15 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
     credits: {
       enabled: false,
     },
+    // ember-highcharts always imports the accessibility module, but its
+    // keyboard-navigation point proxies can throw ("Invalid value for <rect>
+    // attribute y=NaN") on series with null/gap points (see
+    // utils/chart-series.ts, which intentionally emits null for missing
+    // readings). This chart's data is also available via the metric cards
+    // and tooltips, so the a11y module isn't adding real value here.
+    accessibility: {
+      enabled: false,
+    },
     chart: {
       height: 272,
       reflow: true,

--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -68,18 +68,32 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
       return [];
     }
 
-    return data.map((elm) => ({
-      x: elm.direction,
-      y: elm.timestamp,
-      color: windToColour(elm.speed),
-      customTooltip: `${this.intl.formatTime(elm.timestamp, {
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: false,
-      })} ${this.intl.formatNumber(elm.speed, {
-        format: 'windSpeed',
-      })}`,
-    }));
+    return data.map((elm) => {
+      const speedColour = windToColour(elm.speed);
+      const gustsColour = windToColour(elm.gusts);
+
+      return {
+        x: elm.direction,
+        y: elm.timestamp,
+        color: speedColour,
+        // Mirrors the map marker's outline/hub convention: the ring stays the
+        // wind-speed colour, and the center only switches to the gusts colour
+        // when gusts fall in a different wind band -- otherwise it's a plain
+        // speed-coloured dot.
+        marker: {
+          enabled: true,
+          lineColor: speedColour,
+          fillColor: gustsColour === speedColour ? speedColour : gustsColour,
+        },
+        customTooltip: `${this.intl.formatTime(elm.timestamp, {
+          hour: 'numeric',
+          minute: 'numeric',
+          hour12: false,
+        })} ${this.intl.formatNumber(elm.speed, {
+          format: 'windSpeed',
+        })}`,
+      };
+    });
   }
 
   get chartData() {
@@ -91,6 +105,7 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
         lineWidth: 1.5,
         marker: {
           radius: 3,
+          lineWidth: 1.5,
         },
       },
     ];

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.7.20 - 2026-06-21
+
+### Added
+
+- The "Last hour" wind-direction chart's points now show gusts too: the outline stays the wind-speed colour, and the center switches to the gusts colour only when gusts fall in a different wind band, matching the map marker's outline/hub convention.
+
+### Fixed
+
+- Fixed a console error ("Invalid value for `<rect>` attribute y=NaN") that could occur on stations with sparse or gapped history data, by disabling the chart accessibility module that ember-highcharts loads by default.
+
 ## v0.7.19 - 2026-06-21
 
 ### Changed

--- a/tests/integration/components/station/wind-direction/graph-test.ts
+++ b/tests/integration/components/station/wind-direction/graph-test.ts
@@ -65,6 +65,50 @@ module(
       assert.dom('.highcharts-container').exists();
     });
 
+    test('it outlines a point in the wind-speed colour and fills it with the gusts colour only when the bands differ', async function (this: WindDirectionGraphTestContext, assert) {
+      const now = Date.now();
+
+      this.data = [
+        {
+          id: 'same-band',
+          direction: 180,
+          speed: 2,
+          gusts: 2,
+          temperature: 6,
+          humidity: 60,
+          timestamp: now - 10 * 60 * 1000,
+          [Type]: 'history',
+        },
+        {
+          id: 'different-band',
+          direction: 225,
+          speed: 2,
+          gusts: 20,
+          temperature: 7,
+          humidity: 58,
+          timestamp: now - 5 * 60 * 1000,
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+      await settled();
+
+      const points = findAll('.highcharts-point');
+      const [samePoint, differentPoint] = points;
+
+      assert.strictEqual(
+        samePoint?.getAttribute('fill'),
+        samePoint?.getAttribute('stroke'),
+        'same wind-speed and gusts band: the dot is plain speed-coloured'
+      );
+      assert.notStrictEqual(
+        differentPoint?.getAttribute('fill'),
+        differentPoint?.getAttribute('stroke'),
+        'different wind-speed and gusts band: the outline is the speed colour and the fill is the gusts colour'
+      );
+    });
+
     test('it keeps rendering points in chronological order when switching stations', async function (this: WindDirectionGraphTestContext, assert) {
       const now = Date.now();
 


### PR DESCRIPTION
## Summary
Two independent fixes bundled together:

1. **Gusts on the Last hour polar chart**: each point's marker now has `lineColor` = wind-speed colour and `fillColor` = gusts colour, but only differing from the outline when gusts fall in a different wind band — mirrors the map marker's outline/hub convention (`app/utils/station-favicon.ts`/`station-marker.gts`). Per-point Highcharts marker objects don't deep-merge with the series-level marker defaults, so the fix needed `marker: { enabled: true, lineColor, fillColor }` per point (no `radius`/`lineWidth` — those still inherit from the series default, preserving the existing responsive thumbnail-size shrinking).

2. **Accessibility-module crash**: a real station (`slf-SWM1`, ~30min report interval) threw `Invalid value for <rect> attribute y="NaN"` in the console. `ember-highcharts` always imports Highcharts' accessibility module regardless of chart type, and its keyboard-navigation proxy code throws on sparse/gapped series (this app's `buildTimeSeriesData` intentionally emits `null` for missing readings). Added `accessibility: { enabled: false }` to both `chart/time-series.gts` and `chart/polar.gts` — this app doesn't otherwise use Highcharts a11y features, and the underlying data is already exposed via metric cards and native `title` tooltips.

Bumps the changelog to v0.7.20.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean (pre-existing, unrelated `no-settled-after-test-helper` warnings in the test file untouched)
- [x] `pnpm test:ember:dev` passes (67/67), including a new test asserting the outline/fill colour split for same-band vs different-band gusts