### PR TITLE
Dev-environment cleanup: stock-blueprint parity, script fixes, and a 183→0 typecheck burn-down

### DIFF
--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.17.0 - 2026-07-11
+
+### Changed
+
+- Updated the app's icon set (Phosphor) to its latest release — icons throughout the interface pick up the refreshed glyph designs.
+
 ## v0.16.0 - 2026-07-10
 
 ### Added


### PR DESCRIPTION
A critical pass over the dev environment against the stock `ember-cli` 6.3 + `@ember/app-blueprint` (Vite, TS) baseline, followed by fixing everything it surfaced. Audit plans were tracked in TODO.md, one focused commit each.

### Scripts & tooling
- **`pnpm test` no longer hangs**: the stock `pnpm:test:*` glob matched the never-exiting `test:ember:dev*` scripts; `test` now enumerates `pnpm:test:ember` explicitly.
- **`pnpm start` dropped `--force`**: the forced dependency re-optimization on every boot was the root cause of recurring 504s/blank pages in the container (documented in TROUBLESHOOTING.md).
- **`lint:js` was never wired into `pnpm lint`** — fixed, plus the 121 pre-existing ESLint errors that gap had been hiding (mostly `no-explicit-any` in tests, unsafe intl casts, and four empty backing classes).
- **testem is a direct devDependency** now; the bespoke `run-testem-dev.cjs` resolver/wrapper is gone (`test:ember:dev` → `testem ci --file testem-dev.js`).
- **Root-caused the "browser failed to connect within 120s" flakiness**: the testem proxy targeted the OrbStack HTTPS domain via `APP_URL`, whose CA node's https client rejects — every proxied page request 500'd. The proxy now hits the colocated dev server over plain-http localhost.
- Removed: `npm rebuild sharp` postinstall (npm/pnpm mixup), unused `lint-to-the-future*` deps, the Dockerfile's unpinned global ember-cli. Restored stock touches (README, `repository`/`description` fields, `lint:fix` order).

### Typecheck burn-down (183 → 0) and `lint:types` gate
The stock blueprint type-checks in `pnpm lint`; this app never did, and 183 Glint errors had accumulated. They reduced to a handful of root causes:
- Seven template-only components **declared signatures but never attached them** (a bare `<template>` is an empty-signature component) — now typed via `TOC<…>`.
- **Duplicate type-symbol copies from dependency drift**: `ember-phosphor-icons@0.3` hard-depended on `@glimmer/component@1` (upgraded to 1.0.2, which drops it), and the Frontile betas hard-depend on `@glint/template@1.5.2` exactly (pnpm override pins 1.7.7) — both made components type as `never`/non-invokable.
- Data layer: typed handler attribute payloads, `TypedRecordInstance`-constrained builders matching Warp Drive's typed overloads, and `Derivation`-conformant derivation signatures.
- Tests: a shared `RenderedTestContext` narrowing `this.element` to `Element` for qunit-dom, honest `as unknown as` casts for fake services, completed `History` fixtures; `@ember/test-helpers` upgraded to ^5 (stock pairing with ember-qunit 9).

`lint:types` (`ember-tsc --noEmit`) is now part of `pnpm lint`, so CI keeps the tree at 0.

### User-facing
- Phosphor icon set refreshed via the 0.3 → 1.0.2 upgrade (changelog v0.17.0).

### Verification
- `pnpm lint` — all five linters green, including the new type-check gate.
- `pnpm test:ember` — 177 tests: 171 pass / 6 known skips / 0 fail (identical profile to before the branch).
- `test:ember:dev` — previously couldn't even connect its browser in the container; now runs green (verified with a filtered run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
