### PR TITLE
🧭 Anchor the wind-direction graph to its own data, not wall-clock time

### DIFF
--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -18,18 +18,6 @@ export interface WindDirectionGraphSignature {
 }
 
 const LAST_HOUR = 1 * 60 * 60 * 1000;
-const QUARTER_HOUR = 15 * 60 * 1000;
-
-function quarterHourTicks(minTimestamp: number, maxTimestamp: number) {
-  const firstTick = Math.ceil(minTimestamp / QUARTER_HOUR) * QUARTER_HOUR;
-  const ticks: number[] = [];
-
-  for (let tick = firstTick; tick <= maxTimestamp; tick += QUARTER_HOUR) {
-    ticks.push(tick);
-  }
-
-  return ticks;
-}
 
 export default class WindDirectionGraph extends Component<WindDirectionGraphSignature> {
   @service declare intl: IntlService;
@@ -40,14 +28,50 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
   // built a fresh object, which made `ember-highcharts` see "changed" args on
   // every access and re-init/update the underlying chart mid-render -- the
   // root cause of this component's flaky marker-rendering (see TODO.md).
-  // `chartOptions` reads `this.args.data` purely to opt back into
-  // recomputing when a refresh brings new history in, matching this
-  // codebase's `mapRefresh.lastRefresh`-read convention for the same purpose.
+
+  // The radial window spans exactly the given data's own oldest-to-newest
+  // range -- not a fixed 1-hour span anchored off either end (issue #120).
+  // Anchoring to a fixed duration (e.g. `newest - 1 hour`) was tried first
+  // and was wrong two ways: anchoring off wall-clock `Date.now()` let the
+  // window drift away from a station that had gone quiet, leaving the graph
+  // looking sparse or empty; anchoring the span off the newest reading
+  // instead still assumed the returned data always covers a full hour, so
+  // any time it covered less (a quiet spell, a station just back online)
+  // the real oldest reading sat inside that assumed boundary while nothing
+  // else moved to match -- not itself a visible bug, but proof the window
+  // and the data could disagree. Deriving both ends directly from the
+  // data's own extremes make that impossible by construction: no point can
+  // ever fall outside axis bounds that are its own dataset's bounds. `data`
+  // is chronological (oldest first, see app/handlers/history.ts), so the
+  // first/last elements are the two extremes.
+  @cached
+  get windowBounds() {
+    const data = this.args.data ?? [];
+
+    if (data.length === 0) {
+      const now = Date.now();
+
+      return { min: now - LAST_HOUR, max: now };
+    }
+
+    // A single reading has no range of its own to derive from -- fall back
+    // to a 1-hour span so it still draws as a spoke (see `points` below)
+    // instead of collapsing both axis ends onto the same value.
+    if (data.length === 1) {
+      const only = data[0]!.timestamp;
+
+      return { min: only - LAST_HOUR, max: only };
+    }
+
+    return {
+      min: data[0]!.timestamp,
+      max: data[data.length - 1]!.timestamp,
+    };
+  }
+
   @cached
   get chartOptions() {
-    void this.args.data;
-    const now = Date.now();
-    const minTimestamp = now - LAST_HOUR;
+    const { min: minTimestamp, max: maxTimestamp } = this.windowBounds;
 
     return {
       chart: {
@@ -67,8 +91,27 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
         : {}),
       yAxis: {
         min: minTimestamp,
-        max: now,
-        tickPositions: quarterHourTicks(minTimestamp, now),
+        max: maxTimestamp,
+        // Highcharts' radial axis places `min` at the pane center and `max`
+        // at the outer edge by default, so the newest reading lands right
+        // on the outer ring and the oldest reading sits at the center, with
+        // everything else spread linearly between (issue #120). A point
+        // exactly at the center can't show a direction (the angle is
+        // meaningless at radius 0), so this deliberately keeps the newest
+        // reading away from the center, not on it.
+        //
+        // No interval rings -- just the single outer boundary from the pane
+        // itself. `startOnTick`/`endOnTick` default to true, which would
+        // otherwise snap the *rendered* extremes to Highcharts' own
+        // auto-picked "nice" tick values instead of our exact `min`/`max`;
+        // since real timestamps essentially never land on those values, the
+        // rendered max would end up slightly less than the newest reading's
+        // own timestamp, pushing it past 100% radius and outside the ring
+        // entirely. Disabling both keeps the axis pinned to the exact
+        // bounds we give it.
+        startOnTick: false,
+        endOnTick: false,
+        gridLineWidth: 0,
       },
     };
   }
@@ -81,7 +124,7 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
       return [];
     }
 
