### PR TITLE
Recenter wind arrow SVGs on their visual centroid

### DIFF
--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed the on-map wind arrows rotating around a point that didn't line up with their visual center, causing the arrow's silhouette to shift unevenly within its frame as it turned to different wind directions.
+
 ## v0.19.2 - 2026-07-23
 
 ### Changed

--- a/public/images/arrow-not-peak.svg
+++ b/public/images/arrow-not-peak.svg
@@ -21,41 +21,57 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="28.160295"
-     inkscape:cx="42.719723"
-     inkscape:cy="59.108046"
+     inkscape:zoom="19.001433"
+     inkscape:cx="50.627762"
+     inkscape:cy="48.180578"
      inkscape:window-width="1710"
      inkscape:window-height="988"
      inkscape:window-x="0"
      inkscape:window-y="39"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg1" />
+     inkscape:current-layer="svg1"
+     showguides="true">
+    <sodipodi:guide
+       position="7.8343396,50"
+       orientation="0,1"
+       id="guide1"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="50,86.942767"
+       orientation="-1,0"
+       id="guide2"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+  </sodipodi:namedview>
   <defs
      id="defs1" />
   <path
      id="wind"
-     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#00ca00;fill-opacity:1;stroke:#000000;stroke-width:0.989767;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#00ca00;fill-opacity:1;stroke:#000000;stroke-width:0.892986;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
      inkscape:label="wind"
-     d="m -99.980469,-69.505859 c -2.928201,0.224329 -3.844861,3.420487 -5.515621,5.363281 -5.50545,7.925576 -11.13177,15.774713 -16.5625,23.748047 -1.613,3.191941 2.75579,6.298169 5.39062,4.039062 2.62511,-1.312565 5.24987,-2.624938 7.875,-3.9375 v 5.160157 c -10.25188,4.20219 -16.14608,16.769616 -12.45117,27.2871089 1.91246,6.1116812 6.55384,11.2827431 12.45117,13.7910156 0.0451,6.9390985 -0.0898,13.8870075 0.0703,20.8203125 0.5555,2.973173 3.82116,2.782027 6.14454,2.707031 3.107881,-0.12823 6.285199,0.284035 9.339839,-0.267578 2.958019,-1.355307 1.859162,-4.894327 2.072265,-7.466797 V 5.9453125 c 10.251416,-4.2011509 16.144055,-16.7646885 12.451172,-27.2812505 -1.913321,-6.112037 -6.552257,-11.288817 -12.451172,-13.796874 v -5.160157 c 3.289876,1.518757 6.415632,3.47623 9.822266,4.681641 3.395435,0.436392 4.953487,-4.121464 2.5,-6.220703 -6.120126,-8.742059 -12.239253,-17.484503 -18.359375,-26.226563 -0.617768,-0.896023 -1.687061,-1.454593 -2.775391,-1.447265 z M -100,-25.650391 c 5.304789,-0.05012 10.197596,4.130715 10.910156,9.400391 1.021849,5.752681 -3.331811,11.7468361 -9.128906,12.5488281 -5.68996,1.0831745 -11.67401,-3.1150319 -12.61133,-8.8320311 -1.29925,-5.852123 3.11242,-12.137708 9.05078,-12.951172 0.58685,-0.108083 1.18238,-0.166197 1.7793,-0.166016 z" />
+     d="m -99.983006,-69.545169 c -2.641884,0.202394 -3.468904,3.086028 -4.976304,4.838852 -4.96712,7.150602 -10.04328,14.232239 -14.94299,21.425929 -1.45528,2.879829 2.48632,5.682327 4.86352,3.644118 2.36843,-1.184221 4.73653,-2.368269 7.10497,-3.552487 v 4.65559 c -9.24943,3.791295 -14.5673,15.129861 -11.23368,24.618939 1.72546,5.5140714 5.913,10.1794997 11.23368,12.4425097 0.0406,6.2605834 -0.0811,12.5291163 0.0634,18.7844733 0.50119,2.682452 3.44753,2.509997 5.54372,2.442334 2.803984,-0.115692 5.670621,0.256261 8.426575,-0.241415 2.66878,-1.222783 1.677368,-4.415752 1.869632,-6.736683 V -1.4717183 c 9.249021,-3.7903565 14.565469,-15.1254137 11.233685,-24.6136507 -1.726233,-5.514395 -5.91157,-10.184981 -11.233685,-12.447798 v -4.65559 c 2.96819,1.370252 5.788309,3.13632 8.861834,4.223864 3.063429,0.393722 4.469131,-3.718461 2.255546,-5.612434 -5.521694,-7.887248 -11.042478,-15.774844 -16.564164,-23.662092 -0.557364,-0.80841 -1.522107,-1.312362 -2.504018,-1.30575 z m -0.01759,39.567219 c 4.786092,-0.04523 9.200476,3.726809 9.843361,8.481208 0.921932,5.190175 -3.006021,10.598214 -8.236273,11.321786 -5.133588,0.9772602 -10.532508,-2.810439 -11.378178,-7.968422 -1.17221,-5.279895 2.80808,-10.950867 8.16578,-11.684789 0.52946,-0.09751 1.06676,-0.149945 1.60531,-0.149783 z" />
   <path
