### PR TITLE
Refresh Help copy; move card-size toggle into Settings, add it for Favourites

### DIFF
--- a/app/components/settings/showcase/compact-list.gts
+++ b/app/components/settings/showcase/compact-list.gts
@@ -1,6 +1,6 @@
 import { array } from '@ember/helper';
 
-export interface SettingsShowcaseNearbyCompactListSignature {
+export interface SettingsShowcaseCompactListSignature {
   Args: {
     enabled: boolean;
   };
@@ -8,10 +8,10 @@ export interface SettingsShowcaseNearbyCompactListSignature {
 }
 
 // A schematic (not real station data) comparing one big landscape card
-// against a 2x2 grid of the same card shrunk down, mirroring the actual
-// big/small toggle on /nearby (a name+time header, then a stat pair and a
-// round thumbnail) without rendering real stations. Whichever size matches
-// the current preference is highlighted; the other stays dim.
+// against a 2x2 grid of the same card shrunk down, mirroring the big/small
+// toggle shared by /nearby and /favorites (a name+time header, then a stat
+// pair and a round thumbnail) without rendering real stations. Whichever
+// size matches the current preference is highlighted; the other stays dim.
 <template>
   <div
     class="flex items-center justify-center gap-3 rounded-lg bg-slate-100 p-4"

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -44,6 +44,14 @@ export default class SettingsService extends Service {
   })
   nearbyCompactList!: boolean;
 
+  // Show the /favorites stations list as dense rows instead of full cards,
+  // mirroring nearbyCompactList.
+  @trackedInLocalStorage({
+    keyName: 'settings.favoritesCompactList',
+    defaultValue: false,
+  })
+  favoritesCompactList!: boolean;
+
   // Replace the Now/Last hour cards' text labels with small icons, so each
   // value shrinks to fit its content instead of stretching full width.
   @trackedInLocalStorage({
@@ -71,6 +79,7 @@ export type BooleanSettingKey =
   | 'showGustsOutline'
   | 'shrinkOldData'
   | 'nearbyCompactList'
+  | 'favoritesCompactList'
   | 'useIconLabels'
   | 'betaFeaturesEnabled';
 

--- a/app/templates/favorites.gts
+++ b/app/templates/favorites.gts
@@ -6,12 +6,14 @@ import { getRequestState } from '@warp-drive/core/reactive';
 import { pageTitle } from 'ember-page-title';
 import { t } from 'ember-intl';
 import { favoritesQuery } from 'winds-mobi-client-web/builders/station';
+import StationCompactCard from 'winds-mobi-client-web/components/station/compact-card';
 import StationNearbyCard from 'winds-mobi-client-web/components/station/nearby-card';
 import StationSectionCard from 'winds-mobi-client-web/components/station/section-card';
 import commitResolvedStations from 'winds-mobi-client-web/modifiers/commit-resolved-stations';
 import registerLoadingProbe from 'winds-mobi-client-web/modifiers/register-loading-probe';
 import type FavoritesService from 'winds-mobi-client-web/services/favorites';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type {
   Station,
   StoreService,
@@ -27,6 +29,7 @@ interface FavoritesTemplateSignature {
 export default class FavoritesTemplate extends Component<FavoritesTemplateSignature> {
   @service declare favorites: FavoritesService;
   @service declare mapRefresh: MapRefreshService;
+  @service declare settings: SettingsService;
   @service declare store: StoreService;
 
   get favoriteIds(): string[] {
@@ -135,6 +138,15 @@ export default class FavoritesTemplate extends Component<FavoritesTemplateSignat
               {{t "favorites.loading"}}
             </p>
           </StationSectionCard>
+        {{else if this.settings.favoritesCompactList}}
+          <div
+            class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(11rem,calc(50%-0.375rem)),1fr))]"
+            data-test-favorites-stations-compact
+          >
+            {{#each this.stations as |station|}}
+              <StationCompactCard @station={{station}} />
+            {{/each}}
+          </div>
         {{else}}
           <div
             class="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(22rem,1fr))]"

--- a/app/templates/help.gts
+++ b/app/templates/help.gts
@@ -59,6 +59,18 @@ export default class HelpTemplate extends Component<HelpTemplateSignature> {
                   }}</dt>
                 <dd class="mt-1">{{t "help.sections.nearbyDescription"}}</dd>
               </div>
+              <div class="rounded-lg bg-slate-50 p-3">
+                <dt class="font-semibold text-slate-950">{{t
+                    "navigation.favorites"
+                  }}</dt>
+                <dd class="mt-1">{{t "help.sections.favoritesDescription"}}</dd>
+              </div>
+              <div class="rounded-lg bg-slate-50 p-3">
+                <dt class="font-semibold text-slate-950">{{t
+                    "navigation.settings"
+                  }}</dt>
+                <dd class="mt-1">{{t "help.sections.settingsDescription"}}</dd>
+              </div>
             </dl>
           </div>
         </StationSectionCard>

--- a/app/templates/nearby.gts
+++ b/app/templates/nearby.gts
@@ -5,12 +5,9 @@ import type { Future } from '@warp-drive/core/request';
 import { getRequestState } from '@warp-drive/core/reactive';
 import { pageTitle } from 'ember-page-title';
 import { action } from '@ember/object';
-import { fn } from '@ember/helper';
 import { Button } from '@frontile/buttons';
 import { t } from 'ember-intl';
 import type { IntlService } from 'ember-intl';
-import GridFour from 'ember-phosphor-icons/components/ph-grid-four';
-import GridNine from 'ember-phosphor-icons/components/ph-grid-nine';
 import { nearbyQuery } from 'winds-mobi-client-web/builders/station';
 import commitResolvedStations from 'winds-mobi-client-web/modifiers/commit-resolved-stations';
 import registerLoadingProbe from 'winds-mobi-client-web/modifiers/register-loading-probe';
@@ -136,11 +133,6 @@ export default class NearbyTemplate extends Component<NearbyTemplateSignature> {
     await this.nearbyLocation.requestCurrentPosition();
   }
 
-  @action
-  setCompactList(compact: boolean) {
-    this.settings.nearbyCompactList = compact;
-  }
-
   <template>
     {{pageTitle (t "nearby.title")}}
 
@@ -151,38 +143,6 @@ export default class NearbyTemplate extends Component<NearbyTemplateSignature> {
     >
       <div class="flex w-full flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         {{#if this.nearbyLocation.hasCoordinates}}
-          <div class="flex justify-end gap-2">
-            <Button
-              aria-label={{t "nearby.view.card"}}
-              aria-pressed={{if this.settings.nearbyCompactList "false" "true"}}
-              data-test-nearby-view-toggle="card"
-              @appearance={{if
-                this.settings.nearbyCompactList
-                "outlined"
-                "default"
-              }}
-              @size="sm"
-              @onPress={{fn this.setCompactList false}}
-            >
-              <GridFour @size={{16}} />
-            </Button>
-
-            <Button
-              aria-label={{t "nearby.view.compact"}}
-              aria-pressed={{if this.settings.nearbyCompactList "true" "false"}}
-              data-test-nearby-view-toggle="compact"
-              @appearance={{if
-                this.settings.nearbyCompactList
-                "default"
-                "outlined"
-              }}
-              @size="sm"
-              @onPress={{fn this.setCompactList true}}
-            >
-              <GridNine @size={{16}} />
-            </Button>
-          </div>
-
           {{#if this.isError}}
             <StationSectionCard
               data-test-nearby-loading

--- a/app/templates/settings.gts
+++ b/app/templates/settings.gts
@@ -8,7 +8,7 @@ import SettingsRow from 'winds-mobi-client-web/components/settings/row';
 import SettingsShowcaseFavicon from 'winds-mobi-client-web/components/settings/showcase/favicon';
 import SettingsShowcaseGusts from 'winds-mobi-client-web/components/settings/showcase/gusts';
 import SettingsShowcaseShrink from 'winds-mobi-client-web/components/settings/showcase/shrink';
-import SettingsShowcaseNearbyCompactList from 'winds-mobi-client-web/components/settings/showcase/nearby-compact-list';
+import SettingsShowcaseCompactList from 'winds-mobi-client-web/components/settings/showcase/compact-list';
 import SettingsShowcaseIconLabels from 'winds-mobi-client-web/components/settings/showcase/icon-labels';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 
@@ -76,8 +76,22 @@ export default class SettingsTemplate extends Component<SettingsTemplateSignatur
             @titleClass="sr-only"
           >
             <SettingsRow @settings={{this.settings}} @name="nearbyCompactList">
-              <SettingsShowcaseNearbyCompactList
+              <SettingsShowcaseCompactList
                 @enabled={{this.settings.nearbyCompactList}}
+              />
+            </SettingsRow>
+          </StationSectionCard>
+
+          <StationSectionCard
+            @title={{t "settings.favoritesCompactList.label"}}
+            @titleClass="sr-only"
+          >
+            <SettingsRow
+              @settings={{this.settings}}
+              @name="favoritesCompactList"
+            >
+              <SettingsShowcaseCompactList
+                @enabled={{this.settings.favoritesCompactList}}
               />
             </SettingsRow>
           </StationSectionCard>

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.16.0 - 2026-07-10
+
+### Added
+
+- **🧪 Beta:** Settings now has a toggle for smaller, compact favourite-station cards, matching the existing nearby-stations toggle.
+
+### Changed
+
+- The nearby view's card-size toggle has moved into Settings — pick bigger or smaller cards there instead of switching on the nearby screen itself.
+- Refreshed the Help page: shorter, more concise descriptions throughout, corrected privacy notes about favourites, and added the missing Favourites and Settings overview sections.
+
 ## v0.15.0 - 2026-07-10
 
 ### Added

--- a/tests/acceptance/favorites-route-test.ts
+++ b/tests/acceptance/favorites-route-test.ts
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { findAll, visit, waitFor } from '@ember/test-helpers';
+import { findAll, settled, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
 import type FavoritesService from 'winds-mobi-client-web/services/favorites';
@@ -124,5 +124,31 @@ module('Acceptance | favorites route', function (hooks) {
       ['Holfuy 2222', 'Holfuy 1804'],
       'cards follow the order favourites were added, not the response order'
     );
+  });
+
+  test('it shows compact cards when the compact favourites list preference is on', async function (assert) {
+    const favorites = this.owner.lookup(
+      'service:favorites'
+    ) as FavoritesService;
+
+    favorites.add('holfuy-1804');
+    favorites.add('holfuy-2222');
+
+    await visit('/favorites');
+
+    assert.dom('[data-test-favorites-stations-compact]').doesNotExist();
+    assert
+      .dom('[data-test-nearby-station-card-compact]')
+      .doesNotExist('compact cards are not rendered in card view');
+
+    this.owner.lookup('service:settings').favoritesCompactList = true;
+    await settled();
+
+    assert
+      .dom(FAVORITES_CARD_SELECTOR)
+      .doesNotExist('full cards are not rendered in compact view');
+    assert
+      .dom('[data-test-nearby-station-card-compact]')
+      .exists({ count: STATION_FIXTURES.length });
   });
 });

--- a/tests/acceptance/nearby-route-test.ts
+++ b/tests/acceptance/nearby-route-test.ts
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL, settled, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
 import { Type } from '@warp-drive/core/types/symbols';
 import MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
@@ -214,7 +214,7 @@ module('Acceptance | nearby route', function (hooks) {
     assert.strictEqual(params.get('zoom'), '10');
   });
 
-  test('it switches to the compact list view and back', async function (assert) {
+  test('it shows compact cards when the compact nearby list preference is on', async function (assert) {
     const nearbyLocation = this.owner.lookup('service:nearby-location');
 
     stubGrantedPermission(nearbyLocation);
@@ -226,7 +226,8 @@ module('Acceptance | nearby route', function (hooks) {
       .dom('[data-test-nearby-station-card-compact]')
       .doesNotExist('compact cards are not rendered in card view');
 
-    await click('[data-test-nearby-view-toggle="compact"]');
+    this.owner.lookup('service:settings').nearbyCompactList = true;
+    await settled();
 
     assert
       .dom(NEARBY_STATION_CARD_SELECTOR)
@@ -238,7 +239,8 @@ module('Acceptance | nearby route', function (hooks) {
       .dom('[data-test-nearby-station-card-compact="holfuy-1804"]')
       .includesText('Holfuy 1804');
 
-    await click('[data-test-nearby-view-toggle="card"]');
+    this.owner.lookup('service:settings').nearbyCompactList = false;
+    await settled();
 
     assert.dom(NEARBY_STATION_CARD_SELECTOR).exists({ count: 2 });
     assert.dom('[data-test-nearby-station-card-compact]').doesNotExist();

--- a/tests/acceptance/settings-route-test.ts
+++ b/tests/acceptance/settings-route-test.ts
@@ -18,7 +18,7 @@ module('Acceptance | settings route', function (hooks) {
     this.owner.register('service:store', FakeStoreService);
   });
 
-  test('it shows the six preferences, on by default except the compact nearby list, icon labels, and beta features', async function (assert) {
+  test('it shows the seven preferences, on by default except the compact nearby/favourite lists, icon labels, and beta features', async function (assert) {
     await visit('/settings');
 
     assert.dom('[data-test-navbar-link="settings"]').hasText('Settings');
@@ -26,6 +26,7 @@ module('Acceptance | settings route', function (hooks) {
     assert.dom('[data-test-setting="showGustsOutline"]').isChecked();
     assert.dom('[data-test-setting="shrinkOldData"]').isChecked();
     assert.dom('[data-test-setting="nearbyCompactList"]').isNotChecked();
+    assert.dom('[data-test-setting="favoritesCompactList"]').isNotChecked();
     assert.dom('[data-test-setting="useIconLabels"]').isNotChecked();
     assert.dom('[data-test-setting="betaFeaturesEnabled"]').isNotChecked();
     assert
@@ -85,6 +86,28 @@ module('Acceptance | settings route', function (hooks) {
     assert.dom('[data-test-setting="nearbyCompactList"]').isNotChecked();
     assert.strictEqual(
       window.localStorage.getItem('settings.nearbyCompactList'),
+      null,
+      'restoring the default clears the stored override'
+    );
+  });
+
+  test('toggling the compact favourites list preference persists it to local storage', async function (assert) {
+    await visit('/settings');
+
+    await click('[data-test-setting="favoritesCompactList"]');
+
+    assert.dom('[data-test-setting="favoritesCompactList"]').isChecked();
+    assert.strictEqual(
+      window.localStorage.getItem('settings.favoritesCompactList'),
+      'true',
+      'the non-default preference is written to local storage'
+    );
+
+    await click('[data-test-setting="favoritesCompactList"]');
+
+    assert.dom('[data-test-setting="favoritesCompactList"]').isNotChecked();
+    assert.strictEqual(
+      window.localStorage.getItem('settings.favoritesCompactList'),
       null,
       'restoring the default clears the stored override'
     );

--- a/tests/integration/components/settings/showcase/compact-list-test.ts
+++ b/tests/integration/components/settings/showcase/compact-list-test.ts
@@ -13,7 +13,7 @@ function previewCards() {
 }
 
 module(
-  'Integration | Component | settings/showcase/nearby-compact-list',
+  'Integration | Component | settings/showcase/compact-list',
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -21,7 +21,7 @@ module(
       this.enabled = false;
 
       await render(
-        hbs`<Settings::Showcase::NearbyCompactList @enabled={{this.enabled}} />`
+        hbs`<Settings::Showcase::CompactList @enabled={{this.enabled}} />`
       );
 
       const off = previewCards();
@@ -30,7 +30,7 @@ module(
 
       this.enabled = true;
       await render(
-        hbs`<Settings::Showcase::NearbyCompactList @enabled={{this.enabled}} />`
+        hbs`<Settings::Showcase::CompactList @enabled={{this.enabled}} />`
       );
 
       const on = previewCards();

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -91,40 +91,42 @@ settings:
 
 help:
   title: Help
-  intro: Winds.mobi helps you inspect live wind and weather stations on the map, compare nearby stations around your current position, and understand what each reading means.
+  intro: Winds.mobi shows live wind and weather stations on a map, so you can check conditions and plan your flight.
   sections:
-    mapDescription: Explore stations on the interactive map, compare marker colours, and open a station panel for more detail.
-    nearbyDescription: Use your location to load the closest stations and compare their current conditions side by side.
+    mapDescription: Browse stations on the map and open one for full detail.
+    nearbyDescription: Use your location to compare the closest stations side by side.
+    favoritesDescription: Save stations for quick access — stored in your browser, no account needed.
+    settingsDescription: Turn display preferences on or off, like gusts outline or compact cards.
   liveExample:
     title: Live station example
-    description: This live example loads the current Holfuy 1804 station so you can see the real widgets used in the app.
+    description: A live Holfuy 1804 station, so you can see the real widgets in action.
     legendTitle: What you are looking at
     items:
       headerTitle: Station header
-      headerDescription: The header shows the station name, altitude, relative update time, provider, and the distance from you when your location is available. A mountain icon next to the altitude marks a free-flight take-off site (peak); other stations show altitude with no icon.
+      headerDescription: Name, altitude, last update, provider, and distance (when your location is available). A mountain icon marks a take-off site.
       nowTitle: Now
-      nowDescription: The left summary card shows the latest reported values for wind, gusts, direction, temperature, humidity, pressure, and rain.
+      nowDescription: Latest wind, gusts, direction, temperature, humidity, pressure, and rain.
       lastHourTitle: Last hour
-      lastHourDescription: The second summary card focuses on the last hour with trend values and a compact wind-direction history.
+      lastHourDescription: Trend values and a compact wind-direction history for the last hour.
       windHistoryTitle: Wind history
-      windHistoryDescription: The wind section shows the larger historical view for wind speed, gusts, and direction over time.
+      windHistoryDescription: Wind speed, gusts, and direction over time.
       airHistoryTitle: Air history
-      airHistoryDescription: The air section shows the matching historical charts for temperature, humidity, and rain.
+      airHistoryDescription: Temperature, humidity, and rain over time.
   colors:
     title: Map marker colours
-    description: Winds.mobi reuses this shared wind palette for wind speed and gusts across station markers, the last-hour wind rose, and the wind history chart so stronger conditions stay easy to read everywhere.
+    description: The same colour scale marks wind speed and gusts on map markers, the last-hour rose, and history charts.
   freshness:
     title: Data freshness colours
-    description: The "updated" time in a station's header and nearby cards fades from glowing gold to grey as a reading ages, so you can tell at a glance how recent the data is.
+    description: The "updated" time fades from gold to grey as a reading ages — a quick way to spot stale data.
   providers:
     title: Data providers
-    description: Winds.mobi aggregates station data from multiple provider networks. The provider name in each station header links back to the original source when available.
+    description: Station data comes from multiple provider networks. Provider names link back to the source when available.
   compatibility:
     title: Compatibility
-    description: Winds.mobi is built for current desktop and mobile browsers, with the interactive map and charts working best on the latest major browser versions.
+    description: Works best in a recent desktop or mobile browser.
   privacy:
     title: Privacy
-    description: Winds.mobi uses your browser location only when you ask it to. The nearby view and distance display depend on that location, and the app does not need location access for normal map browsing.
+    description: Location is only used when you ask, for the nearby view and distances. Favourites are saved in your browser only — no account or cross-device sync.
   about:
     title: About
     description: Questions, issues, or improvement ideas are welcome.
@@ -139,7 +141,7 @@ help:
     repoDescription: For developers — browse the source or open an issue.
   changelog:
     title: Changelog
-    description: The latest shipped changes are listed below directly from the project changelog.
+    description: Recent shipped changes, straight from the project changelog.
     loading: Loading changelog…
     error: The changelog could not be loaded right now.
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -71,10 +71,16 @@ settings:
       stand out and stale ones recede. Arrows scale linearly from full size
       now down to half size at 30 minutes, and never shrink below half size.
   nearbyCompactList:
-    label: Smaller nearby cards
+    label: Compact nearby cards
     description: >-
-      Show nearby stations as smaller cards (name, altitude, wind, gusts, last
+      Show nearby stations as compact cards (name, altitude, wind, gusts, last
       update, and a small wind-direction thumbnail) instead of full-size
+      cards, so more stations fit on screen without scrolling.
+  favoritesCompactList:
+    label: Compact favourite cards
+    description: >-
+      Show favourite stations as compact cards (name, altitude, wind, gusts,
+      last update, and a small wind-direction thumbnail) instead of full-size
       cards, so more stations fit on screen without scrolling.
   useIconLabels:
     label: Use icons for labels
@@ -159,9 +165,6 @@ nearby:
   description: Use your location to find the closest stations around your current position and compare the live reading with the last hour at a glance.
   loading: Looking up the closest stations…
   requestError: Nearby stations could not be loaded right now.
-  view:
-    card: Bigger cards
-    compact: Smaller cards
   location:
     checking: Checking location access…
     locatingDescription: Trying to determine your current location…


### PR DESCRIPTION
## Summary
- Refreshed the Help page: trimmed wordy descriptions throughout, added the missing Favourites and Settings overview tiles, and corrected the privacy copy to mention that favourites are stored locally (no account, no sync).
- Removed the inline big/small card toggle from `/nearby` — card size there is now controlled only via the existing `settings.nearbyCompactList` preference in Settings.
- Added a matching `settings.favoritesCompactList` preference and wired `/favorites` to switch between full and compact cards on it, mirroring nearby.
- Renamed the shared showcase component from `NearbyCompactList` to `CompactList` since both settings rows now use it.
- Bumped CHANGELOG to v0.16.0.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test:ember` (full suite: 171 pass, 6 known WebGL-dependent skips, 0 fail)
- [ ] Manual check in browser: `/help`, `/settings`, `/nearby`, `/favorites`

🤖 Generated with [Claude Code](https://claude.com/claude-code)