### PR TITLE
Store favourites locally, disable sign-in

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,11 @@
 Recreate the old winds.mobi login and favourite-stations feature in this client.
 Branch: `feature/login-favourites`.
 
+**Status:** implemented, then the login/SSO half was disabled (kept in place, commented out
+and marked `TODO: Remove login`) once favourites moved to a device-local `localStorage` list
+(`app/services/favorites.ts`) that needs no account. This doc is kept as background for
+whoever restores sign-in; the plan below no longer reflects current behaviour for favourites.
+
 ## Background — how the existing backend actually works (research findings)
 
 The station API (`https://winds.mobi/api/2.3`, Swagger at

--- a/app/authenticators/winds-mobi.ts
+++ b/app/authenticators/winds-mobi.ts
@@ -1,3 +1,5 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
 import Base from 'ember-simple-auth/authenticators/base';
 import { setAuthToken } from 'winds-mobi-client-web/utils/auth-token';
 import { decodeJwtPayload } from 'winds-mobi-client-web/utils/jwt';

--- a/app/builders/profile.ts
+++ b/app/builders/profile.ts
@@ -1,3 +1,8 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts); favorites now persist locally instead (see
+// app/services/favorites.ts). Depends on the `Profile` type and
+// `ProfileSchema`, both commented out in app/services/store.ts — restore
+// those first. Kept for reference/restoration.
 import { SkipCache } from '@warp-drive/core/types/request';
 import type { QueryRequestOptions } from '@warp-drive/core/types/request';
 import { userApiUrl } from 'winds-mobi-client-web/utils/user-api';

--- a/app/components/auth/sign-in-links.gts
+++ b/app/components/auth/sign-in-links.gts
@@ -1,3 +1,7 @@
+// TODO: Remove login — these OAuth sign-in links back the disabled sign-in
+// feature (see app/services/session.ts). Kept for reference; not currently
+// imported anywhere.
+/*
 import { t } from 'ember-intl';
 import FacebookLogo from 'ember-phosphor-icons/components/ph-facebook-logo';
 import GoogleLogo from 'ember-phosphor-icons/components/ph-google-logo';
@@ -34,3 +38,4 @@ const AuthSignInLinks: TOC<AuthSignInLinksSignature> = <template>
 </template>;
 
 export default AuthSignInLinks;
+*/

--- a/app/components/navbar/auth.gts
+++ b/app/components/navbar/auth.gts
@@ -1,3 +1,7 @@
+// TODO: Remove login — this component renders the disabled sign-in/sign-out
+// account menu (see app/services/session.ts). Kept for reference; not
+// currently imported anywhere.
+/*
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -129,3 +133,4 @@ export default class NavbarAuth extends Component<NavbarAuthSignature> {
     </Dropdown>
   </template>
 }
+*/

--- a/app/components/navbar/index.gts
+++ b/app/components/navbar/index.gts
@@ -3,8 +3,11 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import activateMapRefresh from 'winds-mobi-client-web/modifiers/activate-map-refresh';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
-import type SettingsService from 'winds-mobi-client-web/services/settings';
-import NavbarAuth from './auth';
+// TODO: Remove login — SettingsService and NavbarAuth back the disabled
+// sign-in feature (see app/services/session.ts). Restore these imports
+// alongside it.
+// import type SettingsService from 'winds-mobi-client-web/services/settings';
+// import NavbarAuth from './auth';
 import NavbarLogo from './logo';
 import NavbarSearch from './search';
 import NavbarLocateControl from './locate-control';
@@ -22,7 +25,8 @@ export interface NavbarSignature {
 
 export default class Navbar extends Component<NavbarSignature> {
   @service declare mapRefresh: MapRefreshService;
-  @service declare settings: SettingsService;
+  // TODO: Remove login — settings was only injected to gate NavbarAuth.
+  // @service declare settings: SettingsService;
 
   <template>
     <nav
@@ -43,9 +47,11 @@ export default class Navbar extends Component<NavbarSignature> {
           <NavbarLocateControl />
           <NavbarRefreshControl />
 
-          {{#if this.settings.betaFeaturesEnabled}}
-            <NavbarAuth />
-          {{/if}}
+          {{!-- TODO: Remove login — NavbarAuth backs the disabled sign-in
+            feature (see app/services/session.ts). Restore alongside it.
+            {{#if this.settings.betaFeaturesEnabled}}
+              <NavbarAuth />
+            {{/if}} --}}
 
           <NavbarMenuMobile />
         </div>

--- a/app/components/navbar/menu/items.ts
+++ b/app/components/navbar/menu/items.ts
@@ -1,8 +1,8 @@
 import Binoculars from 'ember-phosphor-icons/components/ph-binoculars';
 import MapTrifold from 'ember-phosphor-icons/components/ph-map-trifold';
 import Gear from 'ember-phosphor-icons/components/ph-gear';
+import Heart from 'ember-phosphor-icons/components/ph-heart';
 import Lifebuoy from 'ember-phosphor-icons/components/ph-lifebuoy';
-import Star from 'ember-phosphor-icons/components/ph-star';
 import type { IconComponent } from 'winds-mobi-client-web/utils/icon-component';
 
 export interface NavbarMenuItem {
@@ -23,7 +23,7 @@ export const NAVBAR_MENU_ITEMS: readonly NavbarMenuItem[] = [
     route: 'nearby',
   },
   {
-    icon: Star,
+    icon: Heart,
     labelKey: 'navigation.favorites',
     route: 'favorites',
   },

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -1,39 +1,25 @@
 import Component from '@glimmer/component';
-import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import { Button } from '@frontile/buttons';
-import { getRequestState } from '@warp-drive/core/reactive';
-import type { Future } from '@warp-drive/core/request';
-import { task } from 'ember-concurrency';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
 import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
+import Heart from 'ember-phosphor-icons/components/ph-heart';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
-import Star from 'ember-phosphor-icons/components/ph-star';
-import {
-  addFavorite,
-  profileQuery,
-  removeFavorite,
-} from 'winds-mobi-client-web/builders/profile';
 import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
 import timeAgo, {
   relativeSecondsFromTimestamp,
 } from 'winds-mobi-client-web/helpers/time-ago';
+import type FavoritesService from 'winds-mobi-client-web/services/favorites';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
-import type SessionService from 'winds-mobi-client-web/services/session';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
-import type {
-  Profile,
-  Station,
-  StoreService,
-} from 'winds-mobi-client-web/services/store.js';
+import type { Station } from 'winds-mobi-client-web/services/store.js';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
 import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
-import { responseData } from 'winds-mobi-client-web/utils/request-response';
 import StationMetaItem from './meta-item';
 
 export interface StationHeaderSignature {
@@ -47,10 +33,9 @@ export interface StationHeaderSignature {
 }
 
 export default class StationHeader extends Component<StationHeaderSignature> {
+  @service declare favorites: FavoritesService;
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
-  @service declare session: SessionService;
   @service declare settings: SettingsService;
-  @service declare store: StoreService;
 
   get hasProviderLink() {
     return Boolean(
@@ -58,47 +43,20 @@ export default class StationHeader extends Component<StationHeaderSignature> {
     );
   }
 
-  // Favouriting is a beta feature (see app/services/settings.ts): still
-  // gated on being signed in, but also hidden until beta is opted into.
+  // Favouriting is a beta feature (see app/services/settings.ts): hidden
+  // until beta is opted into. No account is required — favourites persist
+  // locally (see app/services/favorites.ts).
   get showFavoriteControl(): boolean {
-    return this.session.isAuthenticated && this.settings.betaFeaturesEnabled;
-  }
-
-  @cached
-  get profileRequest(): Future<{ data: Profile }> | undefined {
-    if (!this.session.isAuthenticated) {
-      return undefined;
-    }
-
-    return this.store.request<{ data: Profile }>(profileQuery());
-  }
-
-  get profile(): Profile | undefined {
-    const state = this.profileRequest
-      ? getRequestState(this.profileRequest)
-      : undefined;
-
-    return state?.isSuccess ? responseData(state.value) : undefined;
+    return this.settings.betaFeaturesEnabled;
   }
 
   get isFavorite(): boolean {
-    return this.profile?.favorites.includes(this.args.station.id) === true;
+    return this.favorites.has(this.args.station.id);
   }
-
-  // 204s with no body, so a profile refetch updates the shared record (and
-  // with it every star and the favourites view) after the mutation lands.
-  toggleFavorite = task({ drop: true }, async () => {
-    const stationId = this.args.station.id;
-
-    await this.store.request(
-      this.isFavorite ? removeFavorite(stationId) : addFavorite(stationId)
-    );
-    await this.store.request(profileQuery());
-  });
 
   @action
   handleToggleFavorite() {
-    void this.toggleFavorite.perform();
+    this.favorites.toggle(this.args.station.id);
   }
 
   <template>
@@ -126,15 +84,14 @@ export default class StationHeader extends Component<StationHeaderSignature> {
             }}
             aria-pressed={{if this.isFavorite "true" "false"}}
             data-test-station-favorite
-            disabled={{this.toggleFavorite.isRunning}}
             @appearance="minimal"
             @size="sm"
             @onPress={{this.handleToggleFavorite}}
           >
-            <Star
+            <Heart
               @size={{20}}
               @weight={{if this.isFavorite "fill" "regular"}}
-              class={{if this.isFavorite "text-amber-500" "text-slate-400"}}
+              class={{if this.isFavorite "text-rose-500" "text-slate-400"}}
             />
           </Button>
         {{/if}}

--- a/app/controllers/auth-callback.ts
+++ b/app/controllers/auth-callback.ts
@@ -1,3 +1,7 @@
+// TODO: Remove login — paired with the unregistered auth-callback route
+// (see app/router.ts) backing the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference.
+/*
 import Controller from '@ember/controller';
 
 // Declares the `ott` query param so the router materializes it for the
@@ -7,3 +11,4 @@ export default class AuthCallbackController extends Controller {
 
   ott: string | null = null;
 }
+*/

--- a/app/handlers/user.ts
+++ b/app/handlers/user.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Not currently registered in
+// app/services/store.ts's `handlers` array. Kept for reference/restoration.
 import type { Handler, NextFn } from '@warp-drive/core/request';
 import type { RequestContext } from '@warp-drive/core/types/request';
 import { getAuthToken } from 'winds-mobi-client-web/utils/auth-token';

--- a/app/router.ts
+++ b/app/router.ts
@@ -12,7 +12,9 @@ Router.map(function () {
   });
   this.route('nearby');
   this.route('favorites');
-  this.route('auth-callback', { path: '/auth/callback' });
+  // TODO: Remove login — the auth-callback route backs the disabled sign-in
+  // feature (see app/services/session.ts). Restore alongside it.
+  // this.route('auth-callback', { path: '/auth/callback' });
   this.route('settings');
   this.route('help');
 });

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -3,18 +3,23 @@ import { type Registry as Services, service } from '@ember/service';
 import { formats } from 'winds-mobi-client-web/ember-intl';
 import translationsForEnUs from 'virtual:ember-intl/translations/en-us';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
-import type SessionService from 'winds-mobi-client-web/services/session';
+// TODO: Remove login — SessionService backs the disabled sign-in feature
+// (see app/services/session.ts). Restore this import alongside it.
+// import type SessionService from 'winds-mobi-client-web/services/session';
 
 export default class ApplicationRoute extends Route {
   @service declare intl: Services['intl'];
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
-  @service declare session: SessionService;
+  // TODO: Remove login — session service injection, paired with the setup()
+  // call below.
+  // @service declare session: SessionService;
 
   override async beforeModel() {
     await super.beforeModel(...arguments);
 
-    // Restores a persisted session (and its JWT) before anything renders.
-    await this.session.setup();
+    // TODO: Remove login — restores a persisted session (and its JWT)
+    // before anything renders.
+    // await this.session.setup();
 
     this.intl.addTranslations('en-us', translationsForEnUs);
     this.intl.setFormats(formats);

--- a/app/routes/auth-callback.ts
+++ b/app/routes/auth-callback.ts
@@ -1,3 +1,7 @@
+// TODO: Remove login — this route is unregistered (see app/router.ts) and
+// backs the disabled sign-in feature (see app/services/session.ts). Kept
+// for reference.
+/*
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
@@ -42,3 +46,4 @@ export default class AuthCallbackRoute extends Route {
     return { failed: false };
   }
 }
+*/

--- a/app/services/favorites.ts
+++ b/app/services/favorites.ts
@@ -1,0 +1,42 @@
+import Service from '@ember/service';
+import { trackedInLocalStorage } from 'ember-tracked-local-storage';
+
+// Favourite station ids, persisted directly in the browser via
+// ember-tracked-local-storage (see app/services/settings.ts for the same
+// pattern). No account/profile backs this list — sign-in is currently
+// disabled (see app/services/session.ts), so favourites are device-local.
+export default class FavoritesService extends Service {
+  @trackedInLocalStorage({
+    keyName: 'favorites.stationIds',
+    defaultValue: [] as string[],
+  })
+  stationIds!: string[];
+
+  has(stationId: string): boolean {
+    return this.stationIds.includes(stationId);
+  }
+
+  add(stationId: string): void {
+    if (!this.has(stationId)) {
+      this.stationIds = [...this.stationIds, stationId];
+    }
+  }
+
+  remove(stationId: string): void {
+    this.stationIds = this.stationIds.filter((id) => id !== stationId);
+  }
+
+  toggle(stationId: string): void {
+    if (this.has(stationId)) {
+      this.remove(stationId);
+    } else {
+      this.add(stationId);
+    }
+  }
+}
+
+declare module '@ember/service' {
+  interface Registry {
+    favorites: FavoritesService;
+  }
+}

--- a/app/services/session.ts
+++ b/app/services/session.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — sign-in is currently disabled (unregistered route in
+// app/router.ts, no navbar entry point, no session.setup() call). This
+// service is kept for reference/restoration but is not actively wired in.
 import BaseSessionService from 'ember-simple-auth/services/session';
 import type { SessionAuthenticatedData } from 'winds-mobi-client-web/authenticators/winds-mobi';
 

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -52,9 +52,9 @@ export default class SettingsService extends Service {
   })
   useIconLabels!: boolean;
 
-  // Early access to in-development features (currently: sign-in, the
-  // favourites view, and the favourite star). Off by default — see
-  // app/templates/settings.gts for the warning shown alongside this toggle.
+  // Early access to in-development features (currently: the favourites view
+  // and the favourite heart). Off by default — see app/templates/settings.gts
+  // for the warning shown alongside this toggle.
   @trackedInLocalStorage({
     keyName: 'settings.betaFeaturesEnabled',
     defaultValue: false,

--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -2,7 +2,9 @@ import { useLegacyStore } from '@warp-drive/legacy';
 import { JSONAPICache } from '@warp-drive/json-api';
 import StationHandler from 'winds-mobi-client-web/handlers/station';
 import HistoryHandler from 'winds-mobi-client-web/handlers/history';
-import UserHandler from 'winds-mobi-client-web/handlers/user';
+// TODO: Remove login — UserHandler backs the disabled sign-in feature (see
+// app/services/session.ts). Restore this import alongside it.
+// import UserHandler from 'winds-mobi-client-web/handlers/user';
 import { withDefaults } from '@warp-drive/core/reactive';
 import { Type } from '@warp-drive/core/types/symbols';
 
@@ -91,15 +93,17 @@ export const HistorySchema = withDefaults({
   ],
 });
 
-// The authenticated user's profile from the winds-mobi-admin user API.
-export const ProfileSchema = withDefaults({
-  type: 'profile',
-  fields: [
-    { name: 'displayName', kind: 'field' },
-    { name: 'picture', kind: 'field' },
-    { name: 'favorites', kind: 'array' },
-  ],
-});
+// TODO: Remove login — the authenticated user's profile from the
+// winds-mobi-admin user API. Favourites no longer read from this; see
+// app/services/favorites.ts. Restore alongside app/services/session.ts.
+// export const ProfileSchema = withDefaults({
+//   type: 'profile',
+//   fields: [
+//     { name: 'displayName', kind: 'field' },
+//     { name: 'picture', kind: 'field' },
+//     { name: 'favorites', kind: 'array' },
+//   ],
+// });
 
 export type Station = {
   id: string;
@@ -124,14 +128,15 @@ export type Station = {
   [Type]: 'station';
 };
 
-export type Profile = {
-  id: string;
-  displayName?: string;
-  picture?: string;
-  favorites: string[];
-
-  [Type]: 'profile';
-};
+// TODO: Remove login — Profile type paired with ProfileSchema above.
+// export type Profile = {
+//   id: string;
+//   displayName?: string;
+//   picture?: string;
+//   favorites: string[];
+//
+//   [Type]: 'profile';
+// };
 
 export type History = {
   id: string;
@@ -197,10 +202,12 @@ const AppStore = useLegacyStore({
   legacyRequests: true,
   modelFragments: true,
   cache: JSONAPICache,
-  schemas: [LocationSchema, StationSchema, HistorySchema, ProfileSchema],
-  // UserHandler must run first: it owns the user-API requests (auth header
-  // + profile reshaping) before the station/history reshapers see them.
-  handlers: [UserHandler, StationHandler, HistoryHandler],
+  // TODO: Remove login — ProfileSchema was listed here; restore alongside it.
+  schemas: [LocationSchema, StationSchema, HistorySchema],
+  // TODO: Remove login — UserHandler ran first here: it owns the user-API
+  // requests (auth header + profile reshaping) and must run before the
+  // station/history reshapers see them. Restore alongside it.
+  handlers: [StationHandler, HistoryHandler],
   derivations: [unwrapDerivation, composeReadingDerivation],
 });
 

--- a/app/session-stores/application.ts
+++ b/app/session-stores/application.ts
@@ -1,3 +1,5 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
 import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
 
 // localStorage-backed (with cookie fallback) so the 30-day JWT survives

--- a/app/templates/auth-callback.gts
+++ b/app/templates/auth-callback.gts
@@ -1,3 +1,7 @@
+// TODO: Remove login — paired with the unregistered auth-callback route
+// (see app/router.ts) backing the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference.
+/*
 import { LinkTo } from '@ember/routing';
 import { pageTitle } from 'ember-page-title';
 import { t } from 'ember-intl';
@@ -56,3 +60,4 @@ const AuthCallbackTemplate: TOC<AuthCallbackTemplateSignature> = <template>
 </template>;
 
 export default AuthCallbackTemplate;
+*/

--- a/app/templates/favorites.gts
+++ b/app/templates/favorites.gts
@@ -6,16 +6,13 @@ import { getRequestState } from '@warp-drive/core/reactive';
 import { pageTitle } from 'ember-page-title';
 import { t } from 'ember-intl';
 import { favoritesQuery } from 'winds-mobi-client-web/builders/station';
-import { profileQuery } from 'winds-mobi-client-web/builders/profile';
-import AuthSignInLinks from 'winds-mobi-client-web/components/auth/sign-in-links';
 import StationNearbyCard from 'winds-mobi-client-web/components/station/nearby-card';
 import StationSectionCard from 'winds-mobi-client-web/components/station/section-card';
 import commitResolvedStations from 'winds-mobi-client-web/modifiers/commit-resolved-stations';
 import registerLoadingProbe from 'winds-mobi-client-web/modifiers/register-loading-probe';
+import type FavoritesService from 'winds-mobi-client-web/services/favorites';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
-import type SessionService from 'winds-mobi-client-web/services/session';
 import type {
-  Profile,
   Station,
   StoreService,
 } from 'winds-mobi-client-web/services/store';
@@ -28,39 +25,22 @@ interface FavoritesTemplateSignature {
 }
 
 export default class FavoritesTemplate extends Component<FavoritesTemplateSignature> {
+  @service declare favorites: FavoritesService;
   @service declare mapRefresh: MapRefreshService;
-  @service declare session: SessionService;
   @service declare store: StoreService;
 
-  @cached
-  get profileRequest(): Future<{ data: Profile }> | undefined {
-    if (!this.session.isAuthenticated) {
-      return undefined;
-    }
-
-    return this.store.request<{ data: Profile }>(profileQuery());
+  get favoriteIds(): string[] {
+    return this.favorites.stationIds;
   }
 
-  get profileState() {
-    return this.profileRequest
-      ? getRequestState(this.profileRequest)
-      : undefined;
-  }
-
-  get favoriteIds(): string[] | undefined {
-    const state = this.profileState;
-
-    return state?.isSuccess ? responseData(state.value).favorites : undefined;
-  }
-
-  // Recreated when the profile's favorites change or the shared refresh tick
+  // Recreated when the favourite ids change or the shared refresh tick
   // fires — same shape as the nearby view: no `backgroundReload`, the latch
   // below keeps the previous cards on screen while a reload is in flight.
   @cached
   get stationsRequest(): Future<{ data: Station[] }> | undefined {
     const ids = this.favoriteIds;
 
-    if (!ids || ids.length === 0) {
+    if (ids.length === 0) {
       return undefined;
     }
 
@@ -91,10 +71,9 @@ export default class FavoritesTemplate extends Component<FavoritesTemplateSignat
       ? responseData(this.requestState.value)
       : this.lastStations;
 
-    // The API doesn't guarantee `ids` order — present in profile order.
-    const order = new Map(
-      (this.favoriteIds ?? []).map((id, index) => [id, index])
-    );
+    // The API doesn't guarantee response order — present in the order
+    // favourites were added.
+    const order = new Map(this.favoriteIds.map((id, index) => [id, index]));
 
     return [...stations].sort(
       (a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0)
@@ -102,12 +81,9 @@ export default class FavoritesTemplate extends Component<FavoritesTemplateSignat
   }
 
   // Reports to the shared refresh service whether this view is loading, so
-  // the navbar refresh control spins while either request is in flight.
+  // the navbar refresh control spins while the request is in flight.
   loadingProbe = (): boolean => {
-    return (
-      this.requestState?.isPending === true ||
-      this.profileState?.isPending === true
-    );
+    return this.requestState?.isPending === true;
   };
 
   get isInitialLoad(): boolean {
@@ -115,13 +91,11 @@ export default class FavoritesTemplate extends Component<FavoritesTemplateSignat
   }
 
   get isError(): boolean {
-    return (
-      this.requestState?.isError === true || this.profileState?.isError === true
-    );
+    return this.requestState?.isError === true;
   }
 
   get hasNoFavorites(): boolean {
-    return this.favoriteIds?.length === 0;
+    return this.favoriteIds.length === 0;
   }
 
   <template>
@@ -133,60 +107,43 @@ export default class FavoritesTemplate extends Component<FavoritesTemplateSignat
       {{registerLoadingProbe this.mapRefresh this.loadingProbe}}
     >
       <div class="flex w-full flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-        {{#if this.session.isAuthenticated}}
-          {{#if this.isError}}
-            <StationSectionCard
-              data-test-favorites-error
-              @title={{t "favorites.title"}}
-              @titleClass="text-rose-700"
-            >
-              <p class="py-10 text-center text-sm font-medium text-rose-700">
-                {{t "favorites.requestError"}}
-              </p>
-            </StationSectionCard>
-          {{else if this.hasNoFavorites}}
-            <StationSectionCard
-              data-test-favorites-empty
-              @title={{t "favorites.title"}}
-            >
-              <p class="py-10 text-center text-sm font-medium text-slate-500">
-                {{t "favorites.empty"}}
-              </p>
-            </StationSectionCard>
-          {{else if this.isInitialLoad}}
-            <StationSectionCard
-              data-test-favorites-loading
-              @title={{t "favorites.title"}}
-            >
-              <p class="py-10 text-center text-sm font-medium text-slate-500">
-                {{t "favorites.loading"}}
-              </p>
-            </StationSectionCard>
-          {{else}}
-            <div
-              class="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(22rem,1fr))]"
-              data-test-favorites-stations
-            >
-              {{#each this.stations as |station|}}
-                <StationNearbyCard @station={{station}} />
-              {{/each}}
-            </div>
-          {{/if}}
-        {{else}}
+        {{#if this.isError}}
           <StationSectionCard
-            data-test-favorites-signed-out
+            data-test-favorites-error
+            @title={{t "favorites.title"}}
+            @titleClass="text-rose-700"
+          >
+            <p class="py-10 text-center text-sm font-medium text-rose-700">
+              {{t "favorites.requestError"}}
+            </p>
+          </StationSectionCard>
+        {{else if this.hasNoFavorites}}
+          <StationSectionCard
+            data-test-favorites-empty
             @title={{t "favorites.title"}}
           >
-            <div class="max-w-2xl">
-              <p class="text-sm leading-6 text-slate-600">
-                {{t "favorites.signedOut"}}
-              </p>
-
-              <div class="mt-4">
-                <AuthSignInLinks />
-              </div>
-            </div>
+            <p class="py-10 text-center text-sm font-medium text-slate-500">
+              {{t "favorites.empty"}}
+            </p>
           </StationSectionCard>
+        {{else if this.isInitialLoad}}
+          <StationSectionCard
+            data-test-favorites-loading
+            @title={{t "favorites.title"}}
+          >
+            <p class="py-10 text-center text-sm font-medium text-slate-500">
+              {{t "favorites.loading"}}
+            </p>
+          </StationSectionCard>
+        {{else}}
+          <div
+            class="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(22rem,1fr))]"
+            data-test-favorites-stations
+          >
+            {{#each this.stations as |station|}}
+              <StationNearbyCard @station={{station}} />
+            {{/each}}
+          </div>
         {{/if}}
       </div>
     </section>

--- a/app/utils/auth-token.ts
+++ b/app/utils/auth-token.ts
@@ -1,3 +1,5 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
 // Module-scope mirror of the session's JWT for the Warp Drive request layer:
 // handlers are registered at module scope in app/services/store.ts and have
 // no service injection, so they can't read the ember-simple-auth session

--- a/app/utils/jwt.ts
+++ b/app/utils/jwt.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — only used by app/authenticators/winds-mobi.ts, which
+// backs the disabled sign-in feature (see app/services/session.ts). Kept
+// for reference/restoration.
 export interface JwtPayload {
   username?: string;
   exp?: number;

--- a/app/utils/user-api.ts
+++ b/app/utils/user-api.ts
@@ -1,3 +1,5 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
 // The user/auth API lives in winds-mobi-admin (Django), served under
 // https://winds.mobi/user/ — a separate service from the station API
 // configured via setBuildURLConfig in app/app.ts.

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.14.0 - 2026-07-10
+
+### Changed
+
+- **🧪 Beta:** Favouriting a station no longer requires signing in — starring a station now saves it directly in this browser, so favourites work right away and stay put across visits on this device. The favourite icon on the station panel is now a heart instead of a star.
+
+### Removed
+
+- **🧪 Beta:** Removed sign-in with Google or Facebook and the account menu, introduced in v0.13.0. Favourites no longer depend on a winds.mobi profile.
+
 ## v0.13.0 - 2026-07-09
 
 ### Added

--- a/tests/acceptance/app-walkthrough-test.ts
+++ b/tests/acceptance/app-walkthrough-test.ts
@@ -5,20 +5,15 @@ import {
   currentURL,
   fillIn,
   find,
-  settled,
   visit,
   waitFor,
   waitUntil,
 } from '@ember/test-helpers';
-import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Type } from '@warp-drive/core/types/symbols';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
+import type FavoritesService from 'winds-mobi-client-web/services/favorites';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
-import type {
-  History,
-  Profile,
-  Station,
-} from 'winds-mobi-client-web/services/store';
+import type { History, Station } from 'winds-mobi-client-web/services/store';
 
 // A single continuous walk through the app's main routes and interactions,
 // on top of (not instead of) the focused per-route/per-feature acceptance
@@ -115,29 +110,12 @@ const HISTORY_FIXTURES: History[] = [
 
 class FakeStoreService extends Service {
   calls: { method: string; url: string }[] = [];
-  favorites: string[] = [];
 
   request(request: FakeStoreRequest) {
     const url = request.url ?? '';
     const method = request.method ?? 'GET';
 
     this.calls.push({ method, url });
-
-    if (url.includes('/user/profile/favorites/')) {
-      return Promise.resolve({ content: null });
-    }
-
-    if (url.includes('/user/profile/')) {
-      const profile: Profile = {
-        id: 'google-123',
-        displayName: 'Michal',
-        picture: 'https://example.com/avatar.png',
-        favorites: [...this.favorites],
-        [Type]: 'profile',
-      };
-
-      return Promise.resolve({ content: { data: profile } });
-    }
 
     if (url.includes('/historic/')) {
       return Promise.resolve({ content: { data: HISTORY_FIXTURES } });
@@ -189,10 +167,6 @@ function stubGrantedPermission(nearbyLocation: NearbyLocationService) {
       longitude: 7.9,
     };
   };
-}
-
-function favoriteMutations(calls: { method: string; url: string }[]) {
-  return calls.filter(({ url }) => url.includes('/user/profile/favorites/'));
 }
 
 module('Acceptance | app walkthrough', function (hooks) {
@@ -252,42 +226,38 @@ module('Acceptance | app walkthrough', function (hooks) {
     assert.strictEqual(currentURL(), '/help');
     assert.dom('[data-test-help-changelog]').exists();
 
-    // Never signed in, so no favorite/profile requests were made.
-    const store = this.owner.lookup('service:store') as FakeStoreService;
-    assert.strictEqual(favoriteMutations(store.calls).length, 0);
+    // No station was favourited along the way.
+    const favorites = this.owner.lookup(
+      'service:favorites'
+    ) as FavoritesService;
+
+    assert.deepEqual(favorites.stationIds, []);
   });
 
-  test('a signed-in visitor favourites a station and finds it again in favourites', async function (assert) {
+  test('a visitor favourites a station and finds it again in favourites', async function (assert) {
     this.owner.lookup('service:settings').betaFeaturesEnabled = true;
-    await authenticateSession();
 
     await visit('/map/holfuy-1804?latitude=46.67719&longitude=7.86323&zoom=13');
     await waitFor('[data-test-station-favorite]');
 
-    const store = this.owner.lookup('service:store') as FakeStoreService;
+    const favorites = this.owner.lookup(
+      'service:favorites'
+    ) as FavoritesService;
 
     assert
       .dom('[data-test-station-favorite]')
       .hasAria('pressed', 'false', 'not yet a favourite');
 
-    // Star the open station. The panel's own profile request is cached for
-    // the life of this mount (see the header component's `@cached
-    // profileRequest`), so — same as station-favorite-test.ts — we assert
-    // the mutation fired rather than an in-place visual flip; the fake store
-    // has no shared cache to reactively update an already-mounted request.
-    // `store.favorites` below stands in for "the backend now reflects this,"
-    // which the *next* fresh mount (the favourites route, then reopening the
-    // station) will correctly read.
-    store.favorites = ['holfuy-1804'];
+    // Star the open station.
     await click('[data-test-station-favorite]');
 
-    let mutations = favoriteMutations(store.calls);
-    assert.strictEqual(mutations.length, 1);
-    assert.strictEqual(mutations[0]?.method, 'POST');
+    assert
+      .dom('[data-test-station-favorite]')
+      .hasAria('pressed', 'true', 'the star reflects the new favourite');
+    assert.deepEqual(favorites.stationIds, ['holfuy-1804']);
 
-    // Jump to the favourites view from the account menu.
-    await click('[data-test-navbar-auth]');
-    await click('[data-test-navbar-auth-item="favorites"]');
+    // Jump to the favourites view from the nav menu.
+    await click('[data-test-navbar-link="favorites"]');
     assert.strictEqual(currentURL(), '/favorites');
 
     assert
@@ -304,16 +274,12 @@ module('Acceptance | app walkthrough', function (hooks) {
       .hasAria('pressed', 'true', 'the fresh mount picks up the favourite');
 
     // Unstar it.
-    store.favorites = [];
     await click('[data-test-station-favorite]');
 
-    mutations = favoriteMutations(store.calls);
-    assert.strictEqual(mutations.length, 2, 'one add and one remove');
-    assert.strictEqual(mutations[1]?.method, 'DELETE');
+    assert.deepEqual(favorites.stationIds, []);
 
     // Back in favourites, a fresh mount shows the now-empty list.
-    await click('[data-test-navbar-auth]');
-    await click('[data-test-navbar-auth-item="favorites"]');
+    await click('[data-test-navbar-link="favorites"]');
     await waitFor('[data-test-favorites-empty]');
 
     assert.dom('[data-test-nearby-station-card]').doesNotExist();

--- a/tests/acceptance/auth-callback-test.ts
+++ b/tests/acceptance/auth-callback-test.ts
@@ -1,3 +1,7 @@
+// TODO: Remove login — the auth-callback route is unregistered (see
+// app/router.ts) and backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
+/*
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import {
@@ -98,3 +102,4 @@ module('Acceptance | auth callback', function (hooks) {
     assert.true(this.owner.lookup('service:session').isAuthenticated);
   });
 });
+*/

--- a/tests/acceptance/beta-features-test.ts
+++ b/tests/acceptance/beta-features-test.ts
@@ -1,17 +1,15 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { click, visit, waitFor } from '@ember/test-helpers';
-import { authenticateSession } from 'ember-simple-auth/test-support';
 import { Type } from '@warp-drive/core/types/symbols';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
-import type { Profile, Station } from 'winds-mobi-client-web/services/store';
+import type { Station } from 'winds-mobi-client-web/services/store';
 
-// Login, the favourites view, and the favourite star are beta features (see
+// The favourites view and the favourite heart are beta features (see
 // app/services/settings.ts): hidden by default, revealed once a visitor
 // opts into "Enable beta features" in Settings. This file covers the
 // gating itself; the features' own behaviour once visible is covered by
-// navbar-auth-test.ts, favorites-route-test.ts, and station-favorite-test.ts
-// (which all opt into beta in their own setup).
+// favorites-route-test.ts and station-favorite-test.ts.
 
 type FakeStoreRequest = {
   url?: string;
@@ -39,20 +37,9 @@ const STATION_FIXTURE: Station = {
   [Type]: 'station',
 };
 
-const PROFILE_FIXTURE: Profile = {
-  id: 'google-123',
-  displayName: 'Michal',
-  favorites: [],
-  [Type]: 'profile',
-};
-
 class FakeStoreService extends Service {
   request(request: FakeStoreRequest) {
     const url = request.url ?? '';
-
-    if (url.includes('/user/profile/')) {
-      return Promise.resolve({ content: { data: PROFILE_FIXTURE } });
-    }
 
     if (url.includes('/historic/')) {
       return Promise.resolve({ content: { data: [] } });
@@ -73,10 +60,9 @@ module('Acceptance | beta features gating', function (hooks) {
     this.owner.register('service:store', FakeStoreService);
   });
 
-  test('login and the favourites nav link are hidden by default', async function (assert) {
+  test('the favourites nav link is hidden by default', async function (assert) {
     await visit('/map/holfuy-1804');
 
-    assert.dom('[data-test-navbar-auth]').doesNotExist();
     assert.dom('[data-test-navbar-link="favorites"]').doesNotExist();
 
     await click('[data-test-navbar-mobile-menu-button]');
@@ -85,27 +71,24 @@ module('Acceptance | beta features gating', function (hooks) {
       .doesNotExist();
   });
 
-  test('the favourite star is hidden by default even when signed in', async function (assert) {
-    await authenticateSession();
+  test('the favourite heart is hidden by default', async function (assert) {
     await visit('/map/holfuy-1804');
 
     assert.dom('[data-test-station-title]').exists();
     assert.dom('[data-test-station-favorite]').doesNotExist();
   });
 
-  test('enabling beta features in settings reveals login and the favourites nav link', async function (assert) {
+  test('enabling beta features in settings reveals the favourites nav link', async function (assert) {
     await visit('/settings');
 
-    assert.dom('[data-test-navbar-auth]').doesNotExist();
+    assert.dom('[data-test-navbar-link="favorites"]').doesNotExist();
 
     await click('[data-test-setting="betaFeaturesEnabled"]');
 
-    assert.dom('[data-test-navbar-auth]').exists();
     assert.dom('[data-test-navbar-link="favorites"]').exists();
   });
 
-  test('enabling beta features reveals the favourite star for a signed-in visitor', async function (assert) {
-    await authenticateSession();
+  test('enabling beta features reveals the favourite heart', async function (assert) {
     await visit('/settings');
 
     await click('[data-test-setting="betaFeaturesEnabled"]');

--- a/tests/acceptance/favorites-route-test.ts
+++ b/tests/acceptance/favorites-route-test.ts
@@ -1,10 +1,10 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { findAll, visit, waitFor } from '@ember/test-helpers';
-import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
-import type { Profile, Station } from 'winds-mobi-client-web/services/store';
+import type FavoritesService from 'winds-mobi-client-web/services/favorites';
+import type { Station } from 'winds-mobi-client-web/services/store';
 
 type FakeStoreRequest = {
   url?: string;
@@ -55,31 +55,13 @@ const STATION_FIXTURES: Station[] = [
   },
 ];
 
-// Reversed relative to STATION_FIXTURES to pin the profile-order sorting.
-const PROFILE_FIXTURE: Profile = {
-  id: 'google-123',
-  displayName: 'Michal',
-  picture: 'https://example.com/avatar.png',
-  favorites: ['holfuy-2222', 'holfuy-1804'],
-  [Type]: 'profile',
-};
-
 class FakeStoreService extends Service {
   calls: string[] = [];
-  profile: Profile = PROFILE_FIXTURE;
 
   request(request: FakeStoreRequest) {
     const url = request.url ?? '';
 
     this.calls.push(url);
-
-    if (url.includes('/user/profile/')) {
-      return Promise.resolve({
-        content: {
-          data: this.profile,
-        },
-      });
-    }
 
     return Promise.resolve({
       content: {
@@ -87,10 +69,6 @@ class FakeStoreService extends Service {
       },
     });
   }
-}
-
-function countProfileRequests(calls: string[]) {
-  return calls.filter((url) => url.includes('/user/profile/')).length;
 }
 
 function countStationRequests(calls: string[]) {
@@ -107,16 +85,15 @@ module('Acceptance | favorites route', function (hooks) {
     this.owner.lookup('service:settings').betaFeaturesEnabled = true;
   });
 
-  test('signed out it shows the sign-in prompt and requests nothing', async function (assert) {
+  test('with no favourites it shows the empty state and skips the station request', async function (assert) {
     const store = this.owner.lookup('service:store') as FakeStoreService;
 
     await visit('/favorites');
+    await waitFor('[data-test-favorites-empty]');
 
-    assert.dom('[data-test-favorites-signed-out]').exists();
-    assert.dom('[data-test-auth-sign-in="google"]').exists();
-    assert.dom('[data-test-auth-sign-in="facebook"]').exists();
+    assert.dom('[data-test-favorites-empty]').exists();
     assert.dom(FAVORITES_CARD_SELECTOR).doesNotExist();
-    assert.strictEqual(store.calls.length, 0);
+    assert.strictEqual(countStationRequests(store.calls), 0);
   });
 
   test('the navbar links to the favourites view', async function (assert) {
@@ -125,17 +102,18 @@ module('Acceptance | favorites route', function (hooks) {
     assert.dom('[data-test-navbar-link="favorites"]').exists();
   });
 
-  test('signed in it renders the favourite stations in profile order', async function (assert) {
-    const store = this.owner.lookup('service:store') as FakeStoreService;
+  test('it renders the favourite stations in the order they were added', async function (assert) {
+    const favorites = this.owner.lookup(
+      'service:favorites'
+    ) as FavoritesService;
 
-    await authenticateSession();
+    // Added in reverse of STATION_FIXTURES to pin the ordering behaviour.
+    favorites.add('holfuy-2222');
+    favorites.add('holfuy-1804');
+
     await visit('/favorites');
 
-    assert.dom('[data-test-favorites-signed-out]').doesNotExist();
-    // The navbar account menu fetches the profile too — assert presence,
-    // not an exact count.
-    assert.true(countProfileRequests(store.calls) >= 1);
-    assert.true(countStationRequests(store.calls) > 0);
+    assert.dom('[data-test-favorites-empty]').doesNotExist();
 
     const titles = findAll(
       `${FAVORITES_CARD_SELECTOR} [data-test-station-title]`
@@ -144,25 +122,7 @@ module('Acceptance | favorites route', function (hooks) {
     assert.deepEqual(
       titles,
       ['Holfuy 2222', 'Holfuy 1804'],
-      'cards follow the profile favorites order, not the response order'
+      'cards follow the order favourites were added, not the response order'
     );
-  });
-
-  test('signed in with no favourites it shows the empty state and skips the station request', async function (assert) {
-    const store = this.owner.lookup('service:store') as FakeStoreService;
-
-    store.profile = {
-      ...PROFILE_FIXTURE,
-      favorites: [],
-    };
-
-    await authenticateSession();
-    await visit('/favorites');
-
-    await waitFor('[data-test-favorites-empty]');
-
-    assert.dom('[data-test-favorites-empty]').exists();
-    assert.dom(FAVORITES_CARD_SELECTOR).doesNotExist();
-    assert.strictEqual(countStationRequests(store.calls), 0);
   });
 });

--- a/tests/acceptance/navbar-auth-test.ts
+++ b/tests/acceptance/navbar-auth-test.ts
@@ -1,3 +1,7 @@
+// TODO: Remove login — NavbarAuth is unmounted (see
+// app/components/navbar/index.gts) and backs the disabled sign-in feature
+// (see app/services/session.ts). Kept for reference/restoration.
+/*
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { click, currentRouteName, visit } from '@ember/test-helpers';
@@ -88,3 +92,4 @@ module('Acceptance | navbar auth menu', function (hooks) {
     assert.dom('[data-test-navbar-auth-avatar]').doesNotExist();
   });
 });
+*/

--- a/tests/acceptance/station-favorite-test.ts
+++ b/tests/acceptance/station-favorite-test.ts
@@ -1,18 +1,13 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { click, visit, waitFor } from '@ember/test-helpers';
-import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
-import type {
-  History,
-  Profile,
-  Station,
-} from 'winds-mobi-client-web/services/store';
+import type FavoritesService from 'winds-mobi-client-web/services/favorites';
+import type { History, Station } from 'winds-mobi-client-web/services/store';
 
 type FakeStoreRequest = {
   url?: string;
-  method?: string;
 };
 
 const STATION_FIXTURE: Station = {
@@ -52,51 +47,15 @@ const HISTORY_FIXTURES: History[] = [
 ];
 
 class FakeStoreService extends Service {
-  calls: { method: string; url: string }[] = [];
-  favorites: string[] = [];
-
   request(request: FakeStoreRequest) {
     const url = request.url ?? '';
-    const method = request.method ?? 'GET';
-
-    this.calls.push({ method, url });
-
-    if (url.includes('/user/profile/favorites/')) {
-      return Promise.resolve({ content: null });
-    }
-
-    if (url.includes('/user/profile/')) {
-      const profile: Profile = {
-        id: 'google-123',
-        displayName: 'Michal',
-        favorites: [...this.favorites],
-        [Type]: 'profile',
-      };
-
-      return Promise.resolve({ content: { data: profile } });
-    }
 
     if (url.includes('/historic/')) {
       return Promise.resolve({ content: { data: HISTORY_FIXTURES } });
     }
 
-    if (url.includes(`/stations/${STATION_FIXTURE.id}?`)) {
-      return Promise.resolve({ content: { data: STATION_FIXTURE } });
-    }
-
-    return Promise.resolve({ content: { data: [STATION_FIXTURE] } });
+    return Promise.resolve({ content: { data: STATION_FIXTURE } });
   }
-}
-
-function favoriteMutations(calls: { method: string; url: string }[]) {
-  return calls.filter(({ url }) => url.includes('/user/profile/favorites/'));
-}
-
-function profileReads(calls: { method: string; url: string }[]) {
-  return calls.filter(
-    ({ url, method }) =>
-      method === 'GET' && /\/user\/profile\/$/.test(url.split('?')[0] ?? url)
-  );
 }
 
 module('Acceptance | station favorite toggle', function (hooks) {
@@ -107,17 +66,16 @@ module('Acceptance | station favorite toggle', function (hooks) {
     this.owner.lookup('service:settings').betaFeaturesEnabled = true;
   });
 
-  test('signed out there is no star on the station panel', async function (assert) {
+  test('with beta features off there is no favourite control', async function (assert) {
+    this.owner.lookup('service:settings').betaFeaturesEnabled = false;
+
     await visit('/map/holfuy-1804');
 
     assert.dom('[data-test-station-title]').exists();
     assert.dom('[data-test-station-favorite]').doesNotExist();
   });
 
-  test('starring a station posts the favorite and refetches the profile', async function (assert) {
-    const store = this.owner.lookup('service:store') as FakeStoreService;
-
-    await authenticateSession();
+  test('starring a station saves it to the local favourites list', async function (assert) {
     await visit('/map/holfuy-1804');
     await waitFor('[data-test-station-favorite]');
 
@@ -126,30 +84,27 @@ module('Acceptance | station favorite toggle', function (hooks) {
       .hasAria('label', 'Add to favourites')
       .hasAria('pressed', 'false');
 
-    const profileReadsBefore = profileReads(store.calls).length;
-
-    store.favorites = ['holfuy-1804'];
     await click('[data-test-station-favorite]');
 
-    const mutations = favoriteMutations(store.calls);
+    assert
+      .dom('[data-test-station-favorite]')
+      .hasAria('label', 'Remove from favourites')
+      .hasAria('pressed', 'true');
 
-    assert.strictEqual(mutations.length, 1);
-    assert.strictEqual(mutations[0]?.method, 'POST');
-    assert.true(
-      mutations[0]?.url.endsWith('/user/profile/favorites/holfuy-1804/')
-    );
-    assert.true(
-      profileReads(store.calls).length > profileReadsBefore,
-      'the profile is refetched after the mutation'
-    );
+    const favorites = this.owner.lookup(
+      'service:favorites'
+    ) as FavoritesService;
+
+    assert.deepEqual(favorites.stationIds, ['holfuy-1804']);
   });
 
-  test('unstarring a favourite station issues a delete', async function (assert) {
-    const store = this.owner.lookup('service:store') as FakeStoreService;
+  test('unstarring a favourite station removes it from the local list', async function (assert) {
+    const favorites = this.owner.lookup(
+      'service:favorites'
+    ) as FavoritesService;
 
-    store.favorites = ['holfuy-1804'];
+    favorites.add('holfuy-1804');
 
-    await authenticateSession();
     await visit('/map/holfuy-1804');
     await waitFor('[data-test-station-favorite]');
 
@@ -158,12 +113,13 @@ module('Acceptance | station favorite toggle', function (hooks) {
       .hasAria('label', 'Remove from favourites')
       .hasAria('pressed', 'true');
 
-    store.favorites = [];
     await click('[data-test-station-favorite]');
 
-    const mutations = favoriteMutations(store.calls);
+    assert
+      .dom('[data-test-station-favorite]')
+      .hasAria('label', 'Add to favourites')
+      .hasAria('pressed', 'false');
 
-    assert.strictEqual(mutations.length, 1);
-    assert.strictEqual(mutations[0]?.method, 'DELETE');
+    assert.deepEqual(favorites.stationIds, []);
   });
 });

--- a/tests/integration/components/auth/sign-in-links-test.ts
+++ b/tests/integration/components/auth/sign-in-links-test.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — Auth::SignInLinks backs the disabled sign-in feature
+// (see app/services/session.ts). Kept for reference/restoration.
+/*
 import { module, test } from 'qunit';
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -28,3 +31,4 @@ module('Integration | Component | auth/sign-in-links', function (hooks) {
     );
   });
 });
+*/

--- a/tests/unit/authenticators/winds-mobi-test.ts
+++ b/tests/unit/authenticators/winds-mobi-test.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — this authenticator backs the disabled sign-in
+// feature (see app/services/session.ts). Kept for reference/restoration.
+/*
 import { module, test } from 'qunit';
 import { setupTest } from 'winds-mobi-client-web/tests/helpers';
 import type WindsMobiAuthenticator from 'winds-mobi-client-web/authenticators/winds-mobi';
@@ -132,3 +135,4 @@ module('Unit | Authenticator | winds-mobi', function (hooks) {
     assert.strictEqual(getAuthToken(), null);
   });
 });
+*/

--- a/tests/unit/builders/profile-test.ts
+++ b/tests/unit/builders/profile-test.ts
@@ -1,3 +1,7 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts); favorites now persist locally instead (see
+// app/services/favorites.ts). Kept for reference/restoration.
+/*
 import { module, test } from 'qunit';
 import { SkipCache } from '@warp-drive/core/types/request';
 import {
@@ -51,3 +55,4 @@ module('Unit | Builder | profile', function () {
     );
   });
 });
+*/

--- a/tests/unit/handlers/user-test.ts
+++ b/tests/unit/handlers/user-test.ts
@@ -1,3 +1,7 @@
+// TODO: Remove login — UserHandler backs the disabled sign-in feature (see
+// app/services/session.ts) and is unregistered in app/services/store.ts.
+// Kept for reference/restoration.
+/*
 import { module, test } from 'qunit';
 import UserHandler from 'winds-mobi-client-web/handlers/user';
 import { setAuthToken } from 'winds-mobi-client-web/utils/auth-token';
@@ -145,3 +149,4 @@ module('Unit | Handler | user', function (hooks) {
     assert.false('displayName' in response.data.attributes);
   });
 });
+*/

--- a/tests/unit/utils/auth-token-test.ts
+++ b/tests/unit/utils/auth-token-test.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
+/*
 import { module, test } from 'qunit';
 import {
   getAuthToken,
@@ -23,3 +26,4 @@ module('Unit | Utility | auth-token', function (hooks) {
     assert.strictEqual(getAuthToken(), null);
   });
 });
+*/

--- a/tests/unit/utils/user-api-test.ts
+++ b/tests/unit/utils/user-api-test.ts
@@ -1,3 +1,6 @@
+// TODO: Remove login — backs the disabled sign-in feature (see
+// app/services/session.ts). Kept for reference/restoration.
+/*
 import { module, test } from 'qunit';
 import { signInUrl, userApiUrl } from 'winds-mobi-client-web/utils/user-api';
 
@@ -28,3 +31,4 @@ module('Unit | Utility | user-api', function () {
     assert.true(signInUrl('google').includes('/user/google/oauth2callback/'));
   });
 });
+*/

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,21 +1,23 @@
 application:
   name: winds.mobi
 
-auth:
-  menu:
-    label: Account
-    signOut: Sign out
-  signIn:
-    google: Sign in with Google
-    facebook: Sign in with Facebook
-  callback:
-    title: Signing in
-    pending: Signing you in…
-    failedTitle: Sign-in failed
-    failed: >-
-      The sign-in link has expired or was already used. Please try signing in
-      again.
-    backToMap: Back to the map
+# TODO: Remove login — these strings back the disabled sign-in feature (see
+# app/services/session.ts). Kept for reference/restoration.
+# auth:
+#   menu:
+#     label: Account
+#     signOut: Sign out
+#   signIn:
+#     google: Sign in with Google
+#     facebook: Sign in with Facebook
+#   callback:
+#     title: Signing in
+#     pending: Signing you in…
+#     failedTitle: Sign-in failed
+#     failed: >-
+#       The sign-in link has expired or was already used. Please try signing in
+#       again.
+#     backToMap: Back to the map
 
 common:
   close: Close
@@ -25,11 +27,13 @@ favorites:
   loading: Loading your favourite stations…
   requestError: Your favourite stations could not be loaded right now.
   empty: >-
-    Your profile has no favourite stations yet. Stations you star show up
-    here with their live readings.
-  signedOut: >-
-    Sign in to see the favourite stations from your winds.mobi profile and
-    compare their live readings at a glance.
+    You have no favourite stations yet. Stations you favourite show up here
+    with their live readings.
+  # TODO: Remove login — shown when signed out; sign-in is currently disabled
+  # (see app/services/session.ts). Kept for reference/restoration.
+  # signedOut: >-
+  #   Sign in to see the favourite stations from your winds.mobi profile and
+  #   compare their live readings at a glance.
 
 navigation:
   menu: Menu


### PR DESCRIPTION
## Summary
- Favourites now persist in `localStorage` via a new `app/services/favorites.ts` (same pattern as `app/services/settings.ts`) instead of the winds.mobi profile — no account needed. The favourite icon is a heart everywhere instead of a star.
- Sign-in (Google/Facebook OAuth, session service, account menu, `/auth/callback`, user-API handler/profile builder/schema) is disabled but kept in the codebase, commented out and marked `TODO: Remove login`, so it can be restored later.
- Tests updated to match: favourites tests seed/assert through `service:favorites` instead of an authenticated session; sign-in-only test files are commented out in place.
- CHANGELOG bumped to v0.14.0.

## Test plan
- [x] `pnpm lint` — passes (stylelint, ember-template-lint, prettier)
- [x] `pnpm test:ember` — full suite passes: 169 passed, 6 pre-existing WebGL-related skips (documented in TODO.md), 0 failures
- [ ] Manual check in a browser: enable beta features in Settings, star/unstar a station, confirm it persists across reload and shows in the Favourites view

🤖 Generated with [Claude Code](https://claude.com/claude-code)