### PR TITLE
Revert to SOSM tiles — OpenFreeMap switch was solving a non-problem

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,32 +8,52 @@
 
 ### 1. What we use today
 
-> **Status update:** the base layer has since been migrated to **OpenFreeMap**
-> (Option A below) in [app/components/map/index.gts](app/components/map/index.gts).
-> The table below documents the original "build & demo" setup this analysis was
-> written against.
+> **Status update:** briefly migrated to OpenFreeMap (Option A below) plus
+> client-side hillshade/contour layers, then **reverted back to SOSM's
+> `tile.osm.ch`** after actually reading SOSM's terms of service — see the
+> correction just below. The original "not acceptable" framing was an
+> unverified inference, not something we'd checked. We're back to the
+> original setup; the OpenFreeMap switch and the outdoor layers were
+> over-engineering for a problem that, on closer reading, didn't need
+> solving the way we solved it.
 
-Originally defined in [app/components/map/index.gts](app/components/map/index.gts) as `OSM_SWISS_STYLE`:
+Defined in [app/components/map/index.gts](app/components/map/index.gts) as `OSM_SWISS_STYLE`:
 
 | Layer       | Source                                                                    | Provider                                                    | Coverage             |
 | ----------- | ------------------------------------------------------------------------- | ----------------------------------------------------------- | -------------------- |
 | Base raster | `https://tile.osm.ch/switzerland/{z}/{x}/{y}.png`                         | **Swiss OpenStreetMap Association (SOSM)** community server | **Switzerland only** |
 | Terrain DEM | `https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png` | **AWS Terrain Tiles** (ex-Mapzen, AWS Open Data)            | Worldwide            |
 
