### PR TITLE
Flatten the map when 3D mode is turned off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,8 @@ issue)` console error in the failure output). `pnpm test:ember` (isolated build 
 
 - Keep [CHANGELOG.md](CHANGELOG.md) user-facing: shipped behavior, visible improvements, notable fixes. Omit internal
   refactors, test-only changes, and implementation details unless they directly affect users.
+- Mark beta/stable transitions with a prefix on the entry: a new beta feature gets `**🧪 Beta:**`, and when a feature
+  graduates from beta to stable (e.g. the gating toggle is removed), its entry gets `**🚀 Stable:**`.
 
 ### Don't touch
 

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -306,13 +306,24 @@ export default class Map extends Component<MapSignature> {
 
   @action
   handleTerrainChange(event: { target: MaplibreMap }) {
-    if (!event.target.getTerrain() || event.target.getPitch() >= 70) {
+    if (event.target.getTerrain()) {
+      if (event.target.getPitch() < 70) {
+        event.target.easeTo({
+          pitch: 70,
+        });
+      }
+
       return;
     }
 
-    event.target.easeTo({
-      pitch: 70,
-    });
+    // Turning 3D off via the TerrainControl button only removes the DEM
+    // source — MapLibre has no "reset to default" for pitch, so without this
+    // the map stays tilted at whatever angle terrain left it at (#100).
+    if (event.target.getPitch() !== 0) {
+      event.target.easeTo({
+        pitch: 0,
+      });
+    }
   }
 
   // Cached so the reference is stable across re-renders (stations loading, each

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,6 +9,14 @@
 - **Beta:** A star on the station panel header lets you add or remove that station from your favourites while signed in.
 - **Beta:** A new "Enable beta features" toggle in Settings (off by default) reveals the three items above.
 
+### Changed
+
+- Each preference in Settings now sits in its own card, making the grouping clearer at every screen width.
+
+### Fixed
+
+- Turning off 3D mode now flattens the map back to a top-down view instead of leaving it tilted.
+
 ## v0.12.0 - 2026-06-25
 
 ### Added

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Added
 
-- **Beta:** Sign in with your Google or Facebook account from the new account menu in the top bar. Signing in connects the app to your winds.mobi profile; your avatar and name appear in the menu while signed in.
-- **Beta:** A new Favourites view in the navigation shows the favourite stations from your profile as live cards — the same format as the nearby view — auto-refreshing with the rest of the app and always in your profile's order.
-- **Beta:** A star on the station panel header lets you add or remove that station from your favourites while signed in.
-- **Beta:** A new "Enable beta features" toggle in Settings (off by default) reveals the three items above.
+- **🧪 Beta:** Sign in with your Google or Facebook account from the new account menu in the top bar. Signing in connects the app to your winds.mobi profile; your avatar and name appear in the menu while signed in.
+- **🧪 Beta:** A new Favourites view in the navigation shows the favourite stations from your profile as live cards — the same format as the nearby view — auto-refreshing with the rest of the app and always in your profile's order.
+- **🧪 Beta:** A star on the station panel header lets you add or remove that station from your favourites while signed in.
+- **🧪 Beta:** A new "Enable beta features" toggle in Settings (off by default) reveals the three items above.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- Fixes #100: turning off 3D mode left the map tilted since `handleTerrainChange` only handled the turn-on case
- Documents this fix and the already-shipped settings-cards layout change in the changelog's Unreleased section

## Test plan
- [ ] Manual check in a real browser (`pnpm start`): enable 3D, let it tilt, disable 3D, confirm the map flattens back to top-down — not verifiable in this dev container (no WebGL in headless Chromium)