### PR TITLE
Icon-label setting, Last hour revert, and spacing/label fixes

### DIFF
--- a/app/components/navbar/menu/items.ts
+++ b/app/components/navbar/menu/items.ts
@@ -1,15 +1,11 @@
-import type { ComponentLike } from '@glint/template';
 import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import MapTrifold from 'ember-phosphor-icons/components/ph-map-trifold';
 import Gear from 'ember-phosphor-icons/components/ph-gear';
 import Lifebuoy from 'ember-phosphor-icons/components/ph-lifebuoy';
+import type { IconComponent } from 'winds-mobi-client-web/utils/icon-component';
 
 export interface NavbarMenuItem {
-  icon: ComponentLike<{
-    Args: {
-      size?: number;
-    };
-  }>;
+  icon: IconComponent;
   labelKey: string;
   route: 'help' | 'map' | 'nearby' | 'settings';
 }

--- a/app/components/settings/showcase/icon-labels.gts
+++ b/app/components/settings/showcase/icon-labels.gts
@@ -1,0 +1,33 @@
+import Thermometer from 'ember-phosphor-icons/components/ph-thermometer';
+import Drop from 'ember-phosphor-icons/components/ph-drop';
+import StationMetricCard from 'winds-mobi-client-web/components/station/metric-card';
+
+export interface SettingsShowcaseIconLabelsSignature {
+  Args: {
+    enabled: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+// Two real StationMetricCards, side by side: with the preference on they
+// shrink to icon + value and sit close together; off, they show the full
+// text label and stretch to fill the row as they do today.
+<template>
+  <div
+    class="flex flex-wrap items-center gap-1.5 rounded-lg bg-slate-100 p-3"
+    ...attributes
+  >
+    <StationMetricCard
+      @format="temperature"
+      @label="Temperature"
+      @value={{24}}
+      @icon={{if @enabled Thermometer}}
+    />
+    <StationMetricCard
+      @format="humidity"
+      @label="Humidity"
+      @value={{56}}
+      @icon={{if @enabled Drop}}
+    />
+  </div>
+</template>

--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
+import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import timeAgo from 'winds-mobi-client-web/helpers/time-ago';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
@@ -93,6 +94,7 @@ export default class StationCompactCard extends Component<StationCompactCardSign
 
         <dl class="m-0">
           <StationMetaItem
+            @icon={{ClockCounterClockwise}}
             @label={{t "station.meta.updated"}}
             class="text-[11px] text-slate-500"
           >

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -4,6 +4,7 @@ import { LinkTo } from '@ember/routing';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
+import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
 import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
@@ -75,7 +76,10 @@ export default class StationHeader extends Component<StationHeaderSignature> {
             m</span>
         </StationMetaItem>
 
-        <StationMetaItem @label={{t "station.meta.updated"}}>
+        <StationMetaItem
+          @icon={{ClockCounterClockwise}}
+          @label={{t "station.meta.updated"}}
+        >
           <span class={{this.lastReadingFreshnessClass}}>{{timeAgo
               this.lastReadingRelativeSeconds
             }}</span>

--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -1,7 +1,12 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
 import { t } from 'ember-intl';
+import ArrowLineDown from 'ember-phosphor-icons/components/ph-arrow-line-down';
+import ArrowLineUp from 'ember-phosphor-icons/components/ph-arrow-line-up';
+import ArrowsInLineVertical from 'ember-phosphor-icons/components/ph-arrows-in-line-vertical';
 import StationMetricCard from '../metric-card';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { History } from 'winds-mobi-client-web/services/store.js';
 import WindDirection from '../wind-direction';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
@@ -17,6 +22,8 @@ export interface StationLastHourContentSignature {
 }
 
 export default class StationLastHourContent extends Component<StationLastHourContentSignature> {
+  @service declare settings: SettingsService;
+
   @cached
   get lastHourHistory() {
     return this.args.history;
@@ -81,6 +88,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
           @label={{t "wind.maximum"}}
           @value={{this.lastHourMaximumSpeed}}
           @valueClass={{this.lastHourMaximumValueClass}}
+          @icon={{if this.settings.useIconLabels ArrowLineUp}}
         />
 
         <StationMetricCard
@@ -88,6 +96,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
           @label={{t "wind.mean"}}
           @value={{this.lastHourMeanSpeed}}
           @valueClass={{this.lastHourMeanValueClass}}
+          @icon={{if this.settings.useIconLabels ArrowsInLineVertical}}
         />
 
         <StationMetricCard
@@ -95,6 +104,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
           @label={{t "wind.minimum"}}
           @value={{this.lastHourMinimumSpeed}}
           @valueClass={{this.lastHourMinimumValueClass}}
+          @icon={{if this.settings.useIconLabels ArrowLineDown}}
         />
       </dl>
     </div>

--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -1,11 +1,7 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
-import { service } from '@ember/service';
 import { t } from 'ember-intl';
-import type { IntlService } from 'ember-intl';
-import ArrowLineDown from 'ember-phosphor-icons/components/ph-arrow-line-down';
-import ArrowLineUp from 'ember-phosphor-icons/components/ph-arrow-line-up';
-import ArrowsInLineVertical from 'ember-phosphor-icons/components/ph-arrows-in-line-vertical';
+import StationMetricCard from '../metric-card';
 import type { History } from 'winds-mobi-client-web/services/store.js';
 import WindDirection from '../wind-direction';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
@@ -21,8 +17,6 @@ export interface StationLastHourContentSignature {
 }
 
 export default class StationLastHourContent extends Component<StationLastHourContentSignature> {
-  @service declare intl: IntlService;
-
   @cached
   get lastHourHistory() {
     return this.args.history;
@@ -75,65 +69,34 @@ export default class StationLastHourContent extends Component<StationLastHourCon
       : undefined;
   }
 
-  get lastHourMinimumLabel() {
-    return this.hasHistory
-      ? this.intl.formatNumber(this.lastHourMinimumSpeed, {
-          format: 'integer',
-        })
-      : undefined;
-  }
-
-  get lastHourMeanLabel() {
-    return this.hasHistory
-      ? this.intl.formatNumber(this.lastHourMeanSpeed, { format: 'integer' })
-      : undefined;
-  }
-
-  get lastHourMaximumLabel() {
-    return this.hasHistory
-      ? this.intl.formatNumber(this.lastHourMaximumSpeed, {
-          format: 'integer',
-        })
-      : undefined;
-  }
-
   <template>
     <div class="grid gap-2 md:gap-3">
       <div class="min-w-0 w-full aspect-square">
         <WindDirection @data={{this.lastHourHistory}} />
       </div>
 
-      {{#if this.hasHistory}}
-        <dl
-          class="m-0 flex items-baseline justify-between text-base font-semibold md:text-lg"
-        >
-          <dt class="sr-only">{{t "wind.minimum"}}</dt>
-          <dd class="m-0 flex items-center gap-0.5" title={{t "wind.minimum"}}>
-            <ArrowLineDown @size={{14}} class="text-slate-400" />
-            <span
-              class={{this.lastHourMinimumValueClass}}
-            >{{this.lastHourMinimumLabel}}</span>
-          </dd>
+      <dl class="m-0 grid gap-1 md:gap-2">
+        <StationMetricCard
+          @format="windSpeed"
+          @label={{t "wind.maximum"}}
+          @value={{this.lastHourMaximumSpeed}}
+          @valueClass={{this.lastHourMaximumValueClass}}
+        />
 
-          <dt class="sr-only">{{t "wind.mean"}}</dt>
-          <dd class="m-0 flex items-center gap-0.5" title={{t "wind.mean"}}>
-            <ArrowsInLineVertical @size={{14}} class="text-slate-400" />
-            <span
-              class={{this.lastHourMeanValueClass}}
-            >{{this.lastHourMeanLabel}}</span>
-          </dd>
+        <StationMetricCard
+          @format="windSpeed"
+          @label={{t "wind.mean"}}
+          @value={{this.lastHourMeanSpeed}}
+          @valueClass={{this.lastHourMeanValueClass}}
+        />
 
-          <dt class="sr-only">{{t "wind.maximum"}}</dt>
-          <dd class="m-0 flex items-center gap-0.5" title={{t "wind.maximum"}}>
-            <ArrowLineUp @size={{14}} class="text-slate-400" />
-            <span
-              class={{this.lastHourMaximumValueClass}}
-            >{{this.lastHourMaximumLabel}}</span>
-          </dd>
-
-          <dd class="m-0 text-xs text-slate-500">km/h</dd>
-        </dl>
-      {{/if}}
+        <StationMetricCard
+          @format="windSpeed"
+          @label={{t "wind.minimum"}}
+          @value={{this.lastHourMinimumSpeed}}
+          @valueClass={{this.lastHourMinimumValueClass}}
+        />
+      </dl>
     </div>
   </template>
 }

--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -59,21 +59,19 @@ export default class StationLastHourContent extends Component<StationLastHourCon
   }
 
   get lastHourMaximumValueClass() {
-    return this.hasHistory
-      ? windToTextClass(this.lastHourMaximumSpeed)
-      : undefined;
+    return this.windClassFor(this.lastHourMaximumSpeed);
   }
 
   get lastHourMeanValueClass() {
-    return this.hasHistory
-      ? windToTextClass(this.lastHourMeanSpeed)
-      : undefined;
+    return this.windClassFor(this.lastHourMeanSpeed);
   }
 
   get lastHourMinimumValueClass() {
-    return this.hasHistory
-      ? windToTextClass(this.lastHourMinimumSpeed)
-      : undefined;
+    return this.windClassFor(this.lastHourMinimumSpeed);
+  }
+
+  private windClassFor(speed: number | undefined) {
+    return this.hasHistory ? windToTextClass(speed) : undefined;
   }
 
   <template>

--- a/app/components/station/meta-item.gts
+++ b/app/components/station/meta-item.gts
@@ -1,12 +1,8 @@
-import type { ComponentLike } from '@glint/template';
+import type { IconComponent } from 'winds-mobi-client-web/utils/icon-component';
 
 export interface StationMetaItemSignature {
   Args: {
-    icon?: ComponentLike<{
-      Args: {
-        size?: number;
-      };
-    }>;
+    icon?: IconComponent;
     label: string;
   };
   Blocks: {

--- a/app/components/station/metric-card.gts
+++ b/app/components/station/metric-card.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
+import type { ComponentLike } from '@glint/template';
 import azimuthToCardinal from 'winds-mobi-client-web/helpers/azimuth-to-cardinal';
 
 type MetricValue = number | string | null | undefined;
@@ -17,6 +18,13 @@ type StationMetricFormat =
 export interface StationMetricCardSignature {
   Args: {
     format?: StationMetricFormat;
+    // When given, the icon replaces the visible label (kept sr-only for
+    // screen readers); the card otherwise keeps its usual full-width layout.
+    icon?: ComponentLike<{
+      Args: {
+        size?: number;
+      };
+    }>;
     label: string;
     labelClass?: string;
     value?: MetricValue;
@@ -88,19 +96,21 @@ export default class StationMetricCard extends Component<StationMetricCardSignat
   <template>
     {{#if this.hasValue}}
       <div
-        class="flex items-baseline justify-between gap-2 rounded-md bg-slate-50 px-2 py-1.5 ring-1 ring-slate-200/80 md:rounded-xl md:px-3 md:py-2.5"
+        class="flex items-baseline justify-between gap-2 rounded-md bg-slate-50 px-2 py-1.5 text-base font-semibold ring-1 ring-slate-200/80 md:rounded-xl md:px-3 md:py-2.5 md:text-lg"
         ...attributes
       >
-        <dt
-          class="text-[11px] font-medium leading-tight text-slate-500 md:text-xs
-            {{if @labelClass @labelClass}}"
-        >
-          {{@label}}
-        </dt>
-        <dd
-          class="text-right text-base font-semibold leading-tight md:text-lg
-            {{if @valueClass @valueClass}}"
-        >
+        {{#if @icon}}
+          <dt class="sr-only">{{@label}}</dt>
+          <@icon class="text-black" />
+        {{else}}
+          <dt
+            class="text-[11px] font-medium leading-tight text-slate-500 md:text-xs
+              {{if @labelClass @labelClass}}"
+          >
+            {{@label}}
+          </dt>
+        {{/if}}
+        <dd class="text-right leading-tight {{if @valueClass @valueClass}}">
           {{this.formattedValue}}
         </dd>
       </div>

--- a/app/components/station/metric-card.gts
+++ b/app/components/station/metric-card.gts
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import type { IntlService } from 'ember-intl';
-import type { ComponentLike } from '@glint/template';
 import azimuthToCardinal from 'winds-mobi-client-web/helpers/azimuth-to-cardinal';
+import type { IconComponent } from 'winds-mobi-client-web/utils/icon-component';
 
 type MetricValue = number | string | null | undefined;
 type StationMetricFormat =
@@ -20,11 +20,7 @@ export interface StationMetricCardSignature {
     format?: StationMetricFormat;
     // When given, the icon replaces the visible label (kept sr-only for
     // screen readers); the card otherwise keeps its usual full-width layout.
-    icon?: ComponentLike<{
-      Args: {
-        size?: number;
-      };
-    }>;
+    icon?: IconComponent;
     label: string;
     labelClass?: string;
     value?: MetricValue;

--- a/app/components/station/metric-card.gts
+++ b/app/components/station/metric-card.gts
@@ -92,7 +92,7 @@ export default class StationMetricCard extends Component<StationMetricCardSignat
   <template>
     {{#if this.hasValue}}
       <div
-        class="flex items-baseline justify-between gap-2 rounded-md bg-slate-50 px-2 py-1.5 text-base font-semibold ring-1 ring-slate-200/80 md:rounded-xl md:px-3 md:py-2.5 md:text-lg"
+        class="flex items-center justify-between gap-2 rounded-md bg-slate-50 px-2 py-1.5 text-base font-semibold ring-1 ring-slate-200/80 md:rounded-xl md:px-3 md:py-2.5 md:text-lg"
         ...attributes
       >
         {{#if @icon}}

--- a/app/components/station/summary.gts
+++ b/app/components/station/summary.gts
@@ -1,9 +1,18 @@
 import Component from '@glimmer/component';
+import { service } from '@ember/service';
 import { t } from 'ember-intl';
+import CloudRain from 'ember-phosphor-icons/components/ph-cloud-rain';
+import Compass from 'ember-phosphor-icons/components/ph-compass';
+import ArrowLineUp from 'ember-phosphor-icons/components/ph-arrow-line-up';
+import Drop from 'ember-phosphor-icons/components/ph-drop';
+import Gauge from 'ember-phosphor-icons/components/ph-gauge';
+import Thermometer from 'ember-phosphor-icons/components/ph-thermometer';
+import Wind from 'ember-phosphor-icons/components/ph-wind';
 import { temperatureToTextClass } from 'winds-mobi-client-web/helpers/temperature-to-colour';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import StationLastHour from './last-hour';
 import StationMetricCard from './metric-card';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import StationSectionCard from './section-card';
 
@@ -18,6 +27,8 @@ export interface StationSummarySignature {
 }
 
 export default class StationSummary extends Component<StationSummarySignature> {
+  @service declare settings: SettingsService;
+
   get reading() {
     return this.args.station.last;
   }
@@ -44,6 +55,7 @@ export default class StationSummary extends Component<StationSummarySignature> {
               @label={{t "wind.speed"}}
               @value={{this.reading.speed}}
               @valueClass={{this.speedValueClass}}
+              @icon={{if this.settings.useIconLabels Wind}}
             />
 
             <StationMetricCard
@@ -51,12 +63,14 @@ export default class StationSummary extends Component<StationSummarySignature> {
               @label={{t "wind.gusts"}}
               @value={{this.reading.gusts}}
               @valueClass={{this.gustsValueClass}}
+              @icon={{if this.settings.useIconLabels ArrowLineUp}}
             />
 
             <StationMetricCard
               @format="azimuth"
               @label={{t "wind.direction"}}
               @value={{this.reading.direction}}
+              @icon={{if this.settings.useIconLabels Compass}}
             />
 
             <StationMetricCard
@@ -64,24 +78,28 @@ export default class StationSummary extends Component<StationSummarySignature> {
               @label={{t "air.temperature"}}
               @value={{this.reading.temperature}}
               @valueClass={{this.temperatureValueClass}}
+              @icon={{if this.settings.useIconLabels Thermometer}}
             />
 
             <StationMetricCard
               @format="humidity"
               @label={{t "air.humidity"}}
               @value={{this.reading.humidity}}
+              @icon={{if this.settings.useIconLabels Drop}}
             />
 
             <StationMetricCard
               @format="pressure"
               @label={{t "air.pressure"}}
               @value={{this.reading.pressure}}
+              @icon={{if this.settings.useIconLabels Gauge}}
             />
 
             <StationMetricCard
               @format="rainfall"
               @label={{t "air.rain"}}
               @value={{this.reading.rain}}
+              @icon={{if this.settings.useIconLabels CloudRain}}
             />
           </dl>
         </StationSectionCard>

--- a/app/components/station/summary.gts
+++ b/app/components/station/summary.gts
@@ -38,7 +38,7 @@ export default class StationSummary extends Component<StationSummarySignature> {
     <section data-test-station-summary-section>
       <div class="grid grid-cols-2 items-stretch gap-1.5 md:gap-3">
         <StationSectionCard @title={{t "station.summary.now"}}>
-          <dl class="m-0 grid gap-2 md:gap-3">
+          <dl class="m-0 grid gap-1 md:gap-2">
             <StationMetricCard
               @format="windSpeed"
               @label={{t "wind.speed"}}

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -24,6 +24,11 @@ export default class SettingsService extends Service {
   // more stations fit on screen without scrolling (#64).
   @trackedInLocalStorage({ keyName: 'settings.nearbyCompactList' })
   nearbyCompactList = false;
+
+  // Replace the Now/Last hour cards' text labels with small icons, so each
+  // value shrinks to fit its content instead of stretching full width.
+  @trackedInLocalStorage({ keyName: 'settings.useIconLabels' })
+  useIconLabels = false;
 }
 
 // The boolean preferences, named so the settings UI can drive each one through a
@@ -34,7 +39,8 @@ export type BooleanSettingKey =
   | 'faviconFollowsStation'
   | 'showGustsOutline'
   | 'shrinkOldData'
-  | 'nearbyCompactList';
+  | 'nearbyCompactList'
+  | 'useIconLabels';
 
 declare module '@ember/service' {
   interface Registry {

--- a/app/templates/settings.gts
+++ b/app/templates/settings.gts
@@ -8,6 +8,7 @@ import SettingsShowcaseFavicon from 'winds-mobi-client-web/components/settings/s
 import SettingsShowcaseGusts from 'winds-mobi-client-web/components/settings/showcase/gusts';
 import SettingsShowcaseShrink from 'winds-mobi-client-web/components/settings/showcase/shrink';
 import SettingsShowcaseNearbyCompactList from 'winds-mobi-client-web/components/settings/showcase/nearby-compact-list';
+import SettingsShowcaseIconLabels from 'winds-mobi-client-web/components/settings/showcase/icon-labels';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 
 interface SettingsTemplateSignature {
@@ -56,6 +57,12 @@ export default class SettingsTemplate extends Component<SettingsTemplateSignatur
             <SettingsRow @settings={{this.settings}} @name="nearbyCompactList">
               <SettingsShowcaseNearbyCompactList
                 @enabled={{this.settings.nearbyCompactList}}
+              />
+            </SettingsRow>
+
+            <SettingsRow @settings={{this.settings}} @name="useIconLabels">
+              <SettingsShowcaseIconLabels
+                @enabled={{this.settings.useIconLabels}}
               />
             </SettingsRow>
           </dl>

--- a/app/utils/icon-component.ts
+++ b/app/utils/icon-component.ts
@@ -1,0 +1,10 @@
+import type { ComponentLike } from '@glint/template';
+
+// Shared shape for the `@icon` arg accepted by StationMetaItem,
+// StationMetricCard, and the navbar menu items: any ember-phosphor-icons
+// component, which all take an optional `size`.
+export type IconComponent = ComponentLike<{
+  Args: {
+    size?: number;
+  };
+}>;

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.7.22 - 2026-06-21
+
+### Added
+
+- A new "Use icons for labels" setting: when on, each value in the "Now" and "Last hour" cards shows a small icon instead of its text label.
+
+### Changed
+
+- Reverted the "Last hour" card's minimum/mean/maximum wind speeds back to three separate labelled rows, undoing the earlier single-line layout.
+- The "Now" card's row spacing now matches "Last hour"'s tighter spacing.
+- The "Now" card's wind speed metric is now labelled "Wind" instead of "Speed".
+- Restored the clock icon next to the "updated" relative time in the station header and compact nearby cards.
+
 ## v0.7.21 - 2026-06-21
 
 ### Fixed

--- a/tests/acceptance/settings-route-test.ts
+++ b/tests/acceptance/settings-route-test.ts
@@ -16,6 +16,7 @@ const STORAGE_KEYS = [
   'settings.showGustsOutline',
   'settings.shrinkOldData',
   'settings.nearbyCompactList',
+  'settings.useIconLabels',
 ];
 
 module('Acceptance | settings route', function (hooks) {
@@ -30,7 +31,7 @@ module('Acceptance | settings route', function (hooks) {
     STORAGE_KEYS.forEach((key) => window.localStorage.removeItem(key));
   });
 
-  test('it shows the four preferences, on by default except the compact nearby list', async function (assert) {
+  test('it shows the five preferences, on by default except the compact nearby list and icon labels', async function (assert) {
     await visit('/settings');
 
     assert.dom('[data-test-navbar-link="settings"]').hasText('Settings');
@@ -38,6 +39,7 @@ module('Acceptance | settings route', function (hooks) {
     assert.dom('[data-test-setting="showGustsOutline"]').isChecked();
     assert.dom('[data-test-setting="shrinkOldData"]').isChecked();
     assert.dom('[data-test-setting="nearbyCompactList"]').isNotChecked();
+    assert.dom('[data-test-setting="useIconLabels"]').isNotChecked();
   });
 
   test('toggling a preference persists it to local storage', async function (assert) {

--- a/tests/integration/components/station/last-hour/presenter-test.ts
+++ b/tests/integration/components/station/last-hour/presenter-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { findAll, render, settled } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { Type } from '@warp-drive/core/types/symbols';
 import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
@@ -56,18 +56,12 @@ module(
       );
       await settled();
 
-      const valueText = findAll('dl dd')
-        .map((element) => element.textContent?.trim())
-        .filter(Boolean);
-
-      assert.deepEqual(
-        valueText,
-        ['7', '12', '18', 'km/h'],
-        'shows minimum, mean, and maximum in that order, with the unit shown once at the end'
-      );
-      assert.dom('dl dt:nth-of-type(1)').hasText('Minimum');
-      assert.dom('dl dt:nth-of-type(2)').hasText('Mean');
-      assert.dom('dl dt:nth-of-type(3)').hasText('Maximum');
+      assert.dom(this.element).includesText('Maximum');
+      assert.dom(this.element).includesText('18 km/h');
+      assert.dom(this.element).includesText('Mean');
+      assert.dom(this.element).includesText('12 km/h');
+      assert.dom(this.element).includesText('Minimum');
+      assert.dom(this.element).includesText('7 km/h');
     });
   }
 );

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -137,7 +137,7 @@ station:
   air: Air
 
 wind:
-  speed: Speed
+  speed: Wind
   gusts: Gusts
   direction: Direction
   timestamp: 'Time'

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -44,6 +44,12 @@ settings:
       Show nearby stations as smaller cards (name, altitude, wind, gusts, last
       update, and a small wind-direction thumbnail) instead of full-size
       cards, so more stations fit on screen without scrolling.
+  useIconLabels:
+    label: Use icons for labels
+    description: >-
+      Show a small icon instead of the text label for each value in the Now
+      and Last hour cards. Each value then only takes as much width as it
+      needs, so several fit per row instead of one per row.
 
 help:
   title: Help


### PR DESCRIPTION
## Summary
- Reverted "Last hour" min/mean/max back to three separate labelled rows (undoing the earlier one-line layout).
- Matched the "Now" card's row spacing to "Last hour"'s tighter gap-1/md:gap-2.
- Relabeled the "Now" card's wind speed metric from "Speed" to "Wind".
- Added a new "Use icons for labels" setting (`useIconLabels`): swaps each Now/Last hour value's text label for a small icon (cards stay full width either way); added a settings page row + showcase preview.
- Restored the clock icon next to the "updated" relative time in `header.gts` and `compact-card.gts` (both use the same `StationMetaItem` component).
- Centered metric-card content vertically (`items-center` instead of `items-baseline`), since icons don't have a real text baseline to align against.
- Cleanup: extracted a shared `IconComponent` type (was duplicated 3x) into `app/utils/icon-component.ts`; deduped `last-hour/presenter.gts`'s three repeated value-class ternaries into one helper.
- Bumps the changelog to v0.7.22.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm exec eslint` on touched files is clean
- [x] `pnpm test:ember:dev` passes (67/67; one pre-existing unrelated flaky test in `wind-direction/graph-test.ts`)