### PR TITLE
Scrollable station panel meta row, sticky header shadow, and Frontile Button conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,22 @@ obvious from the decorator call site:
 ### UI
 
 - Reuse existing Frontile + Tailwind patterns for shared UI before introducing new ones.
+- **Always use Frontile's `<Button>` (`@frontile/buttons`) instead of a bare HTML `<button>`.** Use `@onPress`
+  (not an `{{on "click" ...}}` modifier). Reach for `@appearance="custom"` (plus an explicit `@intent="default"`,
+  since `custom`'s own default intent resolves to `primary`) when a button needs fully bespoke, non-thematic
+  coloring (e.g. an SVG marker whose fill colors are computed data, not a Frontile intent) — `custom` has no
+  background/hover compound classes of its own to fight, unlike `minimal`/`outlined`/`default`. Only a handful of
+  _non-button_ clickable custom elements are legitimate exceptions (e.g. `<LinkTo>` navigation, or a MapLibre
+  control that isn't DOM at all) — a plain `<button>` standing in for one is not.
+  - **A `class` override does NOT tailwind-merge against the theme's own base/variant classes** — verified
+    empirically (render a `<Button class="rounded-full">`, inspect `element.className`): both `rounded-sm` (the
+    theme's base) and your `rounded-full` end up in the class list, and plain CSS source order — not attribute
+    order — decides which one's declaration wins, which is effectively undefined from the call site. Whenever your
+    `class` is meant to _replace_ a variant-driven utility (shape, size/padding, display), force it with Tailwind
+    v4's `!` suffix (e.g. `rounded-full!`, `p-1!`, `flex!`) rather than relying on it winning by luck. This only
+    matters for genuine conflicts (same CSS property); additive classes (new colors, `transition`, etc.) need no
+    `!`. `@frontile/theme` does depend on `tailwind-merge` internally, but not for this — don't assume it applies
+    to a plain `<Button class="...">` override without checking.
 
 ### Testing
 

--- a/app/components/help/live-station.gts
+++ b/app/components/help/live-station.gts
@@ -9,6 +9,7 @@ import type {
 } from 'winds-mobi-client-web/services/store.js';
 import StationAir from 'winds-mobi-client-web/components/station/air';
 import StationHeader from 'winds-mobi-client-web/components/station/header';
+import StationMeta from 'winds-mobi-client-web/components/station/meta';
 import StationSummary from 'winds-mobi-client-web/components/station/summary';
 import StationWind from 'winds-mobi-client-web/components/station/wind';
 
@@ -40,6 +41,7 @@ export default class HelpLiveStation extends Component<HelpLiveStationSignature>
             class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
           >
             <StationHeader @station={{result.data}} />
+            <StationMeta @station={{result.data}} class="mt-1.5" />
           </div>
 
           <div class="rounded-xl border border-slate-200 bg-slate-100 p-3">

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { on } from '@ember/modifier';
+import { Button } from '@frontile/buttons';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 import {
   ARROW_DIRECTION_OFFSET,
@@ -105,14 +105,15 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
   }
 
   <template>
-    <button
-      type="button"
+    <Button
       aria-label={{@station.name}}
-      class={{this.buttonClass}}
       data-selected={{if @isSelected "true"}}
       data-station-id={{@station.id}}
       data-test-map-station-marker
-      {{on "click" this.handleSelect}}
+      @appearance="custom"
+      @intent="default"
+      @onPress={{this.handleSelect}}
+      class={{this.buttonClass}}
     >
       <svg
         aria-hidden="true"
@@ -136,6 +137,6 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
           />
         </g>
       </svg>
-    </button>
+    </Button>
   </template>
 }

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -88,9 +88,16 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     return `${rotate} translate(${cx} ${cy}) scale(${scale}) translate(${-cx} ${-cy})`;
   }
 
+  // Frontile's Button doesn't tailwind-merge its `class` arg against the
+  // theme's own base/variant classes (verified empirically -- both a passed
+  // override and the conflicting theme class end up in the DOM, and CSS
+  // source order decides the winner, not attribute order). `!` forces our
+  // override to win regardless: without it, the theme's own `rounded-sm`/
+  // default-size padding non-deterministically fight this button's own
+  // `rounded-full`/`p-1`.
   get buttonClass() {
     const base =
-      'block cursor-pointer rounded-full p-1 transition focus:outline-none';
+      'block cursor-pointer rounded-full! p-1! transition focus:outline-none';
 
     // Selected: a grey disc + ring hugging the arrow so it stands out without
     // spilling into neighbouring markers' clickable area.

--- a/app/components/settings/showcase/refresh-spin.gts
+++ b/app/components/settings/showcase/refresh-spin.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
 import { htmlSafe } from '@ember/template';
+import { Button } from '@frontile/buttons';
 import { t } from 'ember-intl';
 import ArrowClockwise from 'ember-phosphor-icons/components/ph-arrow-clockwise';
 
@@ -53,11 +53,11 @@ export default class SettingsShowcaseRefreshSpin extends Component<SettingsShowc
       class="flex items-center justify-center rounded-lg bg-slate-100 p-4"
       ...attributes
     >
-      <button
-        type="button"
+      <Button
         aria-label={{t "settings.refreshButtonSpin.tryIt"}}
-        class="flex h-12 w-12 items-center justify-center rounded-sm border border-slate-300 bg-white"
-        {{on "click" this.handlePress}}
+        @appearance="outlined"
+        @onPress={{this.handlePress}}
+        class="flex h-12 w-12 items-center justify-center p-0"
       >
         {{! template-lint-disable no-inline-styles }}
         <span
@@ -67,7 +67,7 @@ export default class SettingsShowcaseRefreshSpin extends Component<SettingsShowc
           <ArrowClockwise />
         </span>
         {{! template-lint-enable no-inline-styles }}
-      </button>
+      </Button>
     </div>
   </template>
 }

--- a/app/components/settings/showcase/refresh-spin.gts
+++ b/app/components/settings/showcase/refresh-spin.gts
@@ -57,7 +57,7 @@ export default class SettingsShowcaseRefreshSpin extends Component<SettingsShowc
         aria-label={{t "settings.refreshButtonSpin.tryIt"}}
         @appearance="outlined"
         @onPress={{this.handlePress}}
-        class="flex h-12 w-12 items-center justify-center p-0"
+        class="flex! h-12 w-12 items-center justify-center p-0!"
       >
         {{! template-lint-disable no-inline-styles }}
         <span

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -68,7 +68,7 @@ export default class StationHeader extends Component<StationHeaderSignature> {
           aria-pressed={{if this.isFavorite "true" "false"}}
           data-test-station-favorite
           @appearance="minimal"
-          @size="sm"
+          @size="xs"
           @onPress={{this.handleToggleFavorite}}
         >
           <Heart

--- a/app/components/station/header.gts
+++ b/app/components/station/header.gts
@@ -3,20 +3,12 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import { Button } from '@frontile/buttons';
-import { formatNumber } from 'ember-intl';
 import { t } from 'ember-intl';
-import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
 import Heart from 'ember-phosphor-icons/components/ph-heart';
-import Mountains from 'ember-phosphor-icons/components/ph-mountains';
-import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
-import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
 import type FavoritesService from 'winds-mobi-client-web/services/favorites';
-import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
-import StationMetaItem from './meta-item';
-import StationUpdatedMeta from './updated-meta';
 
 export interface StationHeaderSignature {
   Args: {
@@ -30,14 +22,7 @@ export interface StationHeaderSignature {
 
 export default class StationHeader extends Component<StationHeaderSignature> {
   @service declare favorites: FavoritesService;
-  @service('nearby-location') declare nearbyLocation: NearbyLocationService;
   @service declare settings: SettingsService;
-
-  get hasProviderLink() {
-    return Boolean(
-      this.args.station.providerName && this.args.station.providerUrl
-    );
-  }
 
   // Favouriting is a beta feature (see app/services/settings.ts): hidden
   // until beta is opted into *and* the favourites feature's own toggle is on.
@@ -59,99 +44,40 @@ export default class StationHeader extends Component<StationHeaderSignature> {
   }
 
   <template>
-    <div class="min-w-0">
-      <div class="flex items-start justify-between gap-2">
-        <h2 class="min-w-0 flex-1">
-          <LinkTo
-            data-test-station-title
-            @route="map.station"
-            @model={{@station.id}}
-            @query={{focusQueryParamsFor @station}}
-            title={{t "station.showOnMap"}}
-            class="block truncate text-xl font-bold text-slate-950 underline decoration-transparent underline-offset-3 transition hover:decoration-slate-300"
-          >
-            {{@station.name}}
-          </LinkTo>
-        </h2>
-
-        {{#if this.showFavoriteControl}}
-          <Button
-            aria-label={{if
-              this.isFavorite
-              (t "station.favorite.remove")
-              (t "station.favorite.add")
-            }}
-            aria-pressed={{if this.isFavorite "true" "false"}}
-            data-test-station-favorite
-            @appearance="minimal"
-            @size="sm"
-            @onPress={{this.handleToggleFavorite}}
-          >
-            <Heart
-              @size={{20}}
-              @weight={{if this.isFavorite "fill" "regular"}}
-              class={{if this.isFavorite "text-rose-500" "text-slate-400"}}
-            />
-          </Button>
-        {{/if}}
-      </div>
-
-      <dl
-        class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] font-medium text-slate-500"
-      >
-        {{! Peaks (free-flight take-off sites) get the mountain glyph; other }}
-        {{! stations show altitude with no icon. }}
-        <StationMetaItem
-          @icon={{if @station.isPeak Mountains}}
-          @label={{t "station.meta.altitude"}}
+    <div class="flex min-w-0 items-start justify-between gap-2">
+      <h2 class="min-w-0 flex-1">
+        <LinkTo
+          data-test-station-title
+          @route="map.station"
+          @model={{@station.id}}
+          @query={{focusQueryParamsFor @station}}
+          title={{t "station.showOnMap"}}
+          class="block truncate text-xl font-bold text-slate-950 underline decoration-transparent underline-offset-3 transition hover:decoration-slate-300"
         >
-          <span>{{formatNumber @station.altitude maximumFractionDigits=0}}
-            m</span>
-        </StationMetaItem>
+          {{@station.name}}
+        </LinkTo>
+      </h2>
 
-        <StationUpdatedMeta @timestamp={{@station.last.timestamp}} />
-
-        {{#let this.nearbyLocation.coordinates as |coordinates|}}
-          {{#let
-            (formatDistanceKm
-              coordinates.latitude
-              coordinates.longitude
-              @station.latitude
-              @station.longitude
-            )
-            as |distanceLabel|
+      {{#if this.showFavoriteControl}}
+        <Button
+          aria-label={{if
+            this.isFavorite
+            (t "station.favorite.remove")
+            (t "station.favorite.add")
           }}
-            {{#if distanceLabel}}
-              <StationMetaItem
-                data-test-station-distance
-                @icon={{NavigationArrow}}
-                @label={{t "station.meta.distance"}}
-              >
-                <span>{{distanceLabel}}</span>
-              </StationMetaItem>
-            {{/if}}
-          {{/let}}
-        {{/let}}
-
-        {{#if this.hasProviderLink}}
-          <StationMetaItem
-            @icon={{ArrowSquareUpRight}}
-            @label={{t "station.meta.provider"}}
-          >
-            <span>
-              <a
-                data-test-station-provider-link
-                href={{@station.providerUrl}}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="underline decoration-slate-300 underline-offset-3 transition hover:text-slate-900 hover:decoration-slate-500"
-              >
-                {{@station.providerName}}
-              </a>
-            </span>
-          </StationMetaItem>
-        {{/if}}
-      </dl>
+          aria-pressed={{if this.isFavorite "true" "false"}}
+          data-test-station-favorite
+          @appearance="minimal"
+          @size="sm"
+          @onPress={{this.handleToggleFavorite}}
+        >
+          <Heart
+            @size={{20}}
+            @weight={{if this.isFavorite "fill" "regular"}}
+            class={{if this.isFavorite "text-rose-500" "text-slate-400"}}
+          />
+        </Button>
+      {{/if}}
     </div>
   </template>
 }

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import type RouterService from '@ember/routing/router-service';
 import { on } from '@ember/modifier';
+import X from 'ember-phosphor-icons/components/ph-x';
 import StationHeader from './header';
 import StationMeta from './meta';
 import StationSummary from './summary';
@@ -50,12 +51,12 @@ export default class StationIndex extends Component<StationIndexSignature> {
         <button
           data-test-station-close
           type="button"
-          class="self-start rounded-md p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+          class="self-start rounded-md p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
           aria-label={{t "common.close"}}
           title={{t "common.close"}}
           {{on "click" this.close}}
         >
-          &times;
+          <X @size={{20}} />
         </button>
       </div>
 

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -66,7 +66,7 @@ export default class StationIndex extends Component<StationIndexSignature> {
 
       <div class="min-h-0 flex-1 overflow-y-auto">
         {{#if @station}}
-          <div class="grid gap-3 px-4 pb-3 sm:px-5 md:gap-4 md:pb-4">
+          <div class="grid gap-3 px-4 py-3 sm:px-5 md:gap-4 md:py-4">
             <StationMeta @station={{@station}} />
             <StationSummary @station={{@station}} />
             <StationWind @stationId={{@station.id}} />

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -42,7 +42,9 @@ export default class StationIndex extends Component<StationIndexSignature> {
       data-test-station-panel
       class="flex h-[24rem] w-full shrink-0 flex-col overflow-hidden border-t border-slate-200 bg-white shadow-md shadow-slate-900/12 landscape:h-full landscape:w-[min(32rem,50vw)] landscape:border-r landscape:border-t-0 landscape:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)] md:h-full md:w-[32rem] md:border-r md:border-t-0 md:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)]"
     >
-      <div class="shrink-0 flex items-start justify-between gap-4 px-4 pt-3">
+      <div
+        class="relative z-10 shrink-0 flex items-start justify-between gap-4 px-4 py-2 shadow-md shadow-slate-900/10"
+      >
         <div class="min-w-0">
           {{#if @station}}
             <StationHeader @station={{@station}} />
@@ -52,10 +54,11 @@ export default class StationIndex extends Component<StationIndexSignature> {
           data-test-station-close
           aria-label={{t "common.close"}}
           title={{t "common.close"}}
-          @appearance="minimal"
+          @appearance="custom"
+          @intent="default"
           @size="xs"
           @onPress={{this.close}}
-          class="self-start rounded-md text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+          class="self-start rounded-md! text-slate-500! transition hover:bg-slate-100 hover:text-slate-900"
         >
           <X @size={{20}} />
         </Button>
@@ -63,7 +66,7 @@ export default class StationIndex extends Component<StationIndexSignature> {
 
       <div class="min-h-0 flex-1 overflow-y-auto">
         {{#if @station}}
-          <div class="grid gap-3 px-4 py-3 sm:px-5 md:gap-4 md:py-4">
+          <div class="grid gap-3 px-4 pb-3 sm:px-5 md:gap-4 md:pb-4">
             <StationMeta @station={{@station}} />
             <StationSummary @station={{@station}} />
             <StationWind @stationId={{@station.id}} />

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import type RouterService from '@ember/routing/router-service';
-import { on } from '@ember/modifier';
+import { Button } from '@frontile/buttons';
 import X from 'ember-phosphor-icons/components/ph-x';
 import StationHeader from './header';
 import StationMeta from './meta';
@@ -42,22 +42,23 @@ export default class StationIndex extends Component<StationIndexSignature> {
       data-test-station-panel
       class="flex h-[24rem] w-full shrink-0 flex-col overflow-hidden border-t border-slate-200 bg-white shadow-md shadow-slate-900/12 landscape:h-full landscape:w-[min(32rem,50vw)] landscape:border-r landscape:border-t-0 landscape:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)] md:h-full md:w-[32rem] md:border-r md:border-t-0 md:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)]"
     >
-      <div class="shrink-0 flex items-start justify-between gap-4 px-4 py-3">
+      <div class="shrink-0 flex items-start justify-between gap-4 px-4 pt-3">
         <div class="min-w-0">
           {{#if @station}}
             <StationHeader @station={{@station}} />
           {{/if}}
         </div>
-        <button
+        <Button
           data-test-station-close
-          type="button"
-          class="self-start rounded-md p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
           aria-label={{t "common.close"}}
           title={{t "common.close"}}
-          {{on "click" this.close}}
+          @appearance="minimal"
+          @size="xs"
+          @onPress={{this.close}}
+          class="self-start rounded-md text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
         >
           <X @size={{20}} />
-        </button>
+        </Button>
       </div>
 
       <div class="min-h-0 flex-1 overflow-y-auto">

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import type RouterService from '@ember/routing/router-service';
 import { on } from '@ember/modifier';
 import StationHeader from './header';
+import StationMeta from './meta';
 import StationSummary from './summary';
 import StationAir from './air';
 import StationWind from './wind';
@@ -61,6 +62,7 @@ export default class StationIndex extends Component<StationIndexSignature> {
       <div class="min-h-0 flex-1 overflow-y-auto">
         {{#if @station}}
           <div class="grid gap-3 px-4 py-3 sm:px-5 md:gap-4 md:py-4">
+            <StationMeta @station={{@station}} />
             <StationSummary @station={{@station}} />
             <StationWind @stationId={{@station.id}} />
             <StationAir @stationId={{@station.id}} />

--- a/app/components/station/meta.gts
+++ b/app/components/station/meta.gts
@@ -1,0 +1,92 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { formatNumber } from 'ember-intl';
+import { t } from 'ember-intl';
+import ArrowSquareUpRight from 'ember-phosphor-icons/components/ph-arrow-square-up-right';
+import Mountains from 'ember-phosphor-icons/components/ph-mountains';
+import NavigationArrow from 'ember-phosphor-icons/components/ph-navigation-arrow';
+import formatDistanceKm from 'winds-mobi-client-web/helpers/format-distance-km';
+import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
+import type { Station } from 'winds-mobi-client-web/services/store.js';
+import StationMetaItem from './meta-item';
+import StationUpdatedMeta from './updated-meta';
+
+export interface StationMetaSignature {
+  Args: {
+    station: Station;
+  };
+  Blocks: {
+    default: [];
+  };
+  Element: HTMLDListElement;
+}
+
+export default class StationMeta extends Component<StationMetaSignature> {
+  @service('nearby-location') declare nearbyLocation: NearbyLocationService;
+
+  get hasProviderLink() {
+    return Boolean(
+      this.args.station.providerName && this.args.station.providerUrl
+    );
+  }
+
+  <template>
+    <dl
+      class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] font-medium text-slate-500"
+      ...attributes
+    >
+      {{! Peaks (free-flight take-off sites) get the mountain glyph; other }}
+      {{! stations show altitude with no icon. }}
+      <StationMetaItem
+        @icon={{if @station.isPeak Mountains}}
+        @label={{t "station.meta.altitude"}}
+      >
+        <span>{{formatNumber @station.altitude maximumFractionDigits=0}}
+          m</span>
+      </StationMetaItem>
+
+      <StationUpdatedMeta @timestamp={{@station.last.timestamp}} />
+
+      {{#let this.nearbyLocation.coordinates as |coordinates|}}
+        {{#let
+          (formatDistanceKm
+            coordinates.latitude
+            coordinates.longitude
+            @station.latitude
+            @station.longitude
+          )
+          as |distanceLabel|
+        }}
+          {{#if distanceLabel}}
+            <StationMetaItem
+              data-test-station-distance
+              @icon={{NavigationArrow}}
+              @label={{t "station.meta.distance"}}
+            >
+              <span>{{distanceLabel}}</span>
+            </StationMetaItem>
+          {{/if}}
+        {{/let}}
+      {{/let}}
+
+      {{#if this.hasProviderLink}}
+        <StationMetaItem
+          @icon={{ArrowSquareUpRight}}
+          @label={{t "station.meta.provider"}}
+        >
+          <span>
+            <a
+              data-test-station-provider-link
+              href={{@station.providerUrl}}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline decoration-slate-300 underline-offset-3 transition hover:text-slate-900 hover:decoration-slate-500"
+            >
+              {{@station.providerName}}
+            </a>
+          </span>
+        </StationMetaItem>
+      {{/if}}
+    </dl>
+  </template>
+}

--- a/app/components/station/nearby-card.gts
+++ b/app/components/station/nearby-card.gts
@@ -1,5 +1,6 @@
 import type { TOC } from '@ember/component/template-only';
 import StationHeader from './header';
+import StationMeta from './meta';
 import StationSummary from './summary';
 import type { Station } from 'winds-mobi-client-web/services/store.js';
 
@@ -20,6 +21,7 @@ const StationNearbyCard: TOC<StationNearbyCardSignature> = <template>
   >
     <div class="mb-4">
       <StationHeader @station={{@station}} />
+      <StationMeta @station={{@station}} class="mt-1.5" />
     </div>
 
     <StationSummary @station={{@station}} />

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The station panel's altitude, last-updated, distance, and provider-link row now scrolls away with the rest of the panel content instead of staying pinned under the station name, freeing up space on the compact mobile layout.
+
 ### Fixed
 
 - Fixed the map sometimes visibly jumping back toward your location when opening a second station's detail panel right after another one.

--- a/tests/integration/components/station/meta-test.ts
+++ b/tests/integration/components/station/meta-test.ts
@@ -8,7 +8,7 @@ import {
 } from 'winds-mobi-client-web/tests/helpers';
 import type { Station } from 'winds-mobi-client-web/services/store';
 
-interface StationHeaderTestContext extends RenderedTestContext {
+interface StationMetaTestContext extends RenderedTestContext {
   station: Station;
 }
 
@@ -33,39 +33,39 @@ const BASE_STATION: Omit<Station, 'providerUrl'> = {
   [Type]: 'station',
 };
 
-module('Integration | Component | station/header', function (hooks) {
+module('Integration | Component | station/meta', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it hides the provider meta item when the provider name is missing', async function (this: StationHeaderTestContext, assert) {
+  test('it hides the provider meta item when the provider name is missing', async function (this: StationMetaTestContext, assert) {
     this.station = {
       ...BASE_STATION,
       providerName: undefined,
     };
 
-    await render(hbs`<Station::Header @station={{this.station}} />`);
+    await render(hbs`<Station::Meta @station={{this.station}} />`);
 
     assert.dom('[data-test-station-provider-link]').doesNotExist();
     assert.dom(this.element).doesNotIncludeText('Provider');
   });
 
-  test('it hides the provider meta item when the provider URL is missing', async function (this: StationHeaderTestContext, assert) {
+  test('it hides the provider meta item when the provider URL is missing', async function (this: StationMetaTestContext, assert) {
     this.station = {
       ...BASE_STATION,
     };
 
-    await render(hbs`<Station::Header @station={{this.station}} />`);
+    await render(hbs`<Station::Meta @station={{this.station}} />`);
 
     assert.dom('[data-test-station-provider-link]').doesNotExist();
     assert.dom(this.element).doesNotIncludeText('Provider');
   });
 
-  test('it renders the provider link when the provider URL is available', async function (this: StationHeaderTestContext, assert) {
+  test('it renders the provider link when the provider URL is available', async function (this: StationMetaTestContext, assert) {
     this.station = {
       ...BASE_STATION,
       providerUrl: 'https://windline.ch/station/4109',
     };
 
-    await render(hbs`<Station::Header @station={{this.station}} />`);
+    await render(hbs`<Station::Meta @station={{this.station}} />`);
 
     assert
       .dom('[data-test-station-provider-link]')


### PR DESCRIPTION
## Summary
- Moves the station panel's altitude/last-updated/distance/provider-link row out of the fixed header and into the scrollable body, closing #133 — it no longer eats fixed vertical space and scrolls away with the rest of the panel content.
- Gives the panel header a `relative z-10 shadow-md` so it visibly casts a shadow over the body content scrolling beneath it.
- Replaces every remaining bare HTML `<button>` in the app (station panel close button, settings refresh-spin demo, map station marker) with Frontile's `<Button>`, and documents the convention in CLAUDE.md — along with a gotcha found while doing it: Frontile's `class` override isn't tailwind-merged against the theme's own classes, so conflicting overrides need Tailwind v4's `!` suffix to reliably win.
- Shrinks the favourite/close buttons back down to a compact size to match the slimmer header.

## Test plan
- [x] `pnpm lint` (eslint, template-lint, stylelint, prettier, Glint) — clean
- [x] `pnpm test:ember:dev` filtered to the touched areas (station, map, favourites, beta-features, refresh-spin) — 137 pass, 6 skip (known WebGL-dependent, expected in this headless env), 0 fail
- [x] Manual screenshot verification of the station panel (title/close row, meta row, header shadow) via headless Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)