### PR TITLE
🧭 Always show cardinal-only labels on the nearby-list thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- The nearby-list thumbnail version of the wind-direction graph now always shows the N/E/S/W compass labels (in a fixed-width font so they line up evenly) instead of hiding all labels.
 - When a station's gusts fall in the same wind-speed band as the average, its wind-direction markers (in the station panel's last-hour graph and the compact-card wind-direction thumbnail) now draw as a hollow ring instead of a solid dot, matching the map marker's existing convention.
 
 ## v0.19.6 - 2026-07-26

--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -3,6 +3,10 @@ import Component from '@glimmer/component';
 import { DIRECTIONS } from 'winds-mobi-client-web/helpers/azimuth-to-cardinal';
 import renderHighcharts from 'winds-mobi-client-web/modifiers/render-highcharts';
 import {
+  cardinalOnlyDirectionLabel,
+  COMPASS_LABEL_FONT_FAMILY,
+} from 'winds-mobi-client-web/utils/compass-labels';
+import {
   mergeChartOptions,
   type ChartOptions,
 } from 'winds-mobi-client-web/utils/highcharts-options';
@@ -150,9 +154,14 @@ export default class Polar extends Component<PolarSignature> {
           },
         },
         {
-          // Thumbnail size (e.g. a compact nearby-list row): the N/E/S/W
-          // labels have no room to render legibly, so drop them entirely and
-          // let the polar pane fill almost the whole box as a plain dot scatter.
+          // Thumbnail size (e.g. the last-hour card on a genuinely narrow
+          // phone viewport): the full 8-way N/NE/E/SE/S/SW/W/NW label set has
+          // no room to render legibly, but the 4 cardinal directions still
+          // fit, so keep only those and drop the diagonals. This is a
+          // fallback keyed on the chart's own measured width; a consumer that
+          // is *always* compact by design (e.g. the nearby-list thumbnail)
+          // should pass `@compact` to `WindDirectionGraph` instead of relying
+          // on this to happen to trigger -- see graph.gts.
           condition: {
             maxWidth: 90,
           },
@@ -170,7 +179,12 @@ export default class Polar extends Component<PolarSignature> {
             },
             xAxis: {
               labels: {
-                enabled: false,
+                formatter: function ({ value }: { value: number }) {
+                  return cardinalOnlyDirectionLabel(value);
+                },
+                style: {
+                  fontFamily: COMPASS_LABEL_FONT_FAMILY,
+                },
               },
             },
           },

--- a/app/components/station/wind-direction-thumbnail.gts
+++ b/app/components/station/wind-direction-thumbnail.gts
@@ -56,21 +56,15 @@ export default class StationWindDirectionThumbnail extends Component<StationWind
     <div class="min-h-0 min-w-0" ...attributes>
       <Request @request={{this.historyRequest}}>
         <:content as |result|>
-          <WindDirectionGraph @data={{result.data}} @hideAxisLabels={{true}} />
+          <WindDirectionGraph @data={{result.data}} @compact={{true}} />
         </:content>
 
         <:loading>
-          <WindDirectionGraph
-            @data={{EMPTY_HISTORY}}
-            @hideAxisLabels={{true}}
-          />
+          <WindDirectionGraph @data={{EMPTY_HISTORY}} @compact={{true}} />
         </:loading>
 
         <:error>
-          <WindDirectionGraph
-            @data={{EMPTY_HISTORY}}
-            @hideAxisLabels={{true}}
-          />
+          <WindDirectionGraph @data={{EMPTY_HISTORY}} @compact={{true}} />
         </:error>
       </Request>
     </div>

--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -4,12 +4,23 @@ import type { History } from 'winds-mobi-client-web/services/store.js';
 import { service } from '@ember/service';
 import { type IntlService } from 'ember-intl';
 import Polar from 'winds-mobi-client-web/components/chart/polar';
