### PR TITLE
🚦 Add `not-found` route with redirect to `index`

### DIFF
--- a/app/router.ts
+++ b/app/router.ts
@@ -17,4 +17,5 @@ Router.map(function () {
   // this.route('auth-callback', { path: '/auth/callback' });
   this.route('settings');
   this.route('help');
+  this.route('not-found', { path: '/*path' });
 });

--- a/app/routes/not-found.ts
+++ b/app/routes/not-found.ts
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import type RouterService from '@ember/routing/router-service';
+import { service } from '@ember/service';
+
+export default class NotFoundRoute extends Route {
+  @service declare router: RouterService;
+
+  beforeModel() {
+    this.router.transitionTo('index');
+  }
+}

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed map, search, nearby, and favourites requests being sent twice: the client was missing a trailing slash that made the API respond with a redirect on every call.
 - Time-series charts (wind, air) now show times in your local timezone instead of UTC.
+- Fixed old bookmarked/shared links (e.g. the pre-rebuild `/stations/...` URLs) showing a blank page with a console error — they now redirect to the map instead.
 
 ## v0.18.0 - 2026-07-15
 

--- a/tests/acceptance/not-found-route-test.ts
+++ b/tests/acceptance/not-found-route-test.ts
@@ -1,0 +1,30 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'winds-mobi-client-web/tests/helpers';
+
+class FakeStoreService extends Service {
+  request() {
+    return Promise.resolve({ content: { data: [] } });
+  }
+}
+
+module('Acceptance | not-found route', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('service:store', FakeStoreService);
+  });
+
+  test('an old pre-rebuild station URL redirects to the map', async function (assert) {
+    await visit('/stations/holfuy-1804');
+
+    assert.strictEqual(currentURL(), '/map');
+  });
+
+  test('an unrecognized path redirects to the map', async function (assert) {
+    await visit('/this/path/does/not/exist');
+
+    assert.strictEqual(currentURL(), '/map');
+  });
+});


### PR DESCRIPTION
The old URL pattern `https://winds.mobi/stations/` is now redirecting to the root SPA and winds.mobi is no longer displaying a blank page with an error.