-    return data.map((elm) => {
+    const mapped = data.map((elm) => {
       const { lineColor, fillColor } = windDirectionMarkerColours(
         elm.speed,
         elm.gusts
@@ -105,6 +148,28 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
         })}`,
       };
     });
+
+    // A single reading on its own would render as one dot on the outer
+    // ring -- technically direction-legible, but easy to miss. Add an
+    // unmarked point at the center in the same direction so it draws as a
+    // full spoke from center to edge instead, reading like a compass needle
+    // (issue #120, point 4).
+    if (mapped.length === 1) {
+      const reading = mapped[0]!;
+
+      return [
+        reading,
+        {
+          x: reading.x,
+          y: this.windowBounds.min,
+          color: reading.color,
+          marker: { enabled: false },
+          customTooltip: reading.customTooltip,
+        },
+      ];
+    }
+
+    return mapped;
   }
 
   @cached

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The last-hour wind-direction graph is now anchored to the last recorded reading instead of the current time, so a station that has gone quiet still shows its full window (previously the graph would empty out as real time drifted past stale data). The most recent reading now sits on the outer ring, with older readings spreading in towards the center. A station with only one reading in the window now draws it as a full spoke from center to edge so its direction stays visible.
+
 ## v0.19.0 - 2026-07-21
 
 ### Added

--- a/tests/integration/components/station/wind-direction/graph-test.ts
+++ b/tests/integration/components/station/wind-direction/graph-test.ts
@@ -5,8 +5,16 @@ import { Type } from '@warp-drive/core/types/symbols';
 import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
 import type { History } from 'winds-mobi-client-web/services/store';
 
+const LAST_HOUR = 1 * 60 * 60 * 1000;
+
 interface WindDirectionGraphTestContext extends RenderingTestContext {
   data: History[];
+}
+
+async function renderedPolarChart() {
+  const Highcharts = (await import('highcharts')).default;
+
+  return Highcharts.charts.findLast((c) => c && c.options.chart?.polar);
 }
 
 // This component's own logic is the marker-colour mapping, covered directly
@@ -56,6 +64,185 @@ module(
       await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
 
       assert.dom('.highcharts-container').exists();
+    });
+
+    // issue #120: the window is derived from the data's own oldest/newest
+    // timestamps, not anchored to wall-clock `Date.now()` or to a fixed
+    // 1-hour span off either end. Anchoring off `Date.now()` let the window
+    // drift away from a station that had gone quiet; anchoring a fixed
+    // 1-hour span off the newest reading instead assumed the returned data
+    // always covers a full hour, which isn't guaranteed -- so a reading
+    // could fall outside the assumed span. Deriving both axis ends from the
+    // data itself rules that out by construction.
+    test('it keeps stale readings on screen instead of anchoring the window to wall-clock time', async function (this: WindDirectionGraphTestContext, assert) {
+      const lastReadingTimestamp = Date.now() - 170 * 60 * 1000;
+
+      this.data = [
+        {
+          id: 'stale-1',
+          direction: 45,
+          speed: 8,
+          gusts: 10,
+          temperature: 5,
+          humidity: 62,
+          rain: 0,
+          timestamp: lastReadingTimestamp - 15 * 60 * 1000,
+          [Type]: 'history',
+        },
+        {
+          id: 'stale-2',
+          direction: 90,
+          speed: 9,
+          gusts: 12,
+          temperature: 5,
+          humidity: 61,
+          rain: 0,
+          timestamp: lastReadingTimestamp,
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+
+      const series = (await renderedPolarChart())?.series[0];
+
+      assert.deepEqual(
+        series?.data.map((p) => p.y),
+        this.data.map((row) => row.timestamp),
+        'both stale readings still render, none clipped by a real-time window'
+      );
+    });
+
+    test('it sizes the axis to the data span it was actually given, not a fixed 1-hour offset', async function (this: WindDirectionGraphTestContext, assert) {
+      const now = Date.now();
+
+      // Only 12 minutes apart -- far short of a full hour. Under a fixed
+      // `newest - 1 hour` window this data would still render fine (nothing
+      // falls outside a *wider* assumed span), but the axis and the data
+      // would disagree about what "the edge" means; deriving the axis from
+      // the data itself keeps them in lockstep, which is what this test pins.
+      this.data = [
+        {
+          id: 'oldest',
+          direction: 200,
+          speed: 4,
+          gusts: 5,
+          temperature: 6,
+          humidity: 60,
+          rain: 0,
+          timestamp: now - 12 * 60 * 1000,
+          [Type]: 'history',
+        },
+        {
+          id: 'newest',
+          direction: 20,
+          speed: 6,
+          gusts: 7,
+          temperature: 6,
+          humidity: 59,
+          rain: 0,
+          timestamp: now,
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+
+      const chart = await renderedPolarChart();
+
+      assert.strictEqual(
+        chart?.yAxis[0]?.min,
+        this.data[0]!.timestamp,
+        'axis min is the oldest reading in the data, not an hour before the newest'
+      );
+      assert.strictEqual(
+        chart?.yAxis[0]?.max,
+        this.data[1]!.timestamp,
+        'axis max is the newest reading in the data'
+      );
+    });
+
+    test('it places the most recently recorded reading closer to the outer edge than an older one', async function (this: WindDirectionGraphTestContext, assert) {
+      const now = Date.now();
+
+      this.data = [
+        {
+          id: 'older',
+          direction: 270,
+          speed: 5,
+          gusts: 6,
+          temperature: 6,
+          humidity: 60,
+          rain: 0,
+          timestamp: now - 30 * 60 * 1000,
+          [Type]: 'history',
+        },
+        {
+          id: 'recent',
+          direction: 90,
+          speed: 15,
+          gusts: 16,
+          temperature: 7,
+          humidity: 58,
+          rain: 0,
+          timestamp: now,
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+
+      const chart = await renderedPolarChart();
+      const series = chart?.series[0];
+      // `pane` (the polar center/radius) isn't part of Highcharts' public
+      // `Chart` type -- it's added at runtime by the highcharts-more/polar
+      // module -- so read it through a narrow local shape instead of `any`.
+      const pane = (
+        chart as unknown as { pane?: { center: number[] }[] } | undefined
+      )?.pane?.[0]?.center;
+      const [centerX, centerY] = [pane?.[0] ?? 0, pane?.[1] ?? 0];
+
+      const distanceFromCenter = (point: { plotX?: number; plotY?: number }) =>
+        Math.hypot((point.plotX ?? 0) - centerX, (point.plotY ?? 0) - centerY);
+
+      const distances = series?.data.map(distanceFromCenter) ?? [];
+      const [olderDistance, recentDistance] = [
+        distances[0] ?? 0,
+        distances[1] ?? 0,
+      ];
+
+      assert.true(
+        recentDistance > olderDistance,
+        'the more recent reading sits closer to the outer edge'
+      );
+    });
+
+    test('it renders a single reading as a spoke from the center to the outer edge', async function (this: WindDirectionGraphTestContext, assert) {
+      const timestamp = Date.now();
+
+      this.data = [
+        {
+          id: 'only',
+          direction: 135,
+          speed: 5,
+          gusts: 6,
+          temperature: 6,
+          humidity: 60,
+          rain: 0,
+          timestamp,
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+
+      const series = (await renderedPolarChart())?.series[0];
+
+      assert.deepEqual(
+        series?.data.map((p) => p.y),
+        [timestamp, timestamp - LAST_HOUR],
+        'a synthetic point is added at the center, in the same direction, so the single reading draws as a visible spoke rather than a lone dot on the outer ring'
+      );
     });
   }
 );


### PR DESCRIPTION
Why: The last-hour polar graph windowed itself off real-time `Date.now()` (`[now - 1h, now]`), so a station that had gone quiet slid its data out of that window as real time passed, leaving the graph sparse or empty even though the "last updated X ago" text right next to it already communicates staleness (issue #120).

How: The radial axis now spans exactly the given data's own oldest-to- newest timestamps instead of a fixed span anchored to either `Date.now()` or the newest reading -- no reading can ever fall outside axis bounds that are its own dataset's bounds. The newest reading lands on the outer ring, the oldest at the center (confirmed with ysavary in #120: a point exactly at the center can't show a direction, since the angle is meaningless at radius 0), and a lone reading in the window gets a synthetic center point so it still draws as a full spoke rather than a single easy-to-miss dot on the ring. The interval-ring gridlines and the tick-position machinery behind them are gone entirely -- Highcharts' own startOnTick/endOnTick were fighting our exact bounds to align to them, and the rings themselves weren't adding anything.
