### PR TITLE
Switch to OpenFreeMap worldwide tiles + outdoor layers (hillshade/contours)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -169,6 +169,12 @@ well-trodden migration. (Stadia is the exception — it can drop in as raster.)
       [app/components/map/index.gts](app/components/map/index.gts)
       (`OPENFREEMAP_STYLE_URL`). Glyphs/sprites/attribution now come from the
       hosted style.
+- [x] Make the basemap **outdoor-usable for free**: native MapLibre hillshade +
+      browser-generated contour lines/labels (`maplibre-contour`), both derived
+      client-side from the Terrarium DEM we already load — no extra tile hosting.
+      In [app/components/map/index.gts](app/components/map/index.gts)
+      (`addOutdoorLayers`). OpenFreeMap doesn't host contour/hillshade itself
+      (OpenMapTiles schema excludes them), so this is the zero-cost route.
 - [ ] Verify terrain DEM (`elevation-tiles-prod`) usage terms are fine at launch scale
       (AWS Open Data — expected yes).
 - [ ] Email Stadia Maps re: non-commercial/nonprofit eligibility (hedge / raster fallback).

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,179 @@
+# TODO
+
+## Map tile provider analysis (launch readiness)
+
+> Context: non-commercial project, no revenue taken, possibly NGO-backed, but we
+> do **not** want to pay to run the service. Currently in "build & demo" phase.
+> Goal: a worldwide basemap we can run sustainably for ~free at real traffic.
+
+### 1. What we use today
+
+> **Status update:** the base layer has since been migrated to **OpenFreeMap**
+> (Option A below) in [app/components/map/index.gts](app/components/map/index.gts).
+> The table below documents the original "build & demo" setup this analysis was
+> written against.
+
+Originally defined in [app/components/map/index.gts](app/components/map/index.gts) as `OSM_SWISS_STYLE`:
+
+| Layer       | Source                                                                    | Provider                                                    | Coverage             |
+| ----------- | ------------------------------------------------------------------------- | ----------------------------------------------------------- | -------------------- |
+| Base raster | `https://tile.osm.ch/switzerland/{z}/{x}/{y}.png`                         | **Swiss OpenStreetMap Association (SOSM)** community server | **Switzerland only** |
+| Terrain DEM | `https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png` | **AWS Terrain Tiles** (ex-Mapzen, AWS Open Data)            | Worldwide            |
+
+Two things to flag before any launch:
+
+- **The base map is Switzerland-only.** `tile.osm.ch/switzerland/...` is a regional
+  extract. "Display a map of anywhere in the world" is **not** possible with the
+  current source — this must change regardless of cost.
+- **`tile.osm.ch` is a volunteer community server, not a product.** It has no
+  published high-volume fair-use allowance and is funded by SOSM members. Pointing
+  a public, worldwide app at it would be abusing a community resource — the same
+  way the OSMF explicitly forbids heavy/commercial-scale use of
+  `tile.openstreetmap.org` ([OSMF Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/)).
+  Fine for build/demo and a Swiss-only audience; **not** an acceptable production
+  basemap. We must move off it before launch.
+- The **AWS terrain DEM is fine to keep** — it's AWS Open Data (sponsored egress),
+  worldwide, no key, no per-request bill.
+
+### 2. Traffic assumption used below
+
+"1 map view per second, sustained, anywhere in the world":
+
+- `1 × 3600 × 24 × 30 = ~2.6 million map views / month`
+- Raster 256px full-screen map ≈ **10–16 tile requests per view**
+  (MapTiler's own figure: [tile requests vs sessions](https://docs.maptiler.com/guides/maps-apis/maps-platform/tile-requests-and-map-sessions-compared/)).
+  Mid estimate ~12 → **~31 million raster tile requests / month**
+  (range ~26M–39M).
+- Bandwidth: raster PNG ~20–40 KB/tile → **~0.9–1.2 TB / month** of tile data.
+- If we switch to **vector** tiles instead: ~4 requests/view → ~10M requests/month,
+  smaller origin egress thanks to heavy CDN caching.
+
+Takeaway: 1 view/s sustained is **serious** traffic (~2.6M views/mo). This is well
+past every commercial free tier.
+
+### 3. Pricing of the commercial pay-per-use providers (the "if we did nothing smart" cost)
+
+#### MapTiler — [pricing](https://www.maptiler.com/cloud/pricing/)
+
+| Plan      | Price   | Included                                      | Overage                                  |
+| --------- | ------- | --------------------------------------------- | ---------------------------------------- |
+| Free      | $0      | 5,000 sessions **or** 100,000 API requests/mo | none — service pauses                    |
+| Flex      | $25/mo  | 25k sessions / 500k requests                  | $2 / 1k sessions, $0.10 / 1k requests    |
+| Unlimited | $295/mo | 300k sessions / 5M requests                   | $1.50 / 1k sessions, $0.08 / 1k requests |
+| Custom    | quote   | negotiated                                    | enterprise                               |
+
+- **Free tier = ~100k tile requests/month.** At our load (~31M) we'd blow through
+  that in **~1 day**, then the map stops loading.
+- We use **raster XYZ** tiles → MapTiler bills by **API requests**. At ~31M/mo on
+  the Unlimited plan: `$295 + (31M − 5M)/1000 × $0.08 ≈ $295 + $2,080 = ~$2,375/month`.
+- Switching to vector doesn't help on MapTiler — it then bills by **sessions**
+  (~2.6M/mo): `$295 + (2.6M − 300k)/1000 × $1.50 ≈ ~$3,750/month`.
+- **Realistic MapTiler bill at 1 view/s: ~$2,000–4,000/month.** Enterprise could
+  negotiate down, but this is firmly "no" for a no-revenue project.
+
+#### For reference (not OSM-leaning, not recommended)
+
+- **Mapbox / Google**: same ballpark or worse; Google ~$3,600 for 10M tiles per the
+  [Bonito Tech write-up](https://bonitotech.com/2024/03/19/how-we-reduced-our-mapping-costs-by-90-using-protomaps-and-cloudflare/).
+
+**Conclusion for §3: pay-per-tile at this scale is ~thousands/month. Not viable.
+We want one of the §4 options.**
+
+### 4. The free / near-free options (recommended)
+
+All of the genuinely-free OSM options below serve **vector** tiles, which means a
+one-time app change: replace our single raster layer with a vector MapLibre style
+(glyphs + sprites + layer styling). MapLibre supports this natively; it's a known,
+well-trodden migration. (Stadia is the exception — it can drop in as raster.)
+
+#### Option A — OpenFreeMap (public instance) — _easiest, $0, zero infra_
+
+- **What**: free public vector-tile hosting of the whole planet, by Zsolt Erő.
+  [openfreemap.org](https://openfreemap.org/) · [GitHub](https://github.com/hyperknot/openfreemap)
+- **Why it's free for us**: explicitly _"completely free with no limits on the number
+  of map views or requests… no registration, no API keys, no cookies."_ Commercial
+  use is allowed too. Funded by donations; designed to be self-sustainable.
+- **Cost**: **$0**, no account.
+- **Coverage**: worldwide.
+- **Risk**: single maintainer, donation-funded, **no SLA / no support guarantee**
+  (their words). Mitigation: it's fully open-source incl. the deploy scripts and they
+  publish weekly full-planet downloads — so if it ever disappears we can self-host the
+  exact same thing (→ Option B) with no app change.
+- **Effort**: low — point the style at their hosted style URL.
+
+#### Option B — Self-host Protomaps PMTiles on Cloudflare R2 — _we own it, ~$0–15/mo_
+
+- **What**: a single `.pmtiles` planet file on Cloudflare R2 + a tiny Worker.
+  [Protomaps](https://protomaps.com/) · [Cloudflare deploy guide](https://docs.protomaps.com/deploy/cloudflare) ·
+  [cost calculator](https://docs.protomaps.com/deploy/cost)
+- **Why it's ~free for us**: **R2 has no bandwidth/egress fees** — only per-request +
+  storage. A whole-planet tileset is ~100–130 GB. Real reports:
+  - _"~130 GB global tileset in R2 + workers = $3/month"_
+  - _"first month $1.67, next month likely $0"_
+  - _"10M tile requests/month ≈ $11 on R2 vs ~$3,600 Google"_
+    ([Bonito Tech](https://bonitotech.com/2024/03/19/how-we-reduced-our-mapping-costs-by-90-using-protomaps-and-cloudflare/),
+    [Pinball Map](https://blog.pinballmap.com/2024/11/05/protomaps-tile-hosting/))
+  - Workers free tier is 100k req/day; paid is $5/mo incl. 10M req. If we ever
+    region-limit the tileset we can sit largely in R2's free tier.
+- **Cost**: **~$0–15/month** even at our load; we control reliability entirely.
+- **Risk**: low/medium — we run it. Need periodic planet rebuilds (or use Protomaps'
+  prebuilt daily planet). Best fit if an **NGO can absorb a tiny, predictable bill**
+  and we want no third-party runtime dependency.
+- **Effort**: medium — one-time setup + a refresh cron.
+
+#### Option C — VersaTiles — _FLOSS, NGO-oriented, self-host or public_
+
+- **What**: fully FLOSS tile stack (generate / serve / render), Shortbread schema.
+  [versatiles.org](https://versatiles.org/)
+- **Why it's free for us**: _"no API keys, no usage fees, no tracking"_; explicitly
+  aimed at _"newsrooms, NGOs, developers, and public institutions."_ Free public tiles
+  or fully self-hostable.
+- **Cost**: **$0** public, or self-host.
+- **Risk**: smaller/newer ecosystem than Protomaps; public hosting is community-scale
+  (donations encouraged). Good ideological fit for an NGO-backed project.
+- **Effort**: low (public) to medium (self-host).
+
+#### Option D — Stadia Maps free non-commercial tier — _only if we stay strictly non-commercial_
+
+- **What**: OSM-based vector **and raster** tiles (raster = smaller app change).
+  [pricing](https://stadiamaps.com/pricing/) · [limits](https://docs.stadiamaps.com/limits/) ·
+  [FAQ on commercial use](https://stadiamaps.com/faqs/)
+- **Why it _might_ be free for us**: free tier covers _"development, evaluation, and
+  non-commercial use (including academic)."_ A genuinely non-commercial, ad-free,
+  NGO-run public service is plausibly eligible — **but** their definition of commercial
+  includes _"generates revenue (including via advertising)"_ and _"use by a for-profit
+  organization."_ So: only if we never monetize. **Action: email them and confirm
+  eligibility in writing** before relying on it.
+- **Cost**: $0 if eligible; monthly-credit limits apply (verify the cap fits ~31M
+  raster requests — likely needs their nonprofit/community arrangement).
+- **Risk**: terms interpretation; free tier has request caps. Upside: can be a
+  **drop-in raster** replacement (least code change).
+- **Effort**: low.
+
+### 5. Recommendation
+
+1. **Now / pre-launch**: switch the base layer off `tile.osm.ch` → **OpenFreeMap
+   (Option A)**. Zero cost, zero infra, worldwide, unblocks the worldwide launch.
+   Keep the AWS terrain DEM as-is.
+2. **If/when we want to own reliability** (NGO backing, predictable tiny budget):
+   move to **self-hosted Protomaps on R2 (Option B)** — same vector style, ~$0–15/mo,
+   no third-party runtime dependency. OpenFreeMap → Protomaps is a small style swap
+   because both are vector.
+3. **Parallel, low-effort hedge**: email **Stadia (Option D)** to see if they'll grant
+   us free non-commercial/nonprofit access — if yes, it's the least code change (raster).
+
+### 6. Follow-up tasks
+
+- [x] Replace the inline Swiss raster style with OpenFreeMap's worldwide **vector**
+      "Liberty" style URL; terrain DEM re-attached on map load. Done in
+      [app/components/map/index.gts](app/components/map/index.gts)
+      (`OPENFREEMAP_STYLE_URL`). Glyphs/sprites/attribution now come from the
+      hosted style.
+- [ ] Verify terrain DEM (`elevation-tiles-prod`) usage terms are fine at launch scale
+      (AWS Open Data — expected yes).
+- [ ] Email Stadia Maps re: non-commercial/nonprofit eligibility (hedge / raster fallback).
+- [ ] Decide hosting posture: rely on OpenFreeMap public vs. self-host Protomaps/R2.
+- [ ] Confirm the OpenFreeMap-provided attribution renders correctly in the
+      `AttributionControl` (OSM + OpenMapTiles + OpenFreeMap).
+- [ ] Consider self-hosting (Option B) before we depend on OpenFreeMap's public
+      instance at production traffic, since it offers no SLA.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,96 @@
+# Troubleshooting
+
+## Dev server returns 504 for most requests (OrbStack / devcontainer)
+
+**Symptom:** the app's `orb.local` domain (e.g.
+`https://ui.winds-mobi-client-web.orb.local/`) returns `504` for most requests —
+typically right after `pnpm install` added or changed a dependency. A handful of
+already-cached assets (e.g. `/@vite/client`) may still return `200`; most others
+hang until they time out.
+
+**What's actually happening:** this devcontainer setup runs two independent dev
+servers against the same source tree:
+
+- the one you start yourself on the host (`pnpm start`), and
+- a long-running one inside a Docker container (`winds-mobi-client-web-ui-1`)
+  that the `orb.local` domain proxies to.
+
+The container bind-mounts the repo (`/app`), but **`node_modules` is a separate
+Docker volume**, independent from the host's `node_modules`. So a dependency
+change (`pnpm add`/`pnpm remove`) updates `package.json`/`pnpm-lock.yaml` (seen by
+both, since those are real files in the bind mount) but does **not** automatically
+reinstall the container's own `node_modules` volume.
+
+Our `start` script always passes `vite --force`, which throws away any cached
+dependency-optimization state and does a full re-scan on every boot. Combined
+with a `node_modules` volume that's now out of sync with the lockfile (or just
+needs the new package physically installed), that forced re-scan can crash
+mid-way — taking the dependency optimizer down with it. Since nearly every route
+imports something from the broken optimization batch, almost every request then
+hangs waiting on a result that never arrives, and the OrbStack proxy in front of
+it eventually returns `504`.
+
+One specific instance we hit and fixed for good (see below): the forced re-scan
+crawls the _entire_ `@frontile/collections` package because we import `Listbox`
+from it, even though we never use its `Table` component. `Table`'s precompiled
+templates aren't prebundle-clean (esbuild can't resolve a `@frontile/theme/src/
+tw.json` import, and two of its helpers — `get`, `or` — aren't in scope under
+strict mode), so the optimizer throws and the whole dependency batch fails.
+
+### Fix
+
+1. **Reinstall the container's own `node_modules`** so it matches the current
+   lockfile (the volume doesn't auto-sync with the host):
+
+   ```sh
+   docker exec <container-name> sh -c "cd /app && pnpm install"
+   ```
+
+   If that reports "already up to date" but the problem persists, the volume's
+   `node_modules` may be subtly stale — force a clean reinstall:
+
+   ```sh
+   docker exec <container-name> sh -c "cd /app && rm -rf node_modules/.vite node_modules/.cache && pnpm install --force"
+   ```
+
+2. **Restart the container properly** (don't `pkill` the dev process directly —
+   its parent `pnpm start` is the container's foreground process, so killing the
+   `vite` child stops the whole container):
+
+   ```sh
+   docker restart <container-name>
+   ```
+
+3. **Watch the boot logs** for the actual underlying error (the 504 itself tells
+   you nothing about _why_):
+
+   ```sh
+   docker logs -f <container-name>
+   ```
+
+   Vite logs everything to stdout — there's no separate persisted log file to
+   look for. Look for lines like `[vite] (client) error while updating
+dependencies:` followed by an `[ERROR]` block; that's the real failure. The
+   server can print `VITE vX ready in ...ms` and still be broken if the _forced
+   re-optimization_ step fails after that — the HTTP server comes up, but most
+   client requests then hang waiting on a dependency batch that never finished.
+
+4. **If the underlying error names a package/component you don't actually use**
+   (as with `@frontile/collections`'s `Table`), add it to `optimizeDeps.exclude`
+   in [vite.config.mjs](vite.config.mjs) instead of trying to fix the dependency
+   itself. Excluding defers that module's resolution to per-request time instead
+   of the bulk pre-scan, so a part of the package you never import is never
+   compiled at all, and it stops being able to take down the whole batch.
+
+### Quick checklist next time this happens
+
+- [ ] `docker ps` — is the container actually up?
+- [ ] `docker logs --tail 80 <container-name>` — find the real `[ERROR]`, not
+      just the 504.
+- [ ] `docker exec <container-name> sh -c "cd /app && pnpm install"` — sync its
+      `node_modules` volume with the lockfile.
+- [ ] `docker exec <container-name> sh -c "rm -rf /app/node_modules/.vite"` —
+      clear the stale/broken optimize-deps cache.
+- [ ] `docker restart <container-name>` — restart cleanly (not `pkill`).
+- [ ] If a specific unused package/component is named in the error, exclude it
+      in `vite.config.mjs`'s `optimizeDeps.exclude` rather than fighting it.

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -19,10 +19,12 @@ import type {
   StyleSpecification,
 } from 'ember-maplibre-gl';
 import {
+  addProtocol,
   GeolocateControl,
   NavigationControl,
   TerrainControl,
 } from 'maplibre-gl';
+import mlcontour from 'maplibre-contour';
 import { windLegendBands } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import config from 'winds-mobi-client-web/config/environment';
 import MapLegend, {
@@ -63,20 +65,142 @@ export interface MapSignature {
 // handleMapLoaded).
 const OPENFREEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/liberty';
 
-// Worldwide elevation tiles (AWS Open Data, Terrarium encoding) powering the 3D
-// terrain toggle. Added to the style on load and referenced by the
-// TerrainControl below by this id.
+// Worldwide elevation tiles (AWS Open Data, Terrarium encoding). One DEM, three
+// outdoor uses, all client-side off the same tiles: the 3D terrain mesh (toggled
+// by the TerrainControl), the hillshade layer, and browser-generated contour
+// lines (maplibre-contour). OpenFreeMap's base style ships none of these, so we
+// attach them on map load (see handleMapLoaded).
+const TERRAIN_DEM_TILE_URL =
+  'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png';
+
 const TERRAIN_SOURCE_ID = 'terrainSource';
 const TERRAIN_SOURCE: SourceSpecification = {
   type: 'raster-dem',
   attribution: '© Mapzen terrain tiles',
   encoding: 'terrarium',
   maxzoom: 15,
-  tiles: [
-    'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
-  ],
+  tiles: [TERRAIN_DEM_TILE_URL],
   tileSize: 256,
 };
+
+const HILLSHADE_LAYER_ID = 'hillshade';
+const CONTOUR_SOURCE_ID = 'contourSource';
+const CONTOUR_LINE_LAYER_ID = 'contourLines';
+const CONTOUR_LABEL_LAYER_ID = 'contourLabels';
+// The vector-tile layer name maplibre-contour emits inside each generated tile.
+const CONTOUR_VECTOR_LAYER = 'contours';
+
+// maplibre-contour generates contour vector tiles in a web worker from the same
+// Terrarium DEM tiles — no extra tile hosting. The DemSource is a page-level
+// singleton: its addProtocol handler is global and only registers once, and the
+// same instance is reused if the map is torn down and rebuilt.
+let demSource: InstanceType<typeof mlcontour.DemSource> | undefined;
+
+function ensureContourDemSource() {
+  if (!demSource) {
+    demSource = new mlcontour.DemSource({
+      url: TERRAIN_DEM_TILE_URL,
+      encoding: 'terrarium',
+      maxzoom: 13,
+      worker: true,
+    });
+    demSource.setupMaplibre({ addProtocol });
+  }
+
+  return demSource;
+}
+
+// Adds hillshading and contour lines + elevation labels to a freshly-loaded map.
+// Hillshade and the contour lines go *under* the style's labels (inserted before
+// its first symbol layer) so place/road labels stay crisp on top; contour labels
+// reuse a font that's already in the style's glyphs so they're guaranteed to
+// render. Contours are zoom-gated by the thresholds below, so they only appear
+// once you've zoomed into terrain.
+function addOutdoorLayers(map: MaplibreMap) {
+  const layers = map.getStyle().layers ?? [];
+  const firstSymbol = layers.find((layer) => layer.type === 'symbol');
+  const beforeId = firstSymbol?.id;
+  const contourFont =
+    firstSymbol && 'layout' in firstSymbol
+      ? (firstSymbol.layout as { 'text-font'?: string[] })['text-font']
+      : undefined;
+
+  if (!map.getLayer(HILLSHADE_LAYER_ID)) {
+    map.addLayer(
+      {
+        id: HILLSHADE_LAYER_ID,
+        type: 'hillshade',
+        source: TERRAIN_SOURCE_ID,
+        paint: {
+          'hillshade-exaggeration': 0.3,
+          'hillshade-shadow-color': '#473b2a',
+        },
+      },
+      beforeId
+    );
+  }
+
+  if (!map.getSource(CONTOUR_SOURCE_ID)) {
+    map.addSource(CONTOUR_SOURCE_ID, {
+      type: 'vector',
+      tiles: [
+        ensureContourDemSource().contourProtocolUrl({
+          // [minor, major] metre spacing per zoom; lines appear from z11 in.
+          thresholds: {
+            11: [200, 1000],
+            12: [100, 500],
+            13: [100, 500],
+            14: [50, 250],
+            15: [20, 100],
+          },
+          elevationKey: 'ele',
+          levelKey: 'level',
+          contourLayer: CONTOUR_VECTOR_LAYER,
+        }),
+      ],
+      maxzoom: 15,
+    });
+  }
+
+  if (!map.getLayer(CONTOUR_LINE_LAYER_ID)) {
+    map.addLayer(
+      {
+        id: CONTOUR_LINE_LAYER_ID,
+        type: 'line',
+        source: CONTOUR_SOURCE_ID,
+        'source-layer': CONTOUR_VECTOR_LAYER,
+        paint: {
+          'line-color': 'rgba(80, 65, 40, 0.45)',
+          // Major contour lines (level 1) are drawn heavier than minor ones.
+          'line-width': ['match', ['get', 'level'], 1, 1.1, 0.5],
+        },
+      },
+      beforeId
+    );
+  }
+
+  if (contourFont && !map.getLayer(CONTOUR_LABEL_LAYER_ID)) {
+    map.addLayer({
+      id: CONTOUR_LABEL_LAYER_ID,
+      type: 'symbol',
+      source: CONTOUR_SOURCE_ID,
+      'source-layer': CONTOUR_VECTOR_LAYER,
+      // Only label major lines, to keep the map readable.
+      filter: ['>', ['get', 'level'], 0],
+      layout: {
+        'symbol-placement': 'line',
+        'text-size': 10,
+        'text-field': ['concat', ['to-string', ['get', 'ele']], ' m'],
+        'text-font': contourFont,
+      },
+      paint: {
+        'text-color': 'rgba(60, 48, 30, 0.9)',
+        'text-halo-color': 'rgba(255, 255, 255, 0.7)',
+        'text-halo-width': 1,
+      },
+    });
+  }
+}
 
 const TEST_MAP_STYLE: StyleSpecification = {
   version: 8,
@@ -269,6 +393,10 @@ export default class Map extends Component<MapSignature> {
       map.addSource(TERRAIN_SOURCE_ID, TERRAIN_SOURCE);
     }
     map.setSky({});
+
+    // Make the basemap outdoor-usable: hillshading + browser-generated contour
+    // lines, both from the DEM source above (see addOutdoorLayers).
+    addOutdoorLayers(map);
 
     // On a fresh load, ask the map's own geolocation for the user's position and
     // center on it; otherwise the whole-Switzerland default view stays (#32).

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -15,6 +15,7 @@ import MapLibreGL from 'ember-maplibre-gl/components/maplibre-gl';
 import type {
   Map as MaplibreMap,
   MapInitOptions,
+  SourceSpecification,
   StyleSpecification,
 } from 'ember-maplibre-gl';
 import {
@@ -54,36 +55,27 @@ export interface MapSignature {
   Element: null;
 }
 
-const OSM_SWISS_STYLE: StyleSpecification = {
-  version: 8,
-  sources: {
-    osmswissstyle: {
-      attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-      maxzoom: 19,
-      tiles: ['https://tile.osm.ch/switzerland/{z}/{x}/{y}.png'],
-      tileSize: 256,
-      type: 'raster',
-    },
-    terrainSource: {
-      type: 'raster-dem',
-      attribution: '© Mapzen terrain tiles',
-      encoding: 'terrarium',
-      maxzoom: 15,
-      tiles: [
-        'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
-      ],
-      tileSize: 256,
-    },
-  },
-  layers: [
-    {
-      id: 'osmswissstyle',
-      source: 'osmswissstyle',
-      type: 'raster',
-    },
+// Base map: OpenFreeMap's hosted "Liberty" vector style — a free, no-key,
+// worldwide OpenStreetMap basemap (https://openfreemap.org). MapLibre fetches
+// this style URL directly, so its sources, glyphs, sprite, and OSM/OpenMapTiles
+// attribution all come from OpenFreeMap. Unlike the previous inline raster style
+// it carries no DEM source, so the terrain source is attached on map load (see
+// handleMapLoaded).
+const OPENFREEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/liberty';
+
+// Worldwide elevation tiles (AWS Open Data, Terrarium encoding) powering the 3D
+// terrain toggle. Added to the style on load and referenced by the
+// TerrainControl below by this id.
+const TERRAIN_SOURCE_ID = 'terrainSource';
+const TERRAIN_SOURCE: SourceSpecification = {
+  type: 'raster-dem',
+  attribution: '© Mapzen terrain tiles',
+  encoding: 'terrarium',
+  maxzoom: 15,
+  tiles: [
+    'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
   ],
-  sky: {},
+  tileSize: 256,
 };
 
 const TEST_MAP_STYLE: StyleSpecification = {
@@ -135,7 +127,7 @@ export default class Map extends Component<MapSignature> {
     config.environment === 'test'
       ? undefined
       : new TerrainControl({
-          source: 'terrainSource',
+          source: TERRAIN_SOURCE_ID,
           exaggeration: 1,
         });
 
@@ -222,7 +214,8 @@ export default class Map extends Component<MapSignature> {
       dragRotate: true,
       maxPitch: 85,
       pitch: 0,
-      style: config.environment === 'test' ? TEST_MAP_STYLE : OSM_SWISS_STYLE,
+      style:
+        config.environment === 'test' ? TEST_MAP_STYLE : OPENFREEMAP_STYLE_URL,
       touchPitch: true,
       zoom: this.mapView.zoom,
     };
@@ -262,10 +255,24 @@ export default class Map extends Component<MapSignature> {
   }
 
   @action
-  handleMapLoaded() {
+  handleMapLoaded(map: MaplibreMap) {
+    // The test style is a bare background with no vector sources or terrain, and
+    // tests don't geolocate — nothing to wire up here.
+    if (config.environment === 'test') {
+      return;
+    }
+
+    // OpenFreeMap's base style carries no DEM source, so attach the terrain
+    // source the TerrainControl toggles now that the style has loaded, and
+    // restore the default atmospheric sky the previous inline style declared.
+    if (!map.getSource(TERRAIN_SOURCE_ID)) {
+      map.addSource(TERRAIN_SOURCE_ID, TERRAIN_SOURCE);
+    }
+    map.setSky({});
+
     // On a fresh load, ask the map's own geolocation for the user's position and
     // center on it; otherwise the whole-Switzerland default view stays (#32).
-    if (this.isInitialDefaultView && config.environment !== 'test') {
+    if (this.isInitialDefaultView) {
       // `mapLoaded` fires before ember-maplibre-gl renders its block and adds the
       // GeolocateControl, so the control isn't on the map yet ("triggered before
       // added to a map"). The addon documents deferring such effectful onMapLoaded

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@warp-drive/schema-record": "5.8.0",
     "@warp-drive/utilities": "5.8.0",
     "highcharts": "12.5.0",
+    "maplibre-contour": "^0.1.0",
     "sharp": "^0.34.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       highcharts:
         specifier: 12.5.0
         version: 12.5.0
+      maplibre-contour:
+        specifier: ^0.1.0
+        version: 0.1.0
       sharp:
         specifier: ^0.34.1
         version: 0.34.1
@@ -6417,6 +6420,9 @@ packages:
   map-visit@1.0.0:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
     engines: {node: '>=0.10.0'}
+
+  maplibre-contour@0.1.0:
+    resolution: {integrity: sha512-H8muT7JWYE4oLbFv7L2RSbIM1NOu5JxjA9P/TQqhODDnRChE8ENoDkQIWOKgfcKNU77ypLk2ggGoh4/pt4UPLA==}
 
   maplibre-gl@5.20.2:
     resolution: {integrity: sha512-0UzMWOe+GZmIUmOA99yTI1vRh15YcGnHxADVB2s+JF3etpjj2/MBCqbPEuu4BP9mLsJWJcpHH0Nzr9uuimmbuQ==}
@@ -16811,6 +16817,8 @@ snapshots:
   map-visit@1.0.0:
     dependencies:
       object-visit: 1.0.1
+
+  maplibre-contour@0.1.0: {}
 
   maplibre-gl@5.20.2:
     dependencies:

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.8.0 - 2026-06-22
+
+### Changed
+
+- The map's base layer now uses [OpenFreeMap](https://openfreemap.org/)'s free, worldwide vector basemap instead of a Switzerland-only raster tile server, so the map now shows the whole world, not just Switzerland.
+
+### Added
+
+- The map now shows hillshading and contour lines with elevation labels, generated in the browser from the same elevation data already used for the 3D terrain view, making it more usable for outdoor/free-flight planning.
+
 ## v0.7.22 - 2026-06-21
 
 ### Added

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -84,6 +84,20 @@ export default defineConfig(({ mode }) => ({
       : null,
   ].filter(Boolean),
   optimizeDeps: {
-    exclude: ['ember-page-title', 'object-inspect', 'embroider-util'],
+    exclude: [
+      'ember-page-title',
+      'object-inspect',
+      'embroider-util',
+      // @frontile/collections' Table component fails to prebundle: its
+      // precompiled templates reference `get`/`or` outside strict-mode scope,
+      // and a `@frontile/theme/src/tw.json` import esbuild can't resolve. We
+      // only use Listbox from this package, never Table, but Vite's forced
+      // dependency scan (`vite --force`, our dev script) still crawls the
+      // whole package and crashes the optimizer on it, breaking nearly every
+      // route on a fresh dev-server start (see TROUBLESHOOTING.md).
+      // Excluding it from prebundling defers resolution to per-module
+      // request time, where the unused Table component is never reached.
+      '@frontile/collections',
+    ],
   },
 }));


### PR DESCRIPTION
## Summary
- **Worldwide base map**: replace the inline `tile.osm.ch/switzerland` raster style (Switzerland-only, volunteer community server) with OpenFreeMap's hosted "Liberty" vector style — free, no key, no limits, worldwide. See `TODO.md` for the full provider/pricing analysis behind this choice.
- **Outdoor-usable**: add hillshading (native MapLibre `hillshade` layer) and contour lines + elevation labels (`maplibre-contour`, browser-generated in a worker), both derived from the same AWS Terrarium DEM already loaded for the 3D terrain toggle — no extra tile hosting or bandwidth.
- **Dev-server fix**: exclude `@frontile/collections` from Vite's `optimizeDeps` pre-bundle — its unused `Table` component fails to prebundle under a forced (`--force`) dependency re-scan, crashing the whole optimizer batch and causing widespread 504s. Added `TROUBLESHOOTING.md` documenting the symptom/diagnosis/fix.
- Bumps the changelog to **v0.8.0** (minor: new map provider + new feature surface).

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` (production) compiles cleanly, including the new `maplibre-contour` worker bundle
- [x] `pnpm test:ember:dev` passes (67/67; one pre-existing unrelated flaky test in `wind-direction/graph-test.ts`)
- [x] Verified the devcontainer's `ui.winds-mobi-client-web.orb.local` proxy serves 200s again after the optimizeDeps fix (previously 504 for most requests)
- [ ] Manual: load the map and pan/zoom worldwide (not just Switzerland), zoom into mountainous terrain to see hillshade + contours, toggle 3D terrain