-     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#aa2800;fill-opacity:1;stroke:#000000;stroke-width:0.702002;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
-     d="m -101.77939,-25.48391 c -5.93837,0.813464 -10.35062,7.099021 -9.05138,12.951144 0.93732,5.716999 6.92167,9.9152515 12.611623,8.832077 5.797095,-0.8019921 10.151299,-6.797396 9.12945,-12.550076 -0.71256,-5.269677 -5.60478,-9.450252 -10.909569,-9.400129 -0.596914,-1.81e-4 -1.193284,0.0589 -1.780124,0.166984 z"
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#aa2800;fill-opacity:1;stroke:#000000;stroke-width:0.633359;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
+     d="m -101.60564,-29.828184 c -5.35772,0.733923 -9.33853,6.40487 -8.16633,11.684764 0.84567,5.157983 6.24487,8.9457237 11.378458,7.968464 5.230248,-0.723572 9.15869,-6.132738 8.236759,-11.322912 -0.642884,-4.7544 -5.056736,-8.526193 -9.842813,-8.480971 -0.538564,-1.63e-4 -1.076614,0.05315 -1.606074,0.150655 z"
      id="gusts"
      inkscape:label="gusts"
      sodipodi:nodetypes="cccccc" />
   <path
-     style="fill:#3d2fb9;fill-opacity:1;stroke:#000000;stroke-width:0.221299;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke markers fill"
+     style="fill:#3d2fb9;fill-opacity:1;stroke:#000000;stroke-width:0.19966;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke markers fill"
      id="center"
      sodipodi:type="arc"
-     sodipodi:cx="99.999733"
-     sodipodi:cy="-14.59056"
-     sodipodi:rx="1"
-     sodipodi:ry="1"
+     sodipodi:cx="100"
+     sodipodi:cy="-20"
+     sodipodi:rx="0.90221858"
+     sodipodi:ry="0.90221858"
      sodipodi:start="0"
      sodipodi:end="6.2745091"
      sodipodi:arc-type="arc"
      inkscape:label="center"
      transform="scale(-1,1)"
-     d="m 100.99973,-14.59056 a 1,1 0 0 1 -0.99783,0.999998 1,1 0 0 1 -1.002158,-0.99566 1,1 0 0 1 0.993484,-1.004317 1,1 0 0 1 1.006474,0.991303"
+     d="m 100.90222,-20 a 0.90221858,0.90221858 0 0 1 -0.90026,0.902216 0.90221858,0.90221858 0 0 1 -0.90417,-0.898302 0.90221858,0.90221858 0 0 1 0.896339,-0.906113 0.90221858,0.90221858 0 0 1 0.908051,0.894371"
      sodipodi:open="true" />
 </svg>

