### PR TITLE
🌐 Add UTC and data grouping settings to time-series charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 /DEBUG/
 
 /.vscode
+/.idea
 
 /node-compile-cache
 /dev-dist

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -34,7 +34,7 @@ interface TimeSeriesSeries extends ChartOptions {
 export default class TimeSeries extends Component<TimeSeriesSignature> {
   defaultChartOptions: TimeSeriesChartOptions = {
     time: {
-      useUTC: false,
+      timezone: undefined,
     },
     credits: {
       enabled: false,

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -33,6 +33,9 @@ interface TimeSeriesSeries extends ChartOptions {
 
 export default class TimeSeries extends Component<TimeSeriesSignature> {
   defaultChartOptions: TimeSeriesChartOptions = {
+    time: {
+      useUTC: false,
+    },
     credits: {
       enabled: false,
     },

--- a/app/components/station/wind/presenter.gts
+++ b/app/components/station/wind/presenter.gts
@@ -42,6 +42,9 @@ export default class StationWindContent extends Component<StationWindContentSign
         name: 'Gusts',
         data: gusts,
         dashStyle: 'ShortDash',
+        dataGrouping: {
+          approximation: 'high',
+        },
         lineWidth: 2.5,
         tooltip: {
           valueSuffix: 'km/h',

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -11,10 +11,12 @@
 - **🧪 Beta:** Favourites now has its own "Favourites" setting (on by default, shown once beta features are enabled) instead of being tied only to the "Enable beta features" toggle. Every individual beta feature's toggle now lives together with the master toggle in one grouped settings card, with the master toggle always shown first.
 - Compact station cards (Nearby and Favourites) now show the same wind arrow used on the map side by side with the existing wind-direction history graph — giving an at-a-glance read on speed, gusts, and direction. The name, altitude, and last-updated time now share a single line, with the updated time shown as a terser "5m" instead of "5m ago" to save space. The cards themselves are a bit bigger.
 - Map markers now shrink as you zoom out, so they no longer dwarf the map when viewing a whole region.
+- On the wind chart, when zoomed out far enough that Highcharts groups several readings into one point, the gusts line now shows the highest gust in the group instead of an average, so peak gusts stay visible.
 
 ### Fixed
 
 - Fixed map, search, nearby, and favourites requests being sent twice: the client was missing a trailing slash that made the API respond with a redirect on every call.
+- Time-series charts (wind, air) now show times in your local timezone instead of UTC.
 
 ## v0.18.0 - 2026-07-15
 

--- a/tests/integration/components/chart/time-series-test.ts
+++ b/tests/integration/components/chart/time-series-test.ts
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { render, type RenderingTestContext } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+import type { TimeSeriesPoint } from 'winds-mobi-client-web/utils/chart-series';
+
+interface TimeSeriesTestContext extends RenderingTestContext {
+  chartData: { name: string; data: TimeSeriesPoint[] }[];
+}
+
+// This is the shared chart shell every station history chart (wind, air)
+// renders through. Drawing/configuring is Highcharts' responsibility, not
+// ours, so these tests only check that the component accepts @chartData and
+// renders without error.
+module('Integration | Component | chart/time-series', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with series data', async function (this: TimeSeriesTestContext, assert) {
+    const now = Date.now();
+
+    this.chartData = [
+      {
+        name: 'Wind',
+        data: [
+          [now - 30 * 60 * 1000, 10],
+          [now - 5 * 60 * 1000, 16],
+        ],
+      },
+    ];
+
+    await render(hbs`<Chart::TimeSeries @chartData={{this.chartData}} />`);
+
+    assert.dom('.highcharts-container').exists();
+  });
+
+  test('it renders with no series data', async function (this: TimeSeriesTestContext, assert) {
+    this.chartData = [];
+
+    await render(hbs`<Chart::TimeSeries @chartData={{this.chartData}} />`);
+
+    assert.dom('.highcharts-container').exists();
+  });
+});


### PR DESCRIPTION
All dates were in local time except the dates in the Highcharts timeseries chart. I also changing the data grouping on long scales with the wind gust: the highest value makes more sense in my opinion.