### PR TITLE
⚙️ Add `base` option to VitePWA configuration for production builds

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig(({ mode }) => ({
     tailwindcss(),
     mode === 'production'
       ? VitePWA({
+          base: '/',
           registerType: 'autoUpdate',
           pwaAssets: {
             config: true,


### PR DESCRIPTION
Looks like ok now in index.html:

```
...
<link rel="manifest" href="/manifest.webmanifest"><script id="vite-plugin-pwa:register-sw" src="/registerSW.js"></script>
<link rel="icon" href="https://v2-winds-mobi.b-cdn.net/favicon.ico" sizes="48x48">
...
```