### PR TITLE
🧭 Compact card wind arrow + zoom-scaled map markers

### DIFF
--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -396,6 +396,7 @@ export default class Map extends Component<MapSignature> {
               @isSelected={{this.isStationSelected station}}
               @onSelect={{this.stationSelected}}
               @station={{station}}
+              @zoom={{this.mapView.zoom}}
             />
           </map.marker>
         {{/each}}

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -116,7 +116,7 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     >
       <svg
         aria-hidden="true"
-        class="h-16 w-16 overflow-visible"
+        class="h-24 w-24 overflow-visible"
         viewBox={{this.viewBox}}
       >
         <g transform={{this.markerTransform}}>

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -9,6 +9,7 @@ import {
   MARKER_OUTLINE_WIDTH,
   MARKER_PLAIN_OUTLINE_COLOUR,
   scaleForReadingAge,
+  scaleForZoom,
   stationArrowGeometry,
 } from 'winds-mobi-client-web/utils/station-arrow';
 import type { Station } from 'winds-mobi-client-web/services/store';
@@ -18,6 +19,7 @@ export interface MapStationMarkerSignature {
     isSelected?: boolean;
     onSelect: (station: Station) => void;
     station: Station;
+    zoom: number;
   };
   Element: HTMLButtonElement;
 }
@@ -56,15 +58,19 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     );
   }
 
-  // Shrink the whole arrow by reading age when the preference is on. Recomputed
-  // each refresh cycle as new readings replace the record, so no timer is needed
-  // — the data only changes on refresh anyway.
+  // Shrink the whole arrow by reading age when the preference is on, and
+  // always by map zoom so markers don't dwarf the map when zoomed out to see
+  // a whole region. The two multiply together, so an old reading at a low
+  // zoom shrinks further still. Recomputed each refresh cycle as new readings
+  // replace the record, so no timer is needed — the data only changes on
+  // refresh anyway; the zoom factor is recomputed whenever the routed zoom
+  // (settled after a pan/zoom gesture) changes.
   get markerScale() {
-    if (!this.settings.shrinkOldData) {
-      return 1;
-    }
+    const ageScale = this.settings.shrinkOldData
+      ? scaleForReadingAge(this.args.station.last.timestamp)
+      : 1;
 
-    return scaleForReadingAge(this.args.station.last.timestamp);
+    return ageScale * scaleForZoom(this.args.zoom);
   }
 
   // Rotate to the wind direction and, when shrinking, scale about the same hub

