### PR TITLE
Flatten Station.last fields to fix data loss on refetch

### DIFF
--- a/app/handlers/station.ts
+++ b/app/handlers/station.ts
@@ -99,47 +99,46 @@ function jsonApifyFields(elm: StationApiPayload) {
     attributes.providerUrl = normalizeProviderUrl(elm.url);
   }
 
+  // Flat `last*` attributes, not a nested `last` object: Warp Drive's upsert
+  // merge is one level deep, so a nested object would get wholesale replaced
+  // whenever a leaner request (e.g. the map's station-list query) omits
+  // fields the richer `findRecord` had already populated. See the matching
+  // comment on StationSchema in app/services/store.ts.
   if (hasOwn(elm, 'last') && elm.last) {
-    const last: Record<string, unknown> = {};
-
     if (hasOwn(elm.last, '_id') && elm.last._id !== undefined) {
-      last.timestamp = elm.last._id * 1000;
+      attributes.lastTimestamp = elm.last._id * 1000;
     }
 
     if (hasOwn(elm.last, 'w-dir')) {
-      last.direction = elm.last['w-dir'];
+      attributes.lastDirection = elm.last['w-dir'];
     }
 
     if (hasOwn(elm.last, 'w-avg')) {
-      last.speed = elm.last['w-avg'];
+      attributes.lastSpeed = elm.last['w-avg'];
     }
 
     if (hasOwn(elm.last, 'w-max')) {
-      last.gusts = elm.last['w-max'];
+      attributes.lastGusts = elm.last['w-max'];
     }
 
     if (hasOwn(elm.last, 'temp')) {
-      last.temperature = elm.last.temp;
+      attributes.lastTemperature = elm.last.temp;
     }
 
     if (hasOwn(elm.last, 'hum')) {
-      last.humidity = elm.last.hum;
+      attributes.lastHumidity = elm.last.hum;
     }
 
     if (hasOwn(elm.last, 'rain')) {
-      last.rain = elm.last.rain;
+      attributes.lastRain = elm.last.rain;
     }
 
     if (hasOwn(elm.last, 'pres')) {
       const pressure = normalizePressure(elm.last.pres);
 
       if (pressure !== undefined) {
-        last.pressure = pressure;
+        attributes.lastPressure = pressure;
       }
-    }
-
-    if (Object.keys(last).length > 0) {
-      attributes.last = last;
     }
   }
 

--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -12,38 +12,6 @@ export const LocationSchema = {
   fields: [{ name: 'coordinates', kind: 'array' }],
 } as const;
 
