### PR TITLE
Configure `navigateFallbackDenylist` in VitePWA to exclude proxy-managed paths

### DIFF
--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed map, search, nearby, and favourites requests being sent twice: the client was missing a trailing slash that made the API respond with a redirect on every call.
 - Time-series charts (wind, air) now show times in your local timezone instead of UTC.
 - Fixed old bookmarked/shared links (e.g. the pre-rebuild `/stations/...` URLs) showing a blank page with a console error — they now redirect to the map instead.
+- Fixed the installed app's service worker intercepting the API docs, admin, and account-management pages (served by other backends, not this app) and wrongly showing the map instead.
 
 ## v0.18.0 - 2026-07-15
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -80,6 +80,13 @@ export default defineConfig(({ mode }) => ({
           workbox: {
             navigateFallback: '/index.html',
             maximumFileSizeToCacheInBytes: 8000000,
+            // Ignore paths that are managed by Caddy reverse proxy backends.
+            // https://github.com/winds-mobi/winds-mobi-config/blob/main/winds.mobi/Caddyfile
+            navigateFallbackDenylist: [
+              /^\/api/,
+              /^\/admin/,
+              /^\/django-static/,
+            ],
             runtimeCaching: [
               {
                 // Base raster map tiles (tile.osm.ch/switzerland): roads/labels

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -84,6 +84,7 @@ export default defineConfig(({ mode }) => ({
             // https://github.com/winds-mobi/winds-mobi-config/blob/main/winds.mobi/Caddyfile
             navigateFallbackDenylist: [
               /^\/api/,
+              /^\/user/,
               /^\/admin/,
               /^\/django-static/,
             ],


### PR DESCRIPTION
Ok fine, now the service worker is working. But it intercepts the /api/2/doc openapi swagger page and /admin django page that allow some users to manage providers.