--- a/public/images/arrow-peak.svg
+++ b/public/images/arrow-peak.svg
@@ -22,40 +22,55 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="16.210087"
-     inkscape:cx="42.905384"
-     inkscape:cy="62.090968"
+     inkscape:zoom="27.397181"
+     inkscape:cx="50.479646"
+     inkscape:cy="7.5372718"
      inkscape:window-width="1710"
      inkscape:window-height="988"
      inkscape:window-x="0"
      inkscape:window-y="39"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg1"
-     showguides="true" />
+     showguides="true">
+    <sodipodi:guide
+       position="50,54.026451"
+       orientation="-1,0"
+       id="guide1"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="11.089097,50"
+       orientation="0,1"
+       id="guide2"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+  </sodipodi:namedview>
   <path
-     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#aa2800;fill-opacity:1;stroke:#000000;stroke-width:0.702002;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
-     d="m -101.77939,-43.354496 c -5.93837,0.81346 -10.35062,7.09902 -9.05138,12.95114 0.93732,5.717 6.92167,9.91526 12.611625,8.83208 5.7971,-0.80199 10.1513,-6.79739 9.12945,-12.55007 -0.71256,-5.26968 -5.60478,-9.45026 -10.90957,-9.40013 -0.596915,-1.8e-4 -1.193285,0.0589 -1.780125,0.16698 z"
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#aa2800;fill-opacity:1;stroke:#000000;stroke-width:0.620617;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
+     d="m -101.5731,-48.630972 c -5.24993,0.719155 -9.15066,6.276017 -8.00204,11.449689 0.82866,5.054217 6.11923,8.765765 11.149539,7.808159 5.125031,-0.709013 8.974439,-6.009355 8.071054,-11.095115 -0.629951,-4.658755 -4.955006,-8.354673 -9.644802,-8.310354 -0.527721,-1.6e-4 -1.054951,0.05208 -1.573751,0.147621 z"
      id="gusts"
      inkscape:label="gusts"
      sodipodi:nodetypes="cccccc" />
   <path
      id="wind"
-     style="baseline-shift:baseline;display:inline;overflow:visible;fill:#008900;fill-opacity:1;stroke:#000000;stroke-width:0.685612;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
+     style="baseline-shift:baseline;display:inline;overflow:visible;fill:#008900;fill-opacity:1;stroke:#000000;stroke-width:0.606127;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;enable-background:accumulate;stop-color:#000000"
      inkscape:label="wind"