-// Embedded object schema: pressure (also just a shape)
-// You can later use it from another schema as
-// { name: 'pressure', kind: 'schema-object', type: 'pressure' }
-export const PressureSchema = {
-  type: 'pressure',
-  identity: null,
-  fields: [
-    { name: 'qfe', kind: 'field' },
-    { name: 'qnh', kind: 'field' },
-    { name: 'qff', kind: 'field' },
-  ],
-} as const;
-
-// Embedded object schema: reading
-// NOTE: no `withDefaults` and `identity: null` so it can safely be used
-// as `kind: 'schema-object'` from StationSchema.
-export const ReadingSchema = {
-  type: 'reading',
-  identity: null,
-  fields: [
-    // `_id` is *not* unique here, we’re just reusing it as a timestamp field
-    { name: 'timestamp', kind: 'field' },
-    { name: 'direction', kind: 'field' },
-    { name: 'speed', kind: 'field' },
-    { name: 'gusts', kind: 'field' },
-    { name: 'temperature', kind: 'field' },
-    { name: 'humidity', kind: 'field' },
-    { name: 'rain', kind: 'field' },
-    { name: 'pressure', kind: 'schema-object', type: 'pressure' },
-  ],
-} as const;
-
 export const StationSchema = withDefaults({
   type: 'station',
   fields: [
@@ -83,8 +51,23 @@ export const StationSchema = withDefaults({
     // providerUrl is normalized to a single URL string in the station handler.
     { name: 'providerUrl', kind: 'field' },
 
-    // last = embedded reading object
-    { name: 'last', kind: 'schema-object', type: 'reading' },
+    // Flat `last*` fields rather than one nested `last` object: Warp Drive's
+    // upsert merge is only one level deep, so a nested object field gets
+    // wholesale *replaced* by any later request for the same station that
+    // omits it -- e.g. the map's lean list query (fewer `last.*` keys than
+    // the station detail's `findRecord`) would otherwise wipe temperature/
+    // humidity/rain/pressure moments after the detail panel populated them.
+    // Flat top-level fields merge safely per-field instead. `last` below is
+    // a derived convenience getter so consumers keep reading `station.last.X`.
+    { name: 'lastTimestamp', kind: 'field' },
+    { name: 'lastDirection', kind: 'field' },
+    { name: 'lastSpeed', kind: 'field' },
+    { name: 'lastGusts', kind: 'field' },
+    { name: 'lastTemperature', kind: 'field' },
+    { name: 'lastHumidity', kind: 'field' },
+    { name: 'lastRain', kind: 'field' },
+    { name: 'lastPressure', kind: 'field' },
+    { name: 'last', kind: 'derived', type: 'composeReading' },
   ],
 });
 
@@ -164,20 +147,34 @@ function unwrapDerivation(
 }
 unwrapDerivation[Type] = 'unwrap';
 
+// Reassembles the flat `last*` fields (see the comment on StationSchema)
+// back into the nested shape consumers read as `station.last`.
+function composeReadingDerivation(record: RecordType): unknown {
+  if (!isRecordType(record)) {
+    return undefined;
+  }
+
+  return {
+    timestamp: record.lastTimestamp,
+    direction: record.lastDirection,
+    speed: record.lastSpeed,
+    gusts: record.lastGusts,
+    temperature: record.lastTemperature,
+    humidity: record.lastHumidity,
+    rain: record.lastRain,
+    pressure: record.lastPressure,
+  };
+}
+composeReadingDerivation[Type] = 'composeReading';
+
 export default useLegacyStore({
   linksMode: false,
   legacyRequests: true,
   modelFragments: true,
   cache: JSONAPICache,
-  schemas: [
-    PressureSchema,
-    ReadingSchema,
-    LocationSchema,
-    StationSchema,
-    HistorySchema,
-  ],
+  schemas: [LocationSchema, StationSchema, HistorySchema],
   handlers: [StationHandler, HistoryHandler],
-  derivations: [unwrapDerivation],
+  derivations: [unwrapDerivation, composeReadingDerivation],
 });
 
 declare module '@ember/service' {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.21 - 2026-06-21
+
+### Fixed
+
+- Fixed a bug where a station's temperature, humidity, rain, and pressure could flash into view and then disappear moments later when opening its detail panel. The map's background station-list refresh (which only needs wind speed/direction) was wholesale-overwriting the richer reading the panel had just loaded for the same station.
+
 ## v0.7.20 - 2026-06-21
 
 ### Added

--- a/tests/unit/handlers/station-test.ts
+++ b/tests/unit/handlers/station-test.ts
@@ -32,10 +32,8 @@ module('Unit | Handler | station', function () {
       _id: 'holfuy-1850',
       altitude: 1850,
       name: 'Holfuy 1850',
-      last: {
-        timestamp: 1_774_341_507_000,
-        speed: 12,
-      },
+      lastTimestamp: 1_774_341_507_000,
+      lastSpeed: 12,
     });
     assert.false('providerName' in response.data.attributes);
     assert.false('providerUrl' in response.data.attributes);


### PR DESCRIPTION
## Summary

User-reported bug: opening a station's detail panel showed temperature, humidity, etc. for a split second, then they disappeared.

**Root cause**: `app/builders/station.ts`'s `findRecord` (station detail) requests the full field set including `last.temp`/`last.hum`/`last.rain`/`last.pres`, but `mapQuery` (the map's background station-list refresh) requests a leaner `summaryStationQueryKeys` set that omits them. Both target the same station identity. `app/handlers/station.ts` built `attributes.last` as a single nested object containing only the `last.*` sub-fields present in *that* response. Warp Drive's upsert merge is only one level deep (already documented in CLAUDE.md's data-flow section), so the leaner upsert from the map's refresh replaced the *entire* `last` object — wiping fields the richer `findRecord` had just populated moments earlier.

**Fix**: replace `StationSchema`'s single `last` schema-object field with flat top-level fields (`lastTimestamp`, `lastDirection`, `lastSpeed`, `lastGusts`, `lastTemperature`, `lastHumidity`, `lastRain`, `lastPressure`), each independently safe to merge per Warp Drive's one-level-deep contract — mirrors how `HistorySchema` already stores its fields flat, and how `latitude`/`longitude` are already derived top-level fields from `location.coordinates` in this same schema. Added a `last` derived field (`composeReadingDerivation`, registered alongside the existing `unwrapDerivation`) that reassembles the nested shape, so every consumer reading `station.last.X` (`header.gts`, `compact-card.gts`, `summary.gts`, `station-marker.gts`, `station-favicon.ts`, `search-result.gts`) is unchanged — only `store.ts` and `handlers/station.ts` needed to change. Removed the now-unused `ReadingSchema`/`PressureSchema`.

Bumps the changelog to v0.7.21.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean (pre-existing unrelated errors in `station-test.ts` left untouched)
- [x] `pnpm test:ember:dev` passes (67/67), run 3x to rule out flakiness; updated the station handler unit test for the new flat attribute names