-Two things to flag before any launch:
+**Correction (verified directly against SOSM's terms, not by analogy to
+OSMF's policy):** the original draft of this doc claimed `tile.osm.ch` "has no
+published high-volume fair-use allowance" and compared it to OSMF's explicit
+ban on heavy use of `tile.openstreetmap.org`. That comparison was never
+actually checked against SOSM's own terms — it was an unverified inference
+presented with more confidence than was warranted. Having now read
+[SOSM's Terms of Service](https://sosm.ch/about/terms-of-service/) directly:
+there is **no stated prohibition** on third-party, commercial, or high-volume
+use. The only relevant clause is _"We retain the right to create limits on
+use and storage at our sole discretion at any time with or without notice."_
+No published quota, no commercial-use ban — just an unpublished, discretionary
+throttle. That's the same risk profile as OpenFreeMap's "no SLA" (donation/
+volunteer-run, no guarantees), not a special restriction unique to SOSM.
 
-- **The base map is Switzerland-only.** `tile.osm.ch/switzerland/...` is a regional
-  extract. "Display a map of anywhere in the world" is **not** possible with the
-  current source — this must change regardless of cost.
-- **`tile.osm.ch` is a volunteer community server, not a product.** It has no
-  published high-volume fair-use allowance and is funded by SOSM members. Pointing
-  a public, worldwide app at it would be abusing a community resource — the same
-  way the OSMF explicitly forbids heavy/commercial-scale use of
-  `tile.openstreetmap.org` ([OSMF Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/)).
-  Fine for build/demo and a Swiss-only audience; **not** an acceptable production
-  basemap. We must move off it before launch.
-- The **AWS terrain DEM is fine to keep** — it's AWS Open Data (sponsored egress),
-  worldwide, no key, no per-request bill.
+What's still true, and is the actual reason this needs revisiting before a
+**worldwide** launch (not a usage-policy question):
+
+- **The base map is Switzerland-only.** `tile.osm.ch/switzerland/...` is a
+  regional extract. "Display a map of anywhere in the world" is not possible
+  with this source. This is a coverage limitation, not a permission one —
+  and for now it's an accepted, deliberate trade-off (see status update
+  above), not an oversight.
+- SOSM's own tile-download page already suggests self-hosting for
+  sustained-high-volume use
+  ([sosm.ch/tile-download/](https://sosm.ch/tile-download/): _"you can
+  download them to either host them yourself, or use them in an offline
+  application"_) — i.e. if/when traffic grows, the off-ramp already exists
+  and matches Option B below in spirit (just Switzerland-only).
+- The **AWS terrain DEM is fine to keep** — it's AWS Open Data (sponsored
+  egress), worldwide, no key, no per-request bill.
 
 ### 2. Traffic assumption used below
 
@@ -152,9 +172,24 @@ well-trodden migration. (Stadia is the exception — it can drop in as raster.)
 
 ### 5. Recommendation
 
-1. **Now / pre-launch**: switch the base layer off `tile.osm.ch` → **OpenFreeMap
-   (Option A)**. Zero cost, zero infra, worldwide, unblocks the worldwide launch.
-   Keep the AWS terrain DEM as-is.
+> **Superseded by the status update in §1.** We tried switching to OpenFreeMap
+> (below) plus client-side hillshade/contours, then reverted: SOSM's terms
+> don't actually forbid what we feared, and `tile.osm.ch/switzerland`'s style
+> _already renders hillshading and contour lines server-side_ — confirmed
+> directly from [SOSM's tile-service page](https://sosm.ch/projects/tile-service/),
+> which describes the style as _"adapted to render for example the Mobility
+> car sharing stations or to include a hill shading and contour lines."_ The
+> entire `maplibre-contour` + native-hillshade-layer effort (§6, now reverted)
+> was solving a problem the tiles already solved for us. Kept below for when
+> worldwide coverage actually becomes the blocker.
+
+1. **When worldwide coverage is actually needed**: switch the base layer off
+   `tile.osm.ch` → **OpenFreeMap (Option A)**. Zero cost, zero infra,
+   worldwide. Keep the AWS terrain DEM as-is. Note: OpenFreeMap's vector style
+   does _not_ include hillshade/contours (OpenMapTiles schema excludes them),
+   so that move would need to either re-add them client-side or accept a
+   plainer style — re-evaluate whether that's worth it at that point, rather
+   than defaulting back into the same complexity.
 2. **If/when we want to own reliability** (NGO backing, predictable tiny budget):
    move to **self-hosted Protomaps on R2 (Option B)** — same vector style, ~$0–15/mo,
    no third-party runtime dependency. OpenFreeMap → Protomaps is a small style swap
@@ -164,22 +199,21 @@ well-trodden migration. (Stadia is the exception — it can drop in as raster.)
 
 ### 6. Follow-up tasks
 
-- [x] Replace the inline Swiss raster style with OpenFreeMap's worldwide **vector**
-      "Liberty" style URL; terrain DEM re-attached on map load. Done in
-      [app/components/map/index.gts](app/components/map/index.gts)
-      (`OPENFREEMAP_STYLE_URL`). Glyphs/sprites/attribution now come from the
-      hosted style.
-- [x] Make the basemap **outdoor-usable for free**: native MapLibre hillshade +
-      browser-generated contour lines/labels (`maplibre-contour`), both derived
-      client-side from the Terrarium DEM we already load — no extra tile hosting.
-      In [app/components/map/index.gts](app/components/map/index.gts)
-      (`addOutdoorLayers`). OpenFreeMap doesn't host contour/hillshade itself
-      (OpenMapTiles schema excludes them), so this is the zero-cost route.
+- [x] ~~Replace the inline Swiss raster style with OpenFreeMap's worldwide vector
+      "Liberty" style URL~~ — **done, then reverted.** See the §1 status
+      update and the correction above: the move solved a permission problem
+      that turned out not to exist, at the cost of losing SOSM's
+      already-baked-in hillshading/contours and gaining a `maplibre-contour`
+      dependency to claw them back. Back to `OSM_SWISS_STYLE` in
+      [app/components/map/index.gts](app/components/map/index.gts).
+- [x] ~~Make the basemap outdoor-usable for free via client-side hillshade +
+      `maplibre-contour`~~ — **reverted as unnecessary**; SOSM's tiles already
+      render hillshading and contours server-side (see §1/§5).
 - [ ] Verify terrain DEM (`elevation-tiles-prod`) usage terms are fine at launch scale
       (AWS Open Data — expected yes).
-- [ ] Email Stadia Maps re: non-commercial/nonprofit eligibility (hedge / raster fallback).
-- [ ] Decide hosting posture: rely on OpenFreeMap public vs. self-host Protomaps/R2.
-- [ ] Confirm the OpenFreeMap-provided attribution renders correctly in the
-      `AttributionControl` (OSM + OpenMapTiles + OpenFreeMap).
-- [ ] Consider self-hosting (Option B) before we depend on OpenFreeMap's public
-      instance at production traffic, since it offers no SLA.
+- [ ] Email Stadia Maps re: non-commercial/nonprofit eligibility (hedge / raster fallback) —
+      lower priority now that SOSM is confirmed fine to keep using.
+- [ ] If/when SOSM ever throttles us or worldwide coverage becomes a real
+      requirement, revisit Option A (OpenFreeMap) or B (self-hosted Protomaps/R2)
+      above — the analysis and the rationale for picking between them is
+      preserved here.

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -15,16 +15,13 @@ import MapLibreGL from 'ember-maplibre-gl/components/maplibre-gl';
 import type {
   Map as MaplibreMap,
   MapInitOptions,
-  SourceSpecification,
   StyleSpecification,
 } from 'ember-maplibre-gl';
 import {
-  addProtocol,
   GeolocateControl,
   NavigationControl,
   TerrainControl,
 } from 'maplibre-gl';
-import mlcontour from 'maplibre-contour';
 import { windLegendBands } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import config from 'winds-mobi-client-web/config/environment';
 import MapLegend, {
@@ -57,150 +54,37 @@ export interface MapSignature {
   Element: null;
 }
 
-// Base map: OpenFreeMap's hosted "Liberty" vector style — a free, no-key,
-// worldwide OpenStreetMap basemap (https://openfreemap.org). MapLibre fetches
-// this style URL directly, so its sources, glyphs, sprite, and OSM/OpenMapTiles
-// attribution all come from OpenFreeMap. Unlike the previous inline raster style
-// it carries no DEM source, so the terrain source is attached on map load (see
-// handleMapLoaded).
-const OPENFREEMAP_STYLE_URL = 'https://tiles.openfreemap.org/styles/liberty';
-
-// Worldwide elevation tiles (AWS Open Data, Terrarium encoding). One DEM, three
-// outdoor uses, all client-side off the same tiles: the 3D terrain mesh (toggled
-// by the TerrainControl), the hillshade layer, and browser-generated contour
-// lines (maplibre-contour). OpenFreeMap's base style ships none of these, so we
-// attach them on map load (see handleMapLoaded).
-const TERRAIN_DEM_TILE_URL =
-  'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png';
-
-const TERRAIN_SOURCE_ID = 'terrainSource';
-const TERRAIN_SOURCE: SourceSpecification = {
-  type: 'raster-dem',
-  attribution: '© Mapzen terrain tiles',
-  encoding: 'terrarium',
-  maxzoom: 15,
-  tiles: [TERRAIN_DEM_TILE_URL],
-  tileSize: 256,
-};
-
-const HILLSHADE_LAYER_ID = 'hillshade';
-const CONTOUR_SOURCE_ID = 'contourSource';
-const CONTOUR_LINE_LAYER_ID = 'contourLines';
-const CONTOUR_LABEL_LAYER_ID = 'contourLabels';
-// The vector-tile layer name maplibre-contour emits inside each generated tile.
-const CONTOUR_VECTOR_LAYER = 'contours';
-
-// maplibre-contour generates contour vector tiles in a web worker from the same
-// Terrarium DEM tiles — no extra tile hosting. The DemSource is a page-level
-// singleton: its addProtocol handler is global and only registers once, and the
-// same instance is reused if the map is torn down and rebuilt.
-let demSource: InstanceType<typeof mlcontour.DemSource> | undefined;
-
-function ensureContourDemSource() {
-  if (!demSource) {
-    demSource = new mlcontour.DemSource({
-      url: TERRAIN_DEM_TILE_URL,
+const OSM_SWISS_STYLE: StyleSpecification = {
+  version: 8,
+  sources: {
+    osmswissstyle: {
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      maxzoom: 19,
+      tiles: ['https://tile.osm.ch/switzerland/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      type: 'raster',
+    },
+    terrainSource: {
+      type: 'raster-dem',
+      attribution: '© Mapzen terrain tiles',
       encoding: 'terrarium',
-      maxzoom: 13,
-      worker: true,
-    });
-    demSource.setupMaplibre({ addProtocol });
-  }
-
-  return demSource;
-}
-
-// Adds hillshading and contour lines + elevation labels to a freshly-loaded map.
-// Hillshade and the contour lines go *under* the style's labels (inserted before
-// its first symbol layer) so place/road labels stay crisp on top; contour labels
-// reuse a font that's already in the style's glyphs so they're guaranteed to
-// render. Contours are zoom-gated by the thresholds below, so they only appear
-// once you've zoomed into terrain.
-function addOutdoorLayers(map: MaplibreMap) {
-  const layers = map.getStyle().layers ?? [];
-  const firstSymbol = layers.find((layer) => layer.type === 'symbol');
-  const beforeId = firstSymbol?.id;
-  const contourFont =
-    firstSymbol && 'layout' in firstSymbol
-      ? (firstSymbol.layout as { 'text-font'?: string[] })['text-font']
-      : undefined;
-
-  if (!map.getLayer(HILLSHADE_LAYER_ID)) {
-    map.addLayer(
-      {
-        id: HILLSHADE_LAYER_ID,
-        type: 'hillshade',
-        source: TERRAIN_SOURCE_ID,
-        paint: {
-          'hillshade-exaggeration': 0.3,
-          'hillshade-shadow-color': '#473b2a',
-        },
-      },
-      beforeId
-    );
-  }
-
-  if (!map.getSource(CONTOUR_SOURCE_ID)) {
-    map.addSource(CONTOUR_SOURCE_ID, {
-      type: 'vector',
-      tiles: [
-        ensureContourDemSource().contourProtocolUrl({
-          // [minor, major] metre spacing per zoom; lines appear from z11 in.
-          thresholds: {
-            11: [200, 1000],
-            12: [100, 500],
-            13: [100, 500],
-            14: [50, 250],
-            15: [20, 100],
-          },
-          elevationKey: 'ele',
-          levelKey: 'level',
-          contourLayer: CONTOUR_VECTOR_LAYER,
-        }),
-      ],
       maxzoom: 15,
-    });
-  }
-
-  if (!map.getLayer(CONTOUR_LINE_LAYER_ID)) {
-    map.addLayer(
-      {
-        id: CONTOUR_LINE_LAYER_ID,
-        type: 'line',
-        source: CONTOUR_SOURCE_ID,
-        'source-layer': CONTOUR_VECTOR_LAYER,
-        paint: {
-          'line-color': 'rgba(80, 65, 40, 0.45)',
-          // Major contour lines (level 1) are drawn heavier than minor ones.
-          'line-width': ['match', ['get', 'level'], 1, 1.1, 0.5],
-        },
-      },
-      beforeId
-    );
-  }
-
-  if (contourFont && !map.getLayer(CONTOUR_LABEL_LAYER_ID)) {
-    map.addLayer({
-      id: CONTOUR_LABEL_LAYER_ID,
-      type: 'symbol',
-      source: CONTOUR_SOURCE_ID,
-      'source-layer': CONTOUR_VECTOR_LAYER,
-      // Only label major lines, to keep the map readable.
-      filter: ['>', ['get', 'level'], 0],
-      layout: {
-        'symbol-placement': 'line',
-        'text-size': 10,
-        'text-field': ['concat', ['to-string', ['get', 'ele']], ' m'],
-        'text-font': contourFont,
-      },
-      paint: {
-        'text-color': 'rgba(60, 48, 30, 0.9)',
-        'text-halo-color': 'rgba(255, 255, 255, 0.7)',
-        'text-halo-width': 1,
-      },
-    });
-  }
-}
+      tiles: [
+        'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+      ],
+      tileSize: 256,
+    },
+  },
+  layers: [
+    {
+      id: 'osmswissstyle',
+      source: 'osmswissstyle',
+      type: 'raster',
+    },
+  ],
+  sky: {},
+};
 
 const TEST_MAP_STYLE: StyleSpecification = {
   version: 8,
@@ -251,7 +135,7 @@ export default class Map extends Component<MapSignature> {
     config.environment === 'test'
       ? undefined
       : new TerrainControl({
-          source: TERRAIN_SOURCE_ID,
+          source: 'terrainSource',
           exaggeration: 1,
         });
 
@@ -338,8 +222,7 @@ export default class Map extends Component<MapSignature> {
       dragRotate: true,
       maxPitch: 85,
       pitch: 0,
-      style:
-        config.environment === 'test' ? TEST_MAP_STYLE : OPENFREEMAP_STYLE_URL,
+      style: config.environment === 'test' ? TEST_MAP_STYLE : OSM_SWISS_STYLE,
       touchPitch: true,
       zoom: this.mapView.zoom,
     };
@@ -379,28 +262,10 @@ export default class Map extends Component<MapSignature> {
   }
 
   @action
-  handleMapLoaded(map: MaplibreMap) {
-    // The test style is a bare background with no vector sources or terrain, and
-    // tests don't geolocate — nothing to wire up here.
-    if (config.environment === 'test') {
-      return;
-    }
-
-    // OpenFreeMap's base style carries no DEM source, so attach the terrain
-    // source the TerrainControl toggles now that the style has loaded, and
-    // restore the default atmospheric sky the previous inline style declared.
-    if (!map.getSource(TERRAIN_SOURCE_ID)) {
-      map.addSource(TERRAIN_SOURCE_ID, TERRAIN_SOURCE);
-    }
-    map.setSky({});
-
-    // Make the basemap outdoor-usable: hillshading + browser-generated contour
-    // lines, both from the DEM source above (see addOutdoorLayers).
-    addOutdoorLayers(map);
-
+  handleMapLoaded() {
     // On a fresh load, ask the map's own geolocation for the user's position and
     // center on it; otherwise the whole-Switzerland default view stays (#32).
-    if (this.isInitialDefaultView) {
+    if (this.isInitialDefaultView && config.environment !== 'test') {
       // `mapLoaded` fires before ember-maplibre-gl renders its block and adds the
       // GeolocateControl, so the control isn't on the map yet ("triggered before
       // added to a map"). The addon documents deferring such effectful onMapLoaded

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@warp-drive/schema-record": "5.8.0",
     "@warp-drive/utilities": "5.8.0",
     "highcharts": "12.5.0",
-    "maplibre-contour": "^0.1.0",
     "sharp": "^0.34.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       highcharts:
         specifier: 12.5.0
         version: 12.5.0
-      maplibre-contour:
-        specifier: ^0.1.0
-        version: 0.1.0
       sharp:
         specifier: ^0.34.1
         version: 0.34.1
@@ -6420,9 +6417,6 @@ packages:
   map-visit@1.0.0:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
     engines: {node: '>=0.10.0'}
-
-  maplibre-contour@0.1.0:
-    resolution: {integrity: sha512-H8muT7JWYE4oLbFv7L2RSbIM1NOu5JxjA9P/TQqhODDnRChE8ENoDkQIWOKgfcKNU77ypLk2ggGoh4/pt4UPLA==}
 
   maplibre-gl@5.20.2:
     resolution: {integrity: sha512-0UzMWOe+GZmIUmOA99yTI1vRh15YcGnHxADVB2s+JF3etpjj2/MBCqbPEuu4BP9mLsJWJcpHH0Nzr9uuimmbuQ==}
@@ -16817,8 +16811,6 @@ snapshots:
   map-visit@1.0.0:
     dependencies:
       object-visit: 1.0.1
-
-  maplibre-contour@0.1.0: {}
 
   maplibre-gl@5.20.2:
     dependencies:

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9.0 - 2026-06-23
+
+### Changed
+
+- Reverted the map's base layer back to the Swiss OpenStreetMap Association's tiles (the v0.8.0 switch to a worldwide vector basemap is reverted, along with the hillshading/contour-line layers added for it): the Swiss tiles already render hillshading and contour lines, so the added layers were redundant, and the map is back to Switzerland coverage with the simpler, original setup for now.
+
 ## v0.8.0 - 2026-06-22
 
 ### Changed


### PR DESCRIPTION
## Summary
- **Revert v0.8.0's map provider switch**: back to SOSM's `tile.osm.ch/switzerland` raster tiles + inline AWS Terrarium DEM, exactly as before that change.
- **Why**: the switch to OpenFreeMap was based on an unverified claim (presented with more confidence than warranted) that SOSM's `tile.osm.ch` had no fair-use allowance, by analogy to OSMF's policy — never actually checked against SOSM's own terms. Having now read [SOSM's ToS](https://sosm.ch/about/terms-of-service/) directly: no such prohibition exists, just an unpublished discretionary "we may limit usage" clause — the same no-SLA risk profile OpenFreeMap has. Worse: [SOSM's tile-service page](https://sosm.ch/projects/tile-service/) confirms `tile.osm.ch/switzerland`'s style already bakes in hillshading and contour lines server-side, which made the `maplibre-contour` + native-hillshade-layer work in v0.8.0 redundant complexity solving an already-solved problem.
- Removed the now-unused `maplibre-contour` dependency.
- Kept the unrelated `@frontile/collections` Vite `optimizeDeps` fix and `TROUBLESHOOTING.md` — that addresses a real, independent dev-server bug unrelated to map tile choice.
- `TODO.md` corrected in place (not deleted): documents the unverified claim, the correction with sources, and that worldwide coverage remains a real future requirement we're knowingly deferring (Switzerland-only for now), not something SOSM's terms force us to solve today.
- Bumps the changelog to **v0.9.0** (minor: reverts a user-visible feature surface).

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` (production) succeeds; bundle shrinks now that `maplibre-contour` is gone
- [x] `pnpm test:ember:dev` passes **67/67** (no flakes this run)