+import {
+  cardinalOnlyDirectionLabel,
+  COMPASS_LABEL_FONT_FAMILY,
+} from 'winds-mobi-client-web/utils/compass-labels';
 import { windDirectionMarkerColours } from 'winds-mobi-client-web/utils/wind-direction-marker';
 
 export interface WindDirectionGraphSignature {
   Args: {
     data: History[];
-    hideAxisLabels?: boolean;
+    // For a consumer that's always small by design (e.g. the nearby-list
+    // thumbnail), not just incidentally narrow. Polar's own maxWidth:90
+    // responsive rule already drops to cardinal-only labels based on the
+    // chart's *measured* width, but a compact grid card can easily render
+    // wider than that threshold depending on viewport/column count while
+    // still being "the small one" by intent -- this forces the same
+    // cardinal-only label set regardless of actual measured width.
+    compact?: boolean;
   };
   Blocks: {
     default: [];
@@ -83,11 +94,25 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
       pane: {
         size: '99%',
       },
-      // Omit `xAxis` entirely rather than setting it to `undefined` — Polar's
-      // shallow merge spreads override keys over defaults, so an explicit
-      // `undefined` would clobber the default xAxis instead of falling back to it.
-      ...(this.args.hideAxisLabels
-        ? { xAxis: { labels: { enabled: false } } }
+      // Matches the distance/font-size Polar's own maxWidth:90 responsive
+      // rule uses for a genuinely narrow chart, so a compact consumer looks
+      // the same whether or not its actual measured width happens to cross
+      // that threshold.
+      ...(this.args.compact
+        ? {
+            xAxis: {
+              labels: {
+                formatter: function ({ value }: { value: number }) {
+                  return cardinalOnlyDirectionLabel(value);
+                },
+                distance: '78%',
+                style: {
+                  fontSize: '10px',
+                  fontFamily: COMPASS_LABEL_FONT_FAMILY,
+                },
+              },
+            },
+          }
         : {}),
       yAxis: {
         min: minTimestamp,

--- a/app/utils/compass-labels.ts
+++ b/app/utils/compass-labels.ts
@@ -1,0 +1,17 @@
+import { DIRECTIONS } from 'winds-mobi-client-web/helpers/azimuth-to-cardinal';
+
+// The 4 cardinal directions are the even indices into DIRECTIONS (N=0, E=2,
+// S=4, W=6); the diagonals (NE/SE/SW/NW) are the odd ones. Used where there's
+// only room for the basic compass points, not the full 8-way set.
+export function cardinalOnlyDirectionLabel(value: number): string {
+  const index = Math.round(value / 45) % 8;
+
+  return index % 2 === 0 ? DIRECTIONS[index]! : '';
+}
+
+// Every visible label in the cardinal-only set is exactly one character
+// (N/E/S/W); a proportional font renders single glyphs at noticeably
+// different widths (a thin "I"-like stroke vs. a wide "W"), which looks
+// inconsistent once every label is down to just one letter. A monospace
+// font keeps them visually uniform.
+export const COMPASS_LABEL_FONT_FAMILY = 'ui-monospace, monospace';

--- a/tests/integration/components/station/wind-direction/graph-test.ts
+++ b/tests/integration/components/station/wind-direction/graph-test.ts
@@ -274,5 +274,35 @@ module(
         'a synthetic point is added at the center, in the same direction, so the single reading draws as a visible spoke rather than a lone dot on the outer ring'
       );
     });
+
+    // A grid card (e.g. the nearby-list thumbnail) can render wider than
+    // Polar's own maxWidth:90 responsive breakpoint depending on viewport/
+    // column count while still being "the small one" by design intent, so
+    // `@compact` must force cardinal-only labels itself rather than relying
+    // on the chart's actual measured width to cross that threshold.
+    test('it forces cardinal-only labels when @compact is set, regardless of measured width', async function (this: WindDirectionGraphTestContext, assert) {
+      this.data = [];
+
+      await render(hbs`
+        <div class="h-96 w-96">
+          <Station::WindDirection::Graph @data={{this.data}} @compact={{true}} />
+        </div>
+      `);
+
+      const chart = await renderedPolarChart();
+      // The label formatter isn't part of Highcharts' public `XAxisOptions`
+      // type in a directly-callable shape, so read it through a narrow local
+      // shape instead of `any`.
+      const formatter = (
+        chart?.userOptions.xAxis as
+          | { labels?: { formatter?: (ctx: { value: number }) => string } }[]
+          | undefined
+      )?.[0]?.labels?.formatter;
+
+      assert.strictEqual(formatter?.({ value: 0 }), 'N');
+      assert.strictEqual(formatter?.({ value: 90 }), 'E');
+      assert.strictEqual(formatter?.({ value: 45 }), '');
+      assert.strictEqual(formatter?.({ value: 315 }), '');
+    });
   }
 );

--- a/tests/unit/utils/compass-labels-test.ts
+++ b/tests/unit/utils/compass-labels-test.ts
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { cardinalOnlyDirectionLabel } from 'winds-mobi-client-web/utils/compass-labels';
+
+module('Unit | Utility | compass-labels', function () {
+  test('it labels the 4 cardinal directions', function (assert) {
+    assert.strictEqual(cardinalOnlyDirectionLabel(0), 'N');
+    assert.strictEqual(cardinalOnlyDirectionLabel(90), 'E');
+    assert.strictEqual(cardinalOnlyDirectionLabel(180), 'S');
+    assert.strictEqual(cardinalOnlyDirectionLabel(270), 'W');
+  });
+
+  test('it drops the 4 diagonal directions', function (assert) {
+    assert.strictEqual(cardinalOnlyDirectionLabel(45), '');
+    assert.strictEqual(cardinalOnlyDirectionLabel(135), '');
+    assert.strictEqual(cardinalOnlyDirectionLabel(225), '');
+    assert.strictEqual(cardinalOnlyDirectionLabel(315), '');
+  });
+
+  test('it wraps a full-circle value back to N', function (assert) {
+    assert.strictEqual(cardinalOnlyDirectionLabel(360), 'N');
+  });
+});


### PR DESCRIPTION
Why: The nearby-list thumbnail version of the wind-direction graph disabled axis labels outright (`@hideAxisLabels`). Polar's own maxWidth:90 responsive rule already reduces to cardinal-only labels for a genuinely narrow chart, but a compact grid card can render wider than that threshold depending on viewport/column count while still being "the small one" by design intent -- so the thumbnail never actually got any labels at all.

How: Replaced `@hideAxisLabels` with an explicit `@compact` arg on `WindDirectionGraph` that forces the same cardinal-only N/E/S/W label set (dropping the diagonals) regardless of the chart's actual measured width, in a monospace font so the single-letter labels line up evenly. The cardinal-only logic is shared between this explicit path and Polar's own width-based responsive rule via a new `app/utils/compass-labels.ts`.

Notes: Addresses #127.