--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -1,4 +1,5 @@
-import type { TOC } from '@ember/component/template-only';
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
@@ -10,8 +11,10 @@ import timeAgo, {
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
 import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
+import SettingsWindArrow from 'winds-mobi-client-web/components/settings/wind-arrow';
 import StationMetaItem from './meta-item';
 import StationWindDirectionThumbnail from './wind-direction-thumbnail';
+import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 
 export interface StationCompactCardSignature {
@@ -24,26 +27,28 @@ export interface StationCompactCardSignature {
   Element: HTMLDivElement;
 }
 
-const StationCompactCard: TOC<StationCompactCardSignature> = <template>
-  <article
-    ...attributes
-    class="flex aspect-[3/2] min-h-0 gap-3 overflow-hidden rounded-xl border border-slate-200 bg-white p-3 shadow-md shadow-slate-900/12"
-    data-test-nearby-station-card-compact={{@station.id}}
-  >
-    <div class="flex min-h-0 min-w-0 flex-1 flex-col justify-between">
-      <div class="min-w-0">
+export default class StationCompactCard extends Component<StationCompactCardSignature> {
+  @service declare settings: SettingsService;
+
+  <template>
+    <article
+      ...attributes
+      class="flex aspect-[3/2] min-h-0 flex-col gap-1 overflow-hidden rounded-xl border border-slate-200 bg-white p-3 shadow-md shadow-slate-900/12"
+      data-test-nearby-station-card-compact={{@station.id}}
+    >
+      <div class="flex min-w-0 items-center justify-between gap-2">
         <LinkTo
           data-test-station-title
           @route="map.station"
           @model={{@station.id}}
           @query={{focusQueryParamsFor @station}}
           title={{t "station.showOnMap"}}
-          class="block truncate text-sm font-semibold text-slate-950 underline decoration-transparent underline-offset-3 transition hover:decoration-slate-300"
+          class="min-w-0 flex-1 truncate text-sm font-semibold text-slate-950 underline decoration-transparent underline-offset-3 transition hover:decoration-slate-300"
         >
           {{@station.name}}
         </LinkTo>
 
-        <dl class="m-0">
+        <dl class="m-0 shrink-0">
           <StationMetaItem
             @icon={{if @station.isPeak Mountains}}
             @label={{t "station.meta.altitude"}}
@@ -53,54 +58,64 @@ const StationCompactCard: TOC<StationCompactCardSignature> = <template>
               m</span>
           </StationMetaItem>
         </dl>
+
+        <dl class="m-0 shrink-0">
+          <StationMetaItem
+            @icon={{ClockCounterClockwise}}
+            @label={{t "station.meta.updated"}}
+            class="text-[11px] text-slate-500"
+          >
+            <span
+              class={{textClassForReadingAge @station.last.timestamp}}
+            >{{timeAgo
+                (relativeSecondsFromTimestamp @station.last.timestamp)
+              }}</span>
+          </StationMetaItem>
+        </dl>
       </div>
 
-      <dl class="m-0">
-        <StationMetaItem
-          @icon={{ClockCounterClockwise}}
-          @label={{t "station.meta.updated"}}
-          class="text-[11px] text-slate-500"
+      <div class="flex min-h-0 flex-1 gap-3">
+        <div
+          class="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-1"
         >
-          <span
-            class={{textClassForReadingAge @station.last.timestamp}}
-          >{{timeAgo
-              (relativeSecondsFromTimestamp @station.last.timestamp)
-            }}</span>
-        </StationMetaItem>
-      </dl>
-    </div>
+          <SettingsWindArrow
+            class="aspect-square h-full max-h-full max-w-full"
+            @direction={{@station.last.direction}}
+            @speed={{@station.last.speed}}
+            @gusts={{@station.last.gusts}}
+            @showGusts={{this.settings.showGustsOutline}}
+          />
 
-    <div class="flex min-h-0 min-w-0 flex-1 flex-col items-center gap-1">
-      <dl class="m-0 flex items-baseline gap-1">
-        <dt class="sr-only">{{t "wind.speed"}}</dt>
-        <dd
-          class="m-0 text-[1.5rem] font-semibold leading-none
-            {{windToTextClass @station.last.speed}}"
-        >
-          {{formatNumber @station.last.speed format="integer"}}
-        </dd>
+          <dl class="m-0 flex items-baseline gap-1">
+            <dt class="sr-only">{{t "wind.speed"}}</dt>
+            <dd
+              class="m-0 text-[1.5rem] font-semibold leading-none
+                {{windToTextClass @station.last.speed}}"
+            >
+              {{formatNumber @station.last.speed format="integer"}}
+            </dd>
 
-        <span aria-hidden="true" class="text-slate-400">/</span>
+            <span aria-hidden="true" class="text-slate-400">/</span>
 
-        <dt class="sr-only">{{t "wind.gusts"}}</dt>
-        <dd
-          class="m-0 text-base font-semibold leading-none
-            {{windToTextClass @station.last.gusts}}"
-        >
-          {{formatNumber @station.last.gusts format="integer"}}
-        </dd>
+            <dt class="sr-only">{{t "wind.gusts"}}</dt>
+            <dd
+              class="m-0 text-base font-semibold leading-none
+                {{windToTextClass @station.last.gusts}}"
+            >
+              {{formatNumber @station.last.gusts format="integer"}}
+            </dd>
 
-        <dd class="m-0 text-xs text-slate-500">km/h</dd>
-      </dl>
+            <dd class="m-0 text-xs text-slate-500">km/h</dd>
+          </dl>
+        </div>
 
-      <div class="flex min-h-0 w-full flex-1 items-center justify-center">
-        <StationWindDirectionThumbnail
-          @stationId={{@station.id}}
-          class="aspect-square h-full max-h-full max-w-full"
-        />
+        <div class="flex min-h-0 min-w-0 flex-1 items-center justify-center">
+          <StationWindDirectionThumbnail
+            @stationId={{@station.id}}
+            class="aspect-square h-full max-h-full max-w-full"
+          />
+        </div>
       </div>
-    </div>
-  </article>
-</template>;
-
-export default StationCompactCard;
+    </article>
+  </template>
+}

--- a/app/components/station/compact-card.gts
+++ b/app/components/station/compact-card.gts
@@ -3,16 +3,12 @@ import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
-import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
-import timeAgo, {
-  relativeSecondsFromTimestamp,
-} from 'winds-mobi-client-web/helpers/time-ago';
 import { windToTextClass } from 'winds-mobi-client-web/helpers/wind-to-colour';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
-import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
 import SettingsWindArrow from 'winds-mobi-client-web/components/settings/wind-arrow';
 import StationMetaItem from './meta-item';
+import StationUpdatedMeta from './updated-meta';
 import StationWindDirectionThumbnail from './wind-direction-thumbnail';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
@@ -60,17 +56,10 @@ export default class StationCompactCard extends Component<StationCompactCardSign
         </dl>
 
         <dl class="m-0 shrink-0">
-          <StationMetaItem
-            @icon={{ClockCounterClockwise}}
-            @label={{t "station.meta.updated"}}
-            class="text-[11px] text-slate-500"
-          >
-            <span
-              class={{textClassForReadingAge @station.last.timestamp}}
-            >{{timeAgo
-                (relativeSecondsFromTimestamp @station.last.timestamp)
-              }}</span>
-          </StationMetaItem>
+          <StationUpdatedMeta
+            @timestamp={{@station.last.timestamp}}
+            @isCompact={{true}}
+          />
         </dl>
       </div>
 
@@ -79,7 +68,7 @@ export default class StationCompactCard extends Component<StationCompactCardSign
           class="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center gap-1"
         >
           <SettingsWindArrow
-            class="aspect-square h-full max-h-full max-w-full"
+            class="aspect-square h-2/3 max-h-2/3 max-w-2/3"
             @direction={{@station.last.direction}}
             @speed={{@station.last.speed}}
             @gusts={{@station.last.gusts}}
@@ -89,17 +78,17 @@ export default class StationCompactCard extends Component<StationCompactCardSign
           <dl class="m-0 flex items-baseline gap-1">
             <dt class="sr-only">{{t "wind.speed"}}</dt>
             <dd
-              class="m-0 text-[1.5rem] font-semibold leading-none
+              class="m-0 text-lg font-semibold leading-none
                 {{windToTextClass @station.last.speed}}"
             >
               {{formatNumber @station.last.speed format="integer"}}
             </dd>
 
-            <span aria-hidden="true" class="text-slate-400">/</span>
+            <span aria-hidden="true" class="text-slate-400">–</span>
 
             <dt class="sr-only">{{t "wind.gusts"}}</dt>
             <dd
-              class="m-0 text-base font-semibold leading-none
+              class="m-0 text-sm font-semibold leading-none
                 {{windToTextClass @station.last.gusts}}"
             >
               {{formatNumber @station.last.gusts format="integer"}}

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -6,21 +6,17 @@ import { Button } from '@frontile/buttons';
 import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
 import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
-import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
 import Heart from 'ember-phosphor-icons/components/ph-heart';
 import Mountains from 'ember-phosphor-icons/components/ph-mountains';
 import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
 import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
-import timeAgo, {
-  relativeSecondsFromTimestamp,
-} from 'winds-mobi-client-web/helpers/time-ago';
 import type FavoritesService from 'winds-mobi-client-web/services/favorites';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
-import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
 import StationMetaItem from './meta-item';
+import StationUpdatedMeta from './updated-meta';
 
 export interface StationHeaderSignature {
   Args: {
@@ -113,16 +109,7 @@ export default class StationHeader extends Component<StationHeaderSignature> {
             m</span>
         </StationMetaItem>
 
-        <StationMetaItem
-          @icon={{ClockCounterClockwise}}
-          @label={{t "station.meta.updated"}}
-        >
-          <span
-            class={{textClassForReadingAge @station.last.timestamp}}
-          >{{timeAgo
-              (relativeSecondsFromTimestamp @station.last.timestamp)
-            }}</span>
-        </StationMetaItem>
+        <StationUpdatedMeta @timestamp={{@station.last.timestamp}} />
 
         {{#let this.nearbyLocation.coordinates as |coordinates|}}
           {{#let

--- a/app/components/station/updated-meta.gts
+++ b/app/components/station/updated-meta.gts
@@ -1,0 +1,54 @@
+import Component from '@glimmer/component';
+import { t } from 'ember-intl';
+import ClockCounterClockwise from 'ember-phosphor-icons/components/ph-clock-counter-clockwise';
+import timeAgo, {
+  compactTimeAgo,
+  relativeSecondsFromTimestamp,
+} from 'winds-mobi-client-web/helpers/time-ago';
+import { textClassForReadingAge } from 'winds-mobi-client-web/utils/reading-freshness';
+import StationMetaItem from './meta-item';
+
+export interface StationUpdatedMetaSignature {
+  Args: {
+    timestamp: number;
+    // Terse "5m" reading with no icon and no "ago" wording, for the tighter
+    // meta row on compact nearby/favourites cards. Defaults to the full
+    // "5m ago" reading with its clock icon (station header, full cards).
+    isCompact?: boolean;
+  };
+  Element: HTMLDivElement;
+}
+
+export default class StationUpdatedMeta extends Component<StationUpdatedMetaSignature> {
+  get icon() {
+    return this.args.isCompact ? undefined : ClockCounterClockwise;
+  }
+
+  // Compact mode's smaller, muted sizing lives here rather than as a `class`
+  // callers pass alongside `@isCompact` -- the two would otherwise have to be
+  // kept in sync by hand at every call site.
+  get sizeClass() {
+    return this.args.isCompact ? 'text-[11px] text-slate-500' : undefined;
+  }
+
+  get relativeSeconds() {
+    return relativeSecondsFromTimestamp(this.args.timestamp);
+  }
+
+  <template>
+    <StationMetaItem
+      @icon={{this.icon}}
+      @label={{t "station.meta.updated"}}
+      class={{this.sizeClass}}
+      ...attributes
+    >
+      <span class={{textClassForReadingAge @timestamp}}>
+        {{if
+          @isCompact
+          (compactTimeAgo this.relativeSeconds)
+          (timeAgo this.relativeSeconds)
+        }}
+      </span>
+    </StationMetaItem>
+  </template>
+}

--- a/app/helpers/time-ago.ts
+++ b/app/helpers/time-ago.ts
@@ -46,6 +46,28 @@ export function renderTimeAgoText(intl: IntlService, seconds: number) {
   return intl.formatRelativeTime(value, { unit, style: 'narrow' });
 }
 
+const COMPACT_UNIT_SUFFIXES: Partial<
+  Record<Intl.RelativeTimeFormatUnit, string>
+> = {
+  second: 's',
+  minute: 'm',
+  hour: 'h',
+  day: 'd',
+  week: 'w',
+  month: 'mo',
+  year: 'y',
+};
+
+// A terse "5m" reading with no "ago"/unit-word, for tight spaces (e.g. the
+// compact nearby/favourites cards) where renderTimeAgoText's full wording
+// doesn't fit. Shares timeAgoParts with the narrow-style helper above so the
+// two never disagree on which unit a given age falls into.
+export function compactTimeAgo(seconds: number): string {
+  const { value, unit } = timeAgoParts(seconds);
+
+  return `${Math.abs(value)}${COMPACT_UNIT_SUFFIXES[unit] ?? ''}`;
+}
+
 interface TimeAgoSignature {
   Args: {
     Positional: [number];

--- a/app/templates/favorites.gts
+++ b/app/templates/favorites.gts
@@ -140,7 +140,7 @@ export default class FavoritesTemplate extends Component<FavoritesTemplateSignat
           </StationSectionCard>
         {{else if this.settings.favoritesCompactList}}
           <div
-            class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(11rem,calc(50%-0.375rem)),1fr))]"
+            class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(14rem,calc(50%-0.375rem)),1fr))]"
             data-test-favorites-stations-compact
           >
             {{#each this.stations as |station|}}

--- a/app/templates/nearby.gts
+++ b/app/templates/nearby.gts
@@ -164,7 +164,7 @@ export default class NearbyTemplate extends Component<NearbyTemplateSignature> {
             </StationSectionCard>
           {{else if this.settings.nearbyCompactList}}
             <div
-              class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(11rem,calc(50%-0.375rem)),1fr))]"
+              class="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(14rem,calc(50%-0.375rem)),1fr))]"
               data-test-nearby-stations-compact
             >
               {{#each this.stations as |station|}}

--- a/app/utils/station-arrow.ts
+++ b/app/utils/station-arrow.ts
@@ -58,6 +58,34 @@ export function scaleForReadingAge(timestamp: number): number {
   return 1 - (1 - MIN_MARKER_SCALE) * progress;
 }
 
+// Marker scale steps by map zoom, so arrows don't dwarf the map when zoomed
+// out to see a whole region. Deliberately discrete steps rather than a
+// continuous function: the routed `zoom` query param this reads only updates
+// once a pan/zoom gesture settles (see CLAUDE.md's map-state architecture),
+// so markers only ever need to hold one of a handful of sizes at a time.
+const ZOOM_SCALE_STEPS: readonly (readonly [minZoom: number, scale: number])[] =
+  [
+    [13, 1],
+    [11, 0.8],
+    [9, 0.65],
+    [7, 0.5],
+  ];
+export const MIN_ZOOM_MARKER_SCALE = 0.4;
+
+export function scaleForZoom(zoom: number): number {
+  if (!Number.isFinite(zoom)) {
+    return 1;
+  }
+
+  for (const [minZoom, scale] of ZOOM_SCALE_STEPS) {
+    if (zoom >= minZoom) {
+      return scale;
+    }
+  }
+
+  return MIN_ZOOM_MARKER_SCALE;
+}
+
 // A reading older than a day is drawn grey rather than in its wind-speed colour.
 export function colourForWindReading(speed: number, timestamp: number): string {
   if (!Number.isFinite(timestamp)) {

--- a/build/station-arrow-geometry.mjs
+++ b/build/station-arrow-geometry.mjs
@@ -381,17 +381,17 @@ export function geometryFromSvg(svg) {
   const hubY = round2(centreY * k);
 
   // The viewBox is a square centred on the hub (the rotation centre), sized to
-  // the farthest the arrow reaches from the hub so it can't clip at any
-  // rotation, plus a little for the outline stroke. Every consumer (the on-map
-  // marker, the favicon, the settings preview) rotates the arrow about the hub
-  // in place, so the hub has to be the centre of the square those rotations
-  // happen inside — that's also what keeps a "selected" ring drawn around the
-  // square concentric with the actual rotation point.
+  // the shape's own natural reach from the hub along each axis, plus a little
+  // for the outline stroke — not padded for full-rotation safety. That means a
+  // rotated arrow can clip its corners against the box at some angles, but
+  // every consumer (the on-map marker, the favicon, the settings preview, the
+  // compact card) renders the same unpadded size instead of each one sitting
+  // inside its own oversized, mostly-empty safety margin.
   const reach = Math.max(
-    Math.hypot(body.minX - centreX, body.minY - centreY),
-    Math.hypot(body.minX - centreX, body.maxY - centreY),
-    Math.hypot(body.maxX - centreX, body.minY - centreY),
-    Math.hypot(body.maxX - centreX, body.maxY - centreY),
+    Math.abs(body.minX - centreX),
+    Math.abs(body.maxX - centreX),
+    Math.abs(body.minY - centreY),
+    Math.abs(body.maxY - centreY),
   );
   const half = Math.ceil((reach + bh * 0.06) * k);
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changed
 
 - **🧪 Beta:** Favourites now has its own "Favourites" setting (on by default, shown once beta features are enabled) instead of being tied only to the "Enable beta features" toggle. Every individual beta feature's toggle now lives together with the master toggle in one grouped settings card, with the master toggle always shown first.
+- Compact station cards (Nearby and Favourites) now show the same wind arrow used on the map — giving an at-a-glance read on speed, gusts, and direction — alongside the existing wind-direction history graph. The name, altitude, and last-updated time now share a single line, and the cards themselves are a bit bigger.
+- Map markers now shrink as you zoom out, so they no longer dwarf the map when viewing a whole region.
 
 ### Fixed
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - **🧪 Beta:** Favourites now has its own "Favourites" setting (on by default, shown once beta features are enabled) instead of being tied only to the "Enable beta features" toggle. Every individual beta feature's toggle now lives together with the master toggle in one grouped settings card, with the master toggle always shown first.
-- Compact station cards (Nearby and Favourites) now show the same wind arrow used on the map — giving an at-a-glance read on speed, gusts, and direction — alongside the existing wind-direction history graph. The name, altitude, and last-updated time now share a single line, and the cards themselves are a bit bigger.
+- Compact station cards (Nearby and Favourites) now show the same wind arrow used on the map side by side with the existing wind-direction history graph — giving an at-a-glance read on speed, gusts, and direction. The name, altitude, and last-updated time now share a single line, with the updated time shown as a terser "5m" instead of "5m ago" to save space. The cards themselves are a bit bigger.
 - Map markers now shrink as you zoom out, so they no longer dwarf the map when viewing a whole region.
 
 ### Fixed

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - **🧪 Beta:** Favourites now has its own "Favourites" setting (on by default, shown once beta features are enabled) instead of being tied only to the "Enable beta features" toggle. Every individual beta feature's toggle now lives together with the master toggle in one grouped settings card, with the master toggle always shown first.
 - Compact station cards (Nearby and Favourites) now show the same wind arrow used on the map side by side with the existing wind-direction history graph — giving an at-a-glance read on speed, gusts, and direction. The name, altitude, and last-updated time now share a single line, with the updated time shown as a terser "5m" instead of "5m ago" to save space. The cards themselves are a bit bigger.
-- Map markers now shrink as you zoom out, so they no longer dwarf the map when viewing a whole region.
+- Station markers on the map are bigger by default, and now shrink progressively in steps as you zoom out, so they no longer dwarf the map when viewing a whole region.
 
 ### Fixed
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - **🧪 Beta:** Favourites now has its own "Favourites" setting (on by default, shown once beta features are enabled) instead of being tied only to the "Enable beta features" toggle. Every individual beta feature's toggle now lives together with the master toggle in one grouped settings card, with the master toggle always shown first.
 - Compact station cards (Nearby and Favourites) now show the same wind arrow used on the map side by side with the existing wind-direction history graph — giving an at-a-glance read on speed, gusts, and direction. The name, altitude, and last-updated time now share a single line, with the updated time shown as a terser "5m" instead of "5m ago" to save space. The cards themselves are a bit bigger.
-- Station markers on the map are bigger by default, and now shrink progressively in steps as you zoom out, so they no longer dwarf the map when viewing a whole region.
+- Map markers now shrink as you zoom out, so they no longer dwarf the map when viewing a whole region.
 
 ### Fixed
 

--- a/tests/integration/components/station/updated-meta-test.ts
+++ b/tests/integration/components/station/updated-meta-test.ts
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { render, type RenderingTestContext } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+
+interface StationUpdatedMetaTestContext extends RenderingTestContext {
+  timestamp: number;
+  isCompact?: boolean;
+}
+
+module('Integration | Component | station/updated-meta', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('by default it shows the clock icon and a full "ago" reading', async function (this: StationUpdatedMetaTestContext, assert) {
+    this.timestamp = Date.now() - 5 * 60 * 1000;
+
+    await render(hbs`<Station::UpdatedMeta @timestamp={{this.timestamp}} />`);
+
+    assert.dom('svg').exists('the clock icon is shown');
+    assert.dom('dd').hasText('5m ago');
+  });
+
+  test('in compact mode it hides the icon and drops the "ago" wording', async function (this: StationUpdatedMetaTestContext, assert) {
+    this.timestamp = Date.now() - 5 * 60 * 1000;
+    this.isCompact = true;
+
+    await render(
+      hbs`<Station::UpdatedMeta
+        @timestamp={{this.timestamp}}
+        @isCompact={{this.isCompact}}
+      />`
+    );
+
+    assert.dom('svg').doesNotExist('no icon in compact mode');
+    assert.dom('dd').hasText('5m');
+  });
+
+  test('compact mode applies its own smaller, muted sizing', async function (this: StationUpdatedMetaTestContext, assert) {
+    this.timestamp = Date.now() - 5 * 60 * 1000;
+    this.isCompact = true;
+
+    await render(
+      hbs`<Station::UpdatedMeta
+        @timestamp={{this.timestamp}}
+        @isCompact={{this.isCompact}}
+      />`
+    );
+
+    assert.dom('dd').hasClass('text-[11px]').hasClass('text-slate-500');
+  });
+});

--- a/tests/unit/helpers/time-ago-test.ts
+++ b/tests/unit/helpers/time-ago-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import type { TestContext } from '@ember/test-helpers';
 import { setupTest } from 'winds-mobi-client-web/tests/helpers';
 import {
+  compactTimeAgo,
   renderTimeAgoText,
   timeAgoParts,
 } from 'winds-mobi-client-web/helpers/time-ago';
@@ -28,5 +29,17 @@ module('Unit | Helper | time-ago', function (hooks) {
     const intl = this.owner.lookup('service:intl');
 
     assert.strictEqual(renderTimeAgoText(intl, 600), 'in 10m');
+  });
+
+  test('compactTimeAgo drops the "ago"/unit wording, keeping just a number and a unit letter', function (assert) {
+    assert.strictEqual(compactTimeAgo(45), '45s');
+    assert.strictEqual(compactTimeAgo(600), '10m');
+    assert.strictEqual(compactTimeAgo(7200), '2h');
+    assert.strictEqual(compactTimeAgo(3 * 86400), '3d');
+    assert.strictEqual(compactTimeAgo(2 * 2629800), '2mo');
+  });
+
+  test('compactTimeAgo treats a future offset the same as a past one', function (assert) {
+    assert.strictEqual(compactTimeAgo(-600), '10m');
   });
 });

--- a/tests/unit/utils/station-arrow-test.ts
+++ b/tests/unit/utils/station-arrow-test.ts
@@ -2,12 +2,39 @@ import { module, test } from 'qunit';
 import {
   colourForWindReading,
   MIN_MARKER_SCALE,
+  MIN_ZOOM_MARKER_SCALE,
   scaleForReadingAge,
+  scaleForZoom,
   STALE_STATION_COLOUR,
 } from 'winds-mobi-client-web/utils/station-arrow';
 import windToColour from 'winds-mobi-client-web/helpers/wind-to-colour';
 
 module('Unit | Utility | station-arrow', function () {
+  module('scaleForZoom', function () {
+    test('draws full size once zoomed in close', function (assert) {
+      assert.strictEqual(scaleForZoom(13), 1);
+      assert.strictEqual(scaleForZoom(17), 1);
+    });
+
+    test('shrinks in discrete steps as zoom decreases', function (assert) {
+      assert.strictEqual(scaleForZoom(12.9), 0.8);
+      assert.strictEqual(scaleForZoom(11), 0.8);
+      assert.strictEqual(scaleForZoom(10.9), 0.65);
+      assert.strictEqual(scaleForZoom(9), 0.65);
+      assert.strictEqual(scaleForZoom(8.9), 0.5);
+      assert.strictEqual(scaleForZoom(7), 0.5);
+    });
+
+    test('holds the floor once zoomed out past the lowest step', function (assert) {
+      assert.strictEqual(scaleForZoom(6.9), MIN_ZOOM_MARKER_SCALE);
+      assert.strictEqual(scaleForZoom(0), MIN_ZOOM_MARKER_SCALE);
+    });
+
+    test('a non-finite zoom is treated as full size', function (assert) {
+      assert.strictEqual(scaleForZoom(Number.NaN), 1);
+    });
+  });
+
   module('scaleForReadingAge', function () {
     test('a fresh reading is drawn full size', function (assert) {
       assert.strictEqual(scaleForReadingAge(Date.now()), 1);


### PR DESCRIPTION
## Summary
- Fixes #90: compact station cards (Nearby/Favourites) now show the same on-map wind arrow (speed/gusts/direction at a glance) side by side, 50/50, with the existing wind-direction history graph — both columns vertically centered. The arrow's own box is sized to 2/3 of its available space (not scaled within an unchanged box), so it's genuinely smaller and doesn't crowd the graph column. Speed/gusts numbers are a notch smaller, and the separator between them is now an en dash rather than a slash (it's a range, not a fraction like km/h's slash). Header row (name/altitude/updated) restructured; grid min-width bumped 11rem -> 14rem for readability.
- Extracted the repeated "updated Xm ago" icon+text into one shared component, `station/updated-meta.gts`, used by both the station header and the compact card. It takes `@isCompact`, which — as a single argument — now owns everything about compact mode: hides the clock icon, swaps in a new terse `compactTimeAgo` helper (in the existing shared `time-ago.ts`) for "5m" with no "ago" wording, and applies its own smaller/muted sizing internally instead of relying on a hand-matched `class` passed in alongside it at the call site.
- Removed the shared arrow geometry's worst-case-rotation safety padding (`build/station-arrow-geometry.mjs`), so the arrow renders at the same, tighter size in every context (map marker, favicon, settings preview, compact card) instead of each one sitting in its own mostly-empty box. Tradeoff: a rotated arrow can clip slightly at some angles — flagging this explicitly since it's a visible behavior change worth double-checking on the live map.
- Map markers now also scale down in discrete steps by zoom level (`scaleForZoom` in `app/utils/station-arrow.ts`), so they no longer dwarf the map when zoomed out to a whole region. The marker's own base size (at full zoom) is also bigger than before (`h-16`/64px -> `h-24`/96px in `station-marker.gts`) — the zoom/reading-age shrink multipliers are unaffected, they just now scale down from this larger base.

## Why draft
Posting as WIP so the arrow-clipping tradeoff and zoom-scale steps can get a look on the live map (WebGL doesn't render in this dev container, so several map-dependent acceptance tests are skip-only here — see `tests/helpers/webgl.ts`).

## Test plan
- [x] `pnpm lint` — all green
- [x] Full test suite — 197 pass, 6 skip (WebGL-gated, expected in this container), 0 fail
- [x] New unit tests for `scaleForZoom` and `compactTimeAgo`
- [x] New integration tests for `station/updated-meta` (icon/text toggling, compact sizing)
- [x] compact-card, wind-arrow, station-favicon, station-arrow, station-header integration/unit suites all pass
- [ ] Manual check on the live map: arrow clipping at various rotations, marker size across zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
