### PR TITLE
⏱️ Shorten the store's cache soft-expiry from 30s to 15s

### DIFF
--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -1,4 +1,5 @@
 import { useLegacyStore } from '@warp-drive/legacy';
+import { DefaultCachePolicy } from '@warp-drive/core/store';
 import { JSONAPICache } from '@warp-drive/json-api';
 import StationHandler from 'winds-mobi-client-web/handlers/station';
 import HistoryHandler from 'winds-mobi-client-web/handlers/history';
@@ -215,6 +216,17 @@ const AppStore = useLegacyStore({
   // station/history reshapers see them. Restore alongside it.
   handlers: [StationHandler, HistoryHandler],
   derivations: [unwrapDerivation, composeReadingDerivation],
+  // Warp Drive's own default (30s soft / 15min hard) means a manual refresh
+  // pressed within 30s of the last fetch does nothing at all -- no request,
+  // foreground or background (see issue #118). Shortening apiCacheSoftExpires
+  // to 15s doesn't remove that dead window, but it does halve it, so a manual
+  // refresh reflects new data sooner without forcing every refresh to bypass
+  // the cache outright (which would defeat its point of avoiding redundant
+  // requests). apiCacheHardExpires is left at Warp Drive's own default.
+  policy: new DefaultCachePolicy({
+    apiCacheSoftExpires: 15 * 1000,
+    apiCacheHardExpires: 15 * 60 * 1000,
+  }),
 });
 
 // The store *instance* type — exposes the generic `request<RT>(builder): Future<RT>`,

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed map, search, nearby, and favourites requests being sent twice: the client was missing a trailing slash that made the API respond with a redirect on every call.
 - Time-series charts (wind, air) now show times in your local timezone instead of UTC.
 - Fixed old bookmarked/shared links (e.g. the pre-rebuild `/stations/...` URLs) showing a blank page with a console error — they now redirect to the map instead.
+- Pressing refresh very soon after the last one (within 15s, down from 30s) is now more likely to actually pick up new data.
 - Fixed the installed app's service worker intercepting the API docs, admin, and account-management pages (served by other backends, not this app) and wrongly showing the map instead.
 
 ## v0.18.0 - 2026-07-15


### PR DESCRIPTION
## Summary
- Fixes #118: a manual refresh pressed within Warp Drive's cache soft-expiry window did nothing at all — no foreground or background request — since `app/services/store.ts` used `useLegacyStore` with no explicit `policy` override, falling back to Warp Drive's default `DefaultCachePolicy` (30s soft / 15min hard expiry).
- Lowered `apiCacheSoftExpires` to 15s (leaving `apiCacheHardExpires` at Warp Drive's own 15-minute default) by constructing `DefaultCachePolicy` explicitly and passing it as `policy`.

## Why this approach over the issue's original suggestion
#118's write-up suggested having `MapRefreshService.refreshNow()` pass `cacheOptions: { reload: true }` to force every manual refresh to bypass the cache outright. Went with shortening the window instead: halves the "refresh does nothing" problem without forcing every explicit refresh to skip the cache — preserving the cache's actual point (avoiding redundant requests) while still making the button noticeably more responsive. It doesn't eliminate the dead window, just halves it.

## Test plan
- [x] `pnpm lint` — all green
- [x] Full test suite — 201 pass, 6 skip (WebGL-gated, expected in this dev container), 0 fail
- [ ] No automated test for the specific 15s value: verifying Warp Drive's own cache policy honors a given millisecond threshold would mean testing the library's internals, not our code. `DefaultCachePolicy`'s own docs also note soft-expiry is disabled entirely in Ember's test environment (to avoid flakiness), so a timing-based test wouldn't exercise this path regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