-     d="M -99.984375 -88.658203 C -100.4118 -88.659907 -100.84343 -88.593057 -101.26562 -88.453125 C -102.08804 -88.18069 -102.80184 -87.649083 -103.29883 -86.939453 L -122.08789 -60.097656 C -124.48288 -56.675084 -120.72485 -52.319885 -116.98828 -54.1875 L -109.39453 -57.984375 L -109.39453 -52.800781 L -127.18945 -21.953125 C -128.73684 -19.269102 -126.7993 -15.916877 -123.70117 -15.916016 L -109.39453 -15.916016 L -109.39453 6.6308594 C -109.39431 8.8544214 -107.5927 10.65798 -105.36914 10.658203 L -94.630859 10.658203 C -92.407301 10.65798 -90.605695 8.8544214 -90.605469 6.6308594 L -90.605469 -15.916016 L -76.298828 -15.916016 C -73.200703 -15.916907 -71.263154 -19.269102 -72.810547 -21.953125 L -90.605469 -52.800781 L -90.605469 -57.984375 L -83.011719 -54.1875 C -79.275152 -52.319882 -75.517121 -56.675082 -77.912109 -60.097656 L -96.701172 -86.939453 C -97.466557 -88.032446 -98.702106 -88.653091 -99.984375 -88.658203 z M -100 -43.521484 C -94.69521 -43.571614 -89.802404 -39.390774 -89.089844 -34.121094 C -88.067994 -28.368414 -92.42165 -22.372303 -98.21875 -21.570312 C -103.9087 -20.487133 -109.89276 -24.687297 -110.83008 -30.404297 C -112.12932 -36.256417 -107.71767 -42.542009 -101.7793 -43.355469 C -101.19246 -43.463549 -100.59691 -43.521664 -100 -43.521484 z " />
+     d="m -99.986057,-88.682754 c -0.377873,-0.0015 -0.759463,0.0576 -1.132713,0.181304 -0.72706,0.240851 -1.35812,0.710828 -1.79747,1.338189 l -16.61081,23.729974 c -2.11734,3.025787 1.20501,6.876079 4.50839,5.22498 l 6.71339,-3.356696 v 4.582651 l -15.7319,27.271425 c -1.36801,2.372859 0.3449,5.336454 3.08386,5.337214 h 12.64804 v 19.9329727 c 1.9e-4,1.96578 1.59295,3.56024854 3.55873,3.56044564 h 9.493355 c 1.965776,-1.971e-4 3.558519,-1.59466564 3.558719,-3.56044564 V -24.373713 h 12.648043 c 2.738954,-7.87e-4 4.451878,-2.964355 3.083878,-5.337214 l -15.731921,-27.271425 v -4.582651 l 6.71339,3.356696 c 3.303381,1.651102 6.625735,-2.199192 4.508403,-5.22498 l -16.610809,-23.729974 c -0.676653,-0.96628 -1.768962,-1.514972 -2.902575,-1.519493 z m -0.0138,39.903931 c 4.689784,-0.04432 9.015358,3.651828 9.64531,8.310584 0.903384,5.08576 -2.945543,10.38673 -8.070574,11.095745 -5.030299,0.957603 -10.320609,-2.755627 -11.149259,-7.809844 -1.14861,-5.173672 2.75158,-10.730563 8.00149,-11.449716 0.51882,-0.09555 1.04532,-0.146929 1.573033,-0.146769 z" />
   <path
-     style="fill:#3d2fb9;fill-opacity:1;stroke:#000000;stroke-width:0.221299;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke markers fill"
+     style="fill:#3d2fb9;fill-opacity:1;stroke:#000000;stroke-width:0.195644;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke markers fill"
      id="center"
      sodipodi:type="arc"
-     sodipodi:cx="99.999733"
-     sodipodi:cy="-32.461143"
-     sodipodi:rx="1"
-     sodipodi:ry="1"
+     sodipodi:cx="100"
+     sodipodi:cy="-39"
+     sodipodi:rx="0.88406795"
+     sodipodi:ry="0.88406795"
      sodipodi:start="0"
      sodipodi:end="6.2745091"
      sodipodi:arc-type="arc"
      inkscape:label="center"
      transform="scale(-1,1)"
-     d="m 100.99973,-32.461143 a 1,1 0 0 1 -0.99783,0.999997 1,1 0 0 1 -1.002158,-0.995659 1,1 0 0 1 0.993484,-1.004317 1,1 0 0 1 1.006474,0.991302"
+     d="m 100.88407,-39 a 0.88406795,0.88406795 0 0 1 -0.88215,0.884066 0.88406795,0.88406795 0 0 1 -0.88598,-0.880231 0.88406795,0.88406795 0 0 1 0.878307,-0.887884 0.88406795,0.88406795 0 0 1 0.889783,0.876379"
      sodipodi:open="true" />
 </svg>


### PR DESCRIPTION
## Summary
- Fixes #125 — the on-map wind arrow rotated around its `id="center"` hub marker, but that marker didn't line up with the drawn shape's actual visual center, so the silhouette shifted unevenly within its frame at different wind directions.
- Repositions the `center` marker (and redraws the arrow body to match) in both `public/images/arrow-not-peak.svg` and `public/images/arrow-peak.svg` to sit on the shape's visual centroid.
- No app-code changes — `build/vite-plugin-station-arrows.mjs` recomputes rotation geometry from these SVGs at build time.

## Test plan
- [ ] Skipped per request — visual SVG fix, no automated coverage for optical centering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)