### PR TITLE
🕳️ Render gust markers as a hollow ring

### DIFF
--- a/app/utils/wind-direction-marker.ts
+++ b/app/utils/wind-direction-marker.ts
@@ -5,10 +5,22 @@ export interface WindDirectionMarkerColours {
   fillColor: string;
 }
 
+// The card behind this chart is always plain white (this app has no dark
+// mode -- see section-card.gts / compact-card.gts). A genuinely transparent
+// fill (CSS `transparent`) lets the connecting line, which Highcharts draws
+// as one continuous path underneath the whole marker layer, show straight
+// through the hollow center -- there's no "line has a hole here" option, a
+// marker is just drawn on top of whatever line segment already passes
+// through its position. Painting the center in the actual background
+// colour instead punches a real opaque hole that hides that segment, giving
+// the same visual result (a hollow ring) without the line bleeding through.
+const CARD_BACKGROUND_COLOUR = 'white';
+
 // Mirrors the map marker's outline/hub convention (see station-favicon.ts):
-// the ring stays the wind-speed colour, and the center only switches to the
-// gusts colour when gusts fall in a different wind band -- otherwise it's a
-// plain speed-coloured dot.
+// the ring stays the wind-speed colour, and the center is only filled with
+// the gusts colour when gusts fall in a different wind band -- otherwise
+// it's left as a hollow ring (see CARD_BACKGROUND_COLOUR above for why that's
+// a background-coloured fill rather than literal transparency).
 export function windDirectionMarkerColours(
   speed: number,
   gusts: number
@@ -18,6 +30,7 @@ export function windDirectionMarkerColours(
 
   return {
     lineColor: speedColour,
-    fillColor: gustsColour === speedColour ? speedColour : gustsColour,
+    fillColor:
+      gustsColour === speedColour ? CARD_BACKGROUND_COLOUR : gustsColour,
   };
 }

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- When a station's gusts fall in the same wind-speed band as the average, its wind-direction markers (in the station panel's last-hour graph and the compact-card wind-direction thumbnail) now draw as a hollow ring instead of a solid dot, matching the map marker's existing convention.
+
 ## v0.19.5 - 2026-07-24
 
 ### Changed

--- a/tests/unit/utils/wind-direction-marker-test.ts
+++ b/tests/unit/utils/wind-direction-marker-test.ts
@@ -2,10 +2,11 @@ import { module, test } from 'qunit';
 import { windDirectionMarkerColours } from 'winds-mobi-client-web/utils/wind-direction-marker';
 
 module('Unit | Utility | wind-direction-marker', function () {
-  test('it returns a plain speed-coloured marker when gusts share the wind-speed band', function (assert) {
+  test('it leaves the marker center a hollow (background-coloured) ring when gusts share the wind-speed band', function (assert) {
     const { lineColor, fillColor } = windDirectionMarkerColours(2, 2);
 
-    assert.strictEqual(lineColor, fillColor);
+    assert.notStrictEqual(fillColor, lineColor);
+    assert.strictEqual(fillColor, 'white');
   });
 
   test('it fills the marker with the gusts colour when gusts fall in a different wind band', function (assert) {


### PR DESCRIPTION
when gusts match the wind-speed band

Why: When a reading's gusts fall in the same wind-speed band as the average, the last-hour wind-direction graph drew a solid dot -- the map marker's own hub convention (#101) already leaves the hub unfilled in this case rather than repeating the body colour, so the chart didn't match.

How: `windDirectionMarkerColours` now fills the marker's center with the card's actual background colour instead of the wind-speed colour when the bands match. A literal transparent fill doesn't work here: Highcharts draws the connecting line as one continuous path underneath the whole marker layer, so a truly see-through center lets the line bleed straight through it. Painting the center with the real background colour (this app has no dark mode, so it's reliably plain white -- see section-card.gts / compact-card.gts) punches a real opaque hole that hides that line segment instead.

Notes: Addresses #126.