### PR TITLE
Replace ember-highcharts with a hand-rolled Highcharts driver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ view backed by geolocation, and search.
 
 Stack: Ember 6 (Octane, Polaris-style `.gts`/TypeScript), Vite + Embroider, Warp Drive / EmberData
 5.8 (schema-record reactive store), Frontile components, Tailwind CSS v4, ember-intl, ember-concurrency,
-ember-maplibre-gl, ember-highcharts. Package manager is **pnpm** (pinned via `packageManager`); Node is
-pinned in `engines`.
+ember-maplibre-gl, Highcharts (driven directly through this app's own modifiers, no wrapper addon — see
+Highcharts below). Package manager is **pnpm** (pinned via `packageManager`); Node is pinned in `engines`.
 
 ## Authoritative external references
 
@@ -257,29 +257,49 @@ obvious from the decorator call site:
 
 ### Highcharts
 
-- Treat `highcharts` as a real, current app dependency (not a transitive peer). If wind/air stock-chart range-selector
-  buttons break, suspect a Highcharts module/version mismatch first and prefer upgrading `highcharts`/`ember-highcharts`
-  over app-side loading workarounds.
-- Both chart wrappers ([chart/polar.gts](app/components/chart/polar.gts),
-  [chart/time-series.gts](app/components/chart/time-series.gts)) set `chart.allowMutatingData: false`. This isn't a
-  perf knob we tuned — it's the fix for issue #111 ("glitches with wind direction history"), and removing it
-  reintroduces a real bug: `ember-highcharts` updates an existing chart via `series.setData()` rather than always
-  destroying/recreating it (confirmed: a station switch that resolves from Warp Drive's cache without a `:loading`
-  gap reuses the same chart instance/DOM node — verified live against the real app by tagging the rendered
-  `.highcharts-container` node across a station-A → station-B → station-A-revisit sequence). Highcharts' default
-  point-matching then falls back to raw x value when it can't match an incoming point by id, and for the polar
-  chart that's wind direction — a coarse 0-360 value that collides constantly, both across two different stations'
-  data and within one station's own sliding-window refresh (a reading that just expired and a brand-new reading can
-  share a direction by coincidence). The mismatch displaces one point to the wrong position in the array — every
-  value stays individually correct, but the connecting line's draw order doesn't, which is what actually reads as
-  a "tangled path." Two earlier fix attempts were tried and abandoned once this was found: giving each point an
-  explicit Highcharts `id` (doesn't help — a never-seen id still falls through to the x-value fallback) and keying
-  the chart's render on `@stationId` via `{{#each (array @stationId)}}` to force a teardown on station switches
-  (works for that one case, but not for the same-station sliding-window case, since the key doesn't change then).
-  `allowMutatingData: false` fixes both by disabling point-reuse entirely — Highcharts always rebuilds series data
-  from the given array's own order. Measured no meaningful performance difference at this app's data volumes (a
-  few dozen points for the polar chart, up to ~1500 for the 5-day wind/air charts) — the docs' "might decrease
-  performance" warning is written for far larger datasets than this app ever renders.
+- **No `ember-highcharts`.** Both chart wrappers ([chart/polar.gts](app/components/chart/polar.gts),
+  [chart/time-series.gts](app/components/chart/time-series.gts)) drive real Highcharts directly through one shared
+  class-based modifier ([modifiers/render-highcharts.ts](app/modifiers/render-highcharts.ts), invoked with a
+  `"chart"`/`"stockChart"` kind), which itself uses a create/update helper
+  ([utils/highcharts-lifecycle.ts](app/utils/highcharts-lifecycle.ts)). This replaced the addon (previously the only
+  Ember-specific Highcharts wrapper that existed) after tracing a real bug (issue #137, see below) to a piece of its
+  own update logic that had gone unrevisited since 2016 and had no open upstream issue covering it — owning the
+  update path ourselves both fixed that root cause and let the app move straight onto the current Highcharts major
+  (`highcharts` is a real, current, direct app dependency, not a transitive peer). Only the exact modules this app
+  actually uses are imported, each as its own dynamically-`import()`ed chunk wrapped in `@ember/test-waiters`'
+  `waitForPromise` (so test helpers' `await settled()` waits for chart creation): `highcharts/modules/stock` for the
+  wind/air stock charts, `highcharts/highcharts-more` for the polar wind-direction chart's pane/radial-axis support.
+  Deliberately not imported: the accessibility module (ember-highcharts always loaded it; this app disables
+  accessibility on every chart anyway, see each component's `accessibility: { enabled: false }` and its comment).
+- **Series updates never let Highcharts match old points to new ones.** `updateChart` (in
+  utils/highcharts-lifecycle.ts) always calls `series.setData(data, false, false, false)` — that last `false` is
+  `updatePoints`, Highcharts' own point-matching-for-animation feature, off unconditionally. This is the fix for
+  issue #111 ("glitches with wind direction history"): a station switch that resolves from Warp Drive's cache
+  without a `:loading` gap reuses the same chart instance/DOM node (confirmed live against the real app by tagging
+  the rendered `.highcharts-container` node across a station-A → station-B → station-A-revisit sequence), and
+  Highcharts' default point-matching falls back to raw x value when it can't match an incoming point by id — for
+  the polar chart that's wind direction, a coarse 0-360 value that collides constantly, both across two different
+  stations' data and within one station's own sliding-window refresh (a reading that just expired and a brand-new
+  reading can share a direction by coincidence). The mismatch displaces one point to the wrong position in the
+  array — every value stays individually correct, but the connecting line's draw order doesn't, which is what
+  actually reads as a "tangled path." Two earlier fix attempts were tried and abandoned once this was found: giving
+  each point an explicit Highcharts `id` (doesn't help — a never-seen id still falls through to the x-value
+  fallback) and keying the chart's render on `@stationId` via `{{#each (array @stationId)}}` to force a teardown on
+  station switches (works for that one case, but not for the same-station sliding-window case, since the key
+  doesn't change then). Before the `ember-highcharts` rewrite, this same fix was expressed as a chart-level
+  `chart.allowMutatingData: false` option (that flag no longer exists in either chart component — don't add it
+  back; the fix now lives in `updateChart`'s own `setData` call). Measured no meaningful performance difference at
+  this app's data volumes (a few dozen points for the polar chart, up to ~1500 for the 5-day wind/air charts) — the
+  docs' "might decrease performance" warning for disabling point-matching is written for far larger datasets than
+  this app ever renders.
+- **The wind/air range selector resets to its default ("6h") on every station change, not on every refresh.**
+  `render-highcharts.ts` re-applies `rangeSelector`'s default button (`RangeSelector#clickButton`) only when
+  `@stationId` itself changes, leaving an ordinary same-station background refresh free to preserve whatever range
+  is currently showing. This is the fix for issue #137: naive chart-update logic (this app's own former use of
+  `ember-highcharts`, and likely any other integration that calls `chart.xAxis[0].setExtremes()` unconditionally
+  after every update, as that addon's own `onDidUpdate` did) resets the visible range to "all data" on _any_ update
+  to an already-existing chart instance, not just a station switch — see
+  [tests/integration/components/chart/range-selector-reset-test.ts](tests/integration/components/chart/range-selector-reset-test.ts).
 
 ### i18n & relative time
 

--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -1,12 +1,12 @@
 import Component from '@glimmer/component';
-import HighCharts from 'ember-highcharts/components/high-charts';
-import type { Options } from 'highcharts';
 
 import { DIRECTIONS } from 'winds-mobi-client-web/helpers/azimuth-to-cardinal';
+import renderHighcharts from 'winds-mobi-client-web/modifiers/render-highcharts';
 import {
   mergeChartOptions,
   type ChartOptions,
 } from 'winds-mobi-client-web/utils/highcharts-options';
+import type { NamedSeriesOptions } from 'winds-mobi-client-web/utils/highcharts-lifecycle';
 
 interface PolarChartOptions extends ChartOptions {
   chart?: ChartOptions;
@@ -21,7 +21,7 @@ interface PolarChartOptions extends ChartOptions {
 export interface PolarSignature {
   Args: {
     chartOptions?: PolarChartOptions;
-    chartData?: Options['series'];
+    chartData?: NamedSeriesOptions[];
   };
   Blocks: {
     default: [];
@@ -34,12 +34,14 @@ export default class Polar extends Component<PolarSignature> {
     credits: {
       enabled: false,
     },
-    // ember-highcharts always imports the accessibility module, but its
-    // keyboard-navigation point proxies can throw ("Invalid value for <rect>
-    // attribute y=NaN") on sparse scatter series (e.g. a station that only
-    // reports every 30 minutes may have just one point in the last-hour
-    // window). This chart's data is also available via the metric cards and
-    // tooltips, so the a11y module isn't adding real value here.
+    // No accessibility module is imported at all (see render-highcharts.ts)
+    // -- unlike ember-highcharts, which always imported it, so the crash risk
+    // that used to force this option (keyboard-navigation point proxies
+    // throwing on sparse scatter series) can't happen any more; there's
+    // simply no such code loaded to run. Highcharts still emits an advisory
+    // console warning whenever `accessibility.enabled` isn't set at all and
+    // the module isn't loaded, though, so this stays just to keep that
+    // warning quiet.
     accessibility: {
       enabled: false,
     },
@@ -48,19 +50,6 @@ export default class Polar extends Component<PolarSignature> {
       reflow: true,
       type: 'line',
       spacing: [0, 0, 0, 0],
-      // ember-highcharts updates an existing chart via series.setData()
-      // rather than always destroying/recreating it (e.g. when a station
-      // switch resolves from cache without a loading gap in between).
-      // Highcharts' default point-matching then falls back to raw x value
-      // (wind direction here, a coarse 0-360 value) when it can't match an
-      // incoming point by id, which displaces a point to the wrong position
-      // in the array when two stations' data happen to share a direction
-      // (issue #111 -- the "tangled path" glitch). Disabling this lets
-      // Highcharts always rebuild series data from the given array's own
-      // order instead of trying to reuse/match old points -- measured no
-      // meaningful performance difference at this chart's data volumes
-      // (a handful to a few dozen points, one hour of history).
-      allowMutatingData: false,
     },
     title: {
       text: undefined,
@@ -175,10 +164,10 @@ export default class Polar extends Component<PolarSignature> {
   }
 
   <template>
-    <HighCharts
+    <div
+      class="chart-container"
       ...attributes
-      @content={{@chartData}}
-      @chartOptions={{this.mergedChartOptions}}
-    />
+      {{renderHighcharts "chart" this.mergedChartOptions @chartData}}
+    ></div>
   </template>
 }

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
-import HighCharts from 'ember-highcharts/components/high-charts';
+import renderHighcharts from 'winds-mobi-client-web/modifiers/render-highcharts';
 import {
   mergeChartOptions,
   type ChartOptions,
@@ -18,6 +18,7 @@ interface TimeSeriesChartOptions extends ChartOptions {
 
 export interface TimeSeriesSignature {
   Args: {
+    stationId: string;
     chartOptions?: TimeSeriesChartOptions;
     chartData?: TimeSeriesSeries[];
   };
@@ -27,7 +28,13 @@ export interface TimeSeriesSignature {
   Element: null;
 }
 
+// The "6h" button -- see `rangeSelector.buttons` below. Shared with the
+// `renderHighcharts` modifier invocation so the two can't silently drift
+// apart.
+const DEFAULT_RANGE_SELECTOR_INDEX = 4;
+
 interface TimeSeriesSeries extends ChartOptions {
+  name: string;
   data: TimeSeriesPoint[];
 }
 
@@ -39,12 +46,14 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
     credits: {
       enabled: false,
     },
-    // ember-highcharts always imports the accessibility module, but its
-    // keyboard-navigation point proxies can throw ("Invalid value for <rect>
-    // attribute y=NaN") on series with null/gap points (see
-    // utils/chart-series.ts, which intentionally emits null for missing
-    // readings). This chart's data is also available via the metric cards
-    // and tooltips, so the a11y module isn't adding real value here.
+    // No accessibility module is imported at all (see render-highcharts.ts)
+    // -- unlike ember-highcharts, which always imported it, so the crash risk
+    // that used to force this option (keyboard-navigation point proxies
+    // throwing on null/gap points, see utils/chart-series.ts) can't happen
+    // any more; there's simply no such code loaded to run. Highcharts still
+    // emits an advisory console warning whenever `accessibility.enabled`
+    // isn't set at all and the module isn't loaded, though, so this stays
+    // just to keep that warning quiet.
     accessibility: {
       enabled: false,
     },
@@ -54,19 +63,6 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
       spacingLeft: 0,
       spacingRight: 0,
       type: 'spline',
-      // ember-highcharts updates an existing chart via series.setData()
-      // rather than always destroying/recreating it (e.g. when a station
-      // switch resolves from cache without a loading gap in between, see
-      // wind-direction/graph.gts). Highcharts' default point-matching then
-      // falls back to raw x value (timestamp here) when it can't match an
-      // incoming point by id, which can displace a point to the wrong
-      // position in the array if a timestamp coincidentally collides
-      // between two stations' data (issue #111). Disabling this lets
-      // Highcharts always rebuild series data from the given array's own
-      // order instead of trying to reuse/match old points -- measured no
-      // meaningful performance difference at this app's data volumes
-      // (~1500 points for the longest, 5-day chart).
-      allowMutatingData: false,
       panning: {
         enabled: true,
         type: 'x',
@@ -114,7 +110,7 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
           fontWeight: '600',
         },
       },
-      selected: 4,
+      selected: DEFAULT_RANGE_SELECTOR_INDEX,
       labelStyle: {
         fontSize: '12px',
       },
@@ -217,10 +213,15 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
   }
 
   <template>
-    <HighCharts
-      @mode="StockChart"
-      @content={{@chartData}}
-      @chartOptions={{this.mergedChartOptions}}
-    />
+    <div
+      class="chart-container"
+      {{renderHighcharts
+        "stockChart"
+        this.mergedChartOptions
+        @chartData
+        stationId=@stationId
+        defaultRangeSelectorIndex=DEFAULT_RANGE_SELECTOR_INDEX
+      }}
+    ></div>
   </template>
 }

--- a/app/components/station/air/index.gts
+++ b/app/components/station/air/index.gts
@@ -22,7 +22,7 @@ const StationAir: TOC<StationAirSignature> = <template>
       @keys={{KEYS}}
       as |history|
     >
-      <StationAirContent @history={{history}} />
+      <StationAirContent @history={{history}} @stationId={{@stationId}} />
     </StationHistorySection>
   </section>
 </template>;

--- a/app/components/station/air/presenter.gts
+++ b/app/components/station/air/presenter.gts
@@ -11,6 +11,7 @@ import {
 export interface StationAirContentSignature {
   Args: {
     history: History[];
+    stationId: string;
   };
   Blocks: {
     default: [];
@@ -79,6 +80,7 @@ export default class StationAirContent extends Component<StationAirContentSignat
 
   <template>
     <TimeSeries
+      @stationId={{@stationId}}
       @chartData={{this.chartData}}
       @chartOptions={{this.chartOptions}}
     />

--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -25,8 +25,8 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
   // `@cached` keeps `chartOptions`/`points`/`chartData` returning the *same*
   // object/array references across the repeated autotracked reads Glimmer's
   // render pipeline performs in a single render pass. Without it, each read
-  // built a fresh object, which made `ember-highcharts` see "changed" args on
-  // every access and re-init/update the underlying chart mid-render -- the
+  // built a fresh object, which made `render-highcharts`'s modifier see
+  // "changed" args on every access and re-run its update mid-render -- the
   // root cause of this component's flaky marker-rendering (see TODO.md).
 
   // The radial window spans exactly the given data's own oldest-to-newest
@@ -190,7 +190,7 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
 
   <template>
     <Polar
-      class="h-full min-h-0 min-w-0 w-full [&_.chart-container]:h-full [&_.chart-container]:min-h-0 [&_.chart-container]:w-full"
+      class="h-full min-h-0 min-w-0 w-full"
       @chartData={{this.chartData}}
       @chartOptions={{this.chartOptions}}
     />

--- a/app/components/station/wind/index.gts
+++ b/app/components/station/wind/index.gts
@@ -22,7 +22,7 @@ const StationWind: TOC<StationWindSignature> = <template>
       @keys={{KEYS}}
       as |history|
     >
-      <StationWindContent @history={{history}} />
+      <StationWindContent @history={{history}} @stationId={{@stationId}} />
     </StationHistorySection>
   </section>
 </template>;

--- a/app/components/station/wind/presenter.gts
+++ b/app/components/station/wind/presenter.gts
@@ -11,6 +11,7 @@ import {
 export interface StationWindContentSignature {
   Args: {
     history: History[];
+    stationId: string;
   };
   Blocks: {
     default: [];
@@ -64,6 +65,7 @@ export default class StationWindContent extends Component<StationWindContentSign
 
   <template>
     <TimeSeries
+      @stationId={{@stationId}}
       @chartOptions={{this.chartOptions}}
       @chartData={{this.chartData}}
     />

--- a/app/modifiers/render-highcharts.ts
+++ b/app/modifiers/render-highcharts.ts
@@ -1,0 +1,147 @@
+import Modifier, { type ArgsFor } from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+import { waitForPromise } from '@ember/test-waiters';
+import type Owner from '@ember/owner';
+import type { Chart, Options } from 'highcharts';
+import {
+  updateChart,
+  type NamedSeriesOptions,
+} from 'winds-mobi-client-web/utils/highcharts-lifecycle';
+import type { ChartOptions } from 'winds-mobi-client-web/utils/highcharts-options';
+
+// Highcharts' own types don't declare the `rangeSelector` runtime property
+// on `Chart` at all (it's a Stock feature, undocumented in the base
+// package's types) -- this widens the real `Chart` type with the one method
+// this modifier calls.
+export interface ChartWithRangeSelector extends Chart {
+  rangeSelector?: {
+    clickButton(index: number, redraw?: boolean): void;
+    selected?: number;
+  };
+}
+
+type ChartKind = 'chart' | 'stockChart';
+
+interface RenderHighchartsSignature {
+  Element: HTMLDivElement;
+  Args: {
+    Positional: [
+      kind: ChartKind,
+      chartOptions: ChartOptions,
+      seriesData: NamedSeriesOptions[] | undefined,
+    ];
+    Named: {
+      // Stock charts only -- see the `stationId` handling below. Left
+      // undefined for the plain/polar chart, which has no range selector.
+      stationId?: string;
+      defaultRangeSelectorIndex?: number;
+    };
+  };
+}
+
+// Drives Highcharts directly (no `ember-highcharts`): builds the chart once,
+// then updates the *same* instance in place on every subsequent call rather
+// than tearing it down and recreating it (matching the previous behavior,
+// which several other comments in this app already depend on -- see e.g.
+// CLAUDE.md's Highcharts section on issue #111). One modifier drives both
+// chart "kinds" this app uses -- the plain/polar wind-direction chart and
+// the wind/air stock charts -- since the only real differences between them
+// (which Highcharts factory function to call, which extra module to import,
+// and the stock-only range-selector reset below) are each a few lines; the
+// actual chart lifecycle (create-or-update, destroy) is identical.
+//
+// Owning this update path ourselves (instead of going through
+// `ember-highcharts`'s own `onDidUpdate`) also fixes issue #137 at the root,
+// for the stock charts: that addon calls `chart.xAxis[0].setExtremes()`
+// with no arguments on *every* update, unconditionally resetting the
+// visible range back to "all data" instead of the configured
+// `rangeSelector.selected` default. This modifier never does that -- it
+// only re-applies the default range (via `RangeSelector#clickButton`, the
+// same as a user clicking the button) when `stationId` actually changes,
+// leaving any other update (e.g. a same-station background refresh) free
+// to preserve whatever range is currently showing.
+export default class RenderHighchartsModifier extends Modifier<RenderHighchartsSignature> {
+  private chart: Chart | null = null;
+  private previousStationId: string | null = null;
+  // Dynamic imports of the same specifier resolve instantly once Highcharts
+  // has loaded once, but the very first chart on a page can still have two
+  // `modify()` calls race while that first import is in flight (e.g. a
+  // station switch that happens before the initial mount has resolved).
+  // This token lets a later call's result win over an earlier one that
+  // resolves after it, rather than clobbering fresher args with stale ones.
+  private latestCallId = 0;
+
+  constructor(owner: Owner, args: ArgsFor<RenderHighchartsSignature>) {
+    super(owner, args);
+    registerDestructor(this, () => this.chart?.destroy());
+  }
+
+  modify(
+    element: HTMLDivElement,
+    [kind, chartOptions, seriesData]: [
+      ChartKind,
+      ChartOptions,
+      NamedSeriesOptions[] | undefined,
+    ],
+    {
+      stationId,
+      defaultRangeSelectorIndex,
+    }: RenderHighchartsSignature['Args']['Named']
+  ) {
+    const callId = ++this.latestCallId;
+
+    void this.sync(
+      callId,
+      element,
+      kind,
+      chartOptions,
+      seriesData,
+      stationId,
+      defaultRangeSelectorIndex
+    );
+  }
+
+  private async sync(
+    callId: number,
+    element: HTMLDivElement,
+    kind: ChartKind,
+    chartOptions: ChartOptions,
+    seriesData: NamedSeriesOptions[] | undefined,
+    stationId: string | undefined,
+    defaultRangeSelectorIndex: number | undefined
+  ) {
+    // Wrapped in `waitForPromise` so test helpers' `await settled()` (and
+    // `render()`, which awaits it internally) wait for this async chart
+    // creation instead of asserting against a not-yet-drawn chart.
+    const Highcharts = (await waitForPromise(import('highcharts'))).default;
+
+    if (kind === 'stockChart') {
+      await waitForPromise(import('highcharts/modules/stock'));
+    } else {
+      // Polar support (the pane, radial axes, `chart.polar: true`) lives in
+      // this module, not core Highcharts.
+      await waitForPromise(import('highcharts/highcharts-more'));
+    }
+
+    if (callId !== this.latestCallId) {
+      return;
+    }
+
+    if (!this.chart) {
+      this.chart = Highcharts[kind](element, {
+        ...chartOptions,
+        series: seriesData,
+      } as Options);
+    } else {
+      updateChart(this.chart, chartOptions, seriesData);
+    }
+
+    if (stationId !== undefined && stationId !== this.previousStationId) {
+      (this.chart as ChartWithRangeSelector).rangeSelector?.clickButton(
+        defaultRangeSelectorIndex ?? 0,
+        true
+      );
+      this.previousStationId = stationId;
+    }
+  }
+}

--- a/app/utils/highcharts-lifecycle.ts
+++ b/app/utils/highcharts-lifecycle.ts
@@ -1,0 +1,78 @@
+import type {
+  Chart,
+  Options,
+  PointOptionsType,
+  SeriesOptionsType,
+} from 'highcharts';
+import type { ChartOptions } from 'winds-mobi-client-web/utils/highcharts-options';
+
+// Highcharts' real `SeriesOptionsType` is a big discriminated union requiring
+// a specific `type` per series kind, which is more rigidity than this app's
+// own loosely-typed chart options buy in elsewhere (see `ChartOptions` in
+// utils/highcharts-options.ts) -- so series data is typed loosely here too,
+// with a real `name` (used below to match series across updates) as the one
+// thing this module actually depends on, and cast to `SeriesOptionsType` at
+// the point of actually calling into Highcharts.
+export interface NamedSeriesOptions {
+  name: string;
+  data?: unknown;
+  [key: string]: unknown;
+}
+
+// Applies new options/series to an already-constructed chart in place,
+// without ever asking Highcharts to match old points to new ones by id or
+// x value. `Series#setData`'s point-matching (its `updatePoints` argument,
+// true by default) is what caused issue #111: two stations' data -- or a
+// single station's own sliding refresh window -- can coincidentally share
+// an x value (a coarse 0-360 wind direction, or a timestamp), and matching
+// on that shared value displaces a point to the wrong array position.
+// Passing `updatePoints: false` here means there is no matching step at all
+// to get wrong -- every update fully replaces a series' data from the given
+// array's own order, by construction.
+export function updateChart(
+  chart: Chart,
+  chartOptions: ChartOptions,
+  seriesData: NamedSeriesOptions[] | undefined
+): void {
+  chart.update(chartOptions as Options, false);
+
+  if (!seriesData) {
+    return;
+  }
+
+  const incomingByName = new Map(
+    seriesData.map((series) => [series.name, series])
+  );
+
+  // Remove series no longer present, matching by name (not array index --
+  // series can be added/removed independently of each other, e.g. the air
+  // chart's gusts hub only showing for some readings).
+  for (const series of [...chart.series]) {
+    if (series.name && !incomingByName.has(series.name)) {
+      series.remove(false);
+    }
+  }
+
+  const existingByName = new Map(
+    chart.series.map((series) => [series.name, series])
+  );
+
+  for (const options of seriesData) {
+    const existing = existingByName.get(options.name);
+
+    if (existing) {
+      const { data, ...rest } = options;
+      existing.update(rest as unknown as SeriesOptionsType, false);
+      existing.setData(
+        (data as PointOptionsType[] | undefined) ?? [],
+        false,
+        false,
+        false
+      );
+    } else {
+      chart.addSeries(options as unknown as SeriesOptionsType, false);
+    }
+  }
+
+  chart.redraw();
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@ember/optional-features": "^2.2.0",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.3",
+    "@ember/test-waiters": "^4.1.2",
     "@embroider/compat": "^4.0.3",
     "@embroider/config-meta-loader": "^1.0.0",
     "@embroider/core": "^4.0.3",
@@ -78,7 +79,6 @@
     "ember-cli-deprecation-workflow": "^3.3.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-concurrency": "^4.0.2",
-    "ember-highcharts": "^7.0.0",
     "ember-intl": "^8.2.1",
     "ember-load-initializers": "^3.0.1",
     "ember-maplibre-gl": "^0.6.2",
@@ -143,7 +143,7 @@
     "@warp-drive/legacy": "5.8.0",
     "@warp-drive/schema-record": "5.8.0",
     "@warp-drive/utilities": "5.8.0",
-    "highcharts": "12.5.0",
+    "highcharts": "13.0.0",
     "sharp": "^0.34.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7)
       '@ember-data/store':
         specifier: 5.8.0
-        version: 5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.0(@glint/template@1.7.7))(@glint/template@1.7.7)
+        version: 5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.2)(@glint/template@1.7.7)
       '@warp-drive/build-config':
         specifier: 5.8.0
         version: 5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7)
@@ -35,7 +35,7 @@ importers:
         version: 5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7)
       '@warp-drive/ember':
         specifier: 5.8.0
-        version: 5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.0(@glint/template@1.7.7))(@glint/template@1.7.7)
+        version: 5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.2)(@glint/template@1.7.7)
       '@warp-drive/experiments':
         specifier: 0.2.6
         version: 0.2.6(@glint/template@1.7.7)(@warp-drive/core@5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7))
@@ -52,8 +52,8 @@ importers:
         specifier: 5.8.0
         version: 5.8.0(@glint/template@1.7.7)(@warp-drive/core@5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7))
       highcharts:
-        specifier: 12.5.0
-        version: 12.5.0
+        specifier: 13.0.0
+        version: 13.0.0
       sharp:
         specifier: ^0.34.1
         version: 0.34.1
@@ -84,7 +84,10 @@ importers:
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.4.3
-        version: 5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7)
+        version: 5.4.3(@babel/core@7.28.4)
+      '@ember/test-waiters':
+        specifier: ^4.1.2
+        version: 4.1.2
       '@embroider/compat':
         specifier: ^4.0.3
         version: 4.1.6(@embroider/core@4.2.3(@glint/template@1.7.7))(@glint/template@1.7.7)
@@ -99,7 +102,7 @@ importers:
         version: 1.19.1(@glint/template@1.7.7)
       '@embroider/router':
         specifier: ^3.0.1
-        version: 3.0.4(@embroider/core@4.2.3(@glint/template@1.7.7))(@glint/template@1.7.7)
+        version: 3.0.4(@embroider/core@4.2.3(@glint/template@1.7.7))
       '@embroider/util':
         specifier: ^1.13.4
         version: 1.13.4(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
@@ -196,12 +199,9 @@ importers:
       ember-concurrency:
         specifier: ^4.0.2
         version: 4.0.3(@babel/core@7.28.4)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
-      ember-highcharts:
-        specifier: ^7.0.0
-        version: 7.0.0(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(highcharts@12.5.0)
       ember-intl:
         specifier: ^8.2.1
-        version: 8.2.1(@babel/core@7.28.4)(@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7))(typescript@5.9.3)
+        version: 8.2.1(@babel/core@7.28.4)(@ember/test-helpers@5.4.3(@babel/core@7.28.4))(typescript@5.9.3)
       ember-load-initializers:
         specifier: ^3.0.1
         version: 3.0.1(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
@@ -219,13 +219,13 @@ importers:
         version: 1.0.2(@babel/core@7.28.4)
       ember-qunit:
         specifier: ^9.0.1
-        version: 9.0.2(@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(qunit@2.24.1)
+        version: 9.0.2(@ember/test-helpers@5.4.3(@babel/core@7.28.4))(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(qunit@2.24.1)
       ember-resolver:
         specifier: ^13.1.0
         version: 13.1.0(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-simple-auth:
         specifier: ^8.3.1
-        version: 8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
+        version: 8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.28.4))(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-source:
         specifier: ~6.3.0
         version: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
@@ -1679,28 +1679,14 @@ packages:
     resolution: {integrity: sha512-a1OQ+w9vDvMXd9BNA9r779yr8MAPguGaMGbIeTMPWACeWBdD6bACBB5iKE3gNyrJAYKMq2wab6BKmRFS3Qw3hw==}
     engines: {node: 10.* || 12.* || >= 14}
 
-  '@ember/render-modifiers@2.1.0':
-    resolution: {integrity: sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==}
-    engines: {node: 12.* || 14.* || >= 16}
-    peerDependencies:
-      '@glint/template': 1.7.7
-      ember-source: ^3.8 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      '@glint/template':
-        optional: true
-
   '@ember/string@4.0.1':
     resolution: {integrity: sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==}
 
   '@ember/test-helpers@5.4.3':
     resolution: {integrity: sha512-WeNABJsXBidEXP87AH5gaI/KAyb0zEUYJxWa31A/Us5lqg85E3tPlHjBwCrlReOrJbSgvvArMnrdCwt7TRpjPQ==}
 
-  '@ember/test-waiters@3.1.0':
-    resolution: {integrity: sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==}
-    engines: {node: 10.* || 12.* || >= 14.*}
-
-  '@ember/test-waiters@4.1.0':
-    resolution: {integrity: sha512-qRFA0OumYv7/C3hmx4ETC2dlPzyD549D+naPhcrnV2xCnc3AZlKouWyoFnNF+Cje918kRp9aEefVgV3vmGL5Bg==}
+  '@ember/test-waiters@4.1.2':
+    resolution: {integrity: sha512-zJwFaHLHjJn6mKoXYVM1SEyMT+U1JpaaSKg3JBmxHJwiIoJRI5djJ/CE33Z7N09mk5JfXd2xdhbd9LBWdlvAzg==}
 
   '@embroider/addon-shim@1.10.0':
     resolution: {integrity: sha512-gcJuHiXgnrzaU8NyU+2bMbtS6PNOr5v5B8OXBqaBvTCsMpXLvKo8OBOQFCoUN0rPX2J6VaFqrbi/371sMvzZug==}
@@ -3409,12 +3395,6 @@ packages:
       '@babel/core': ^7.0.0
       webpack: '>=2'
 
-  babel-plugin-debug-macros@0.2.0:
-    resolution: {integrity: sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-beta.42
-
   babel-plugin-debug-macros@0.3.4:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
     engines: {node: '>=6'}
@@ -4580,10 +4560,6 @@ packages:
     resolution: {integrity: sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==}
     engines: {node: '>= 12.*'}
 
-  ember-cli-version-checker@2.2.0:
-    resolution: {integrity: sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==}
-    engines: {node: '>= 4'}
-
   ember-cli-version-checker@4.1.1:
     resolution: {integrity: sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==}
     engines: {node: 8.* || 10.* || >= 12.*}
@@ -4599,10 +4575,6 @@ packages:
 
   ember-click-outside@6.1.1:
     resolution: {integrity: sha512-1SOW92/k5vm+QiLBdkiSxkxSEzvA1vWdVVAI5RLV9JFztA5cSEKB2m2+10Gvw90ItxekY92JVXXTXIPUcPBqYg==}
-
-  ember-compatibility-helpers@1.2.7:
-    resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
-    engines: {node: 10.* || >= 12.*}
 
   ember-concurrency@4.0.3:
     resolution: {integrity: sha512-deDJiB5OBYtYYOiVSt2qe5YBC8/vj1HwXPXtcw2SHijjMVL3i8ZBUmnHcaFr4RGsZJkGUr7Fg0zM45P9yUqKmQ==}
@@ -4652,12 +4624,6 @@ packages:
     peerDependencies:
       ember-source: ^3.25.0 || >=4.0.0
 
-  ember-highcharts@7.0.0:
-    resolution: {integrity: sha512-fTlm9kHNU8il13sKnJFDV/OajUS1piM/4MuUhdA+KUrF+Hs1Mn0hk1gwH3Th8bu9Bjao16pOy2Jk2T8fjx105w==}
-    peerDependencies:
-      ember-source: '>= 3.28.0'
-      highcharts: '>= 10.0.0'
-
   ember-intl@8.2.1:
     resolution: {integrity: sha512-DVRMTruB+bVdsO1VsjehN8Agj2Fn4n32ijQNjDe4wTT+so9X4rEiJnoefxwBnrMiYPhAeZAp8GRIXuFxu/Ktcw==}
     engines: {node: 20.* || >= 22}
@@ -4682,10 +4648,6 @@ packages:
     peerDependenciesMeta:
       '@glimmer/component':
         optional: true
-
-  ember-modifier-manager-polyfill@1.2.0:
-    resolution: {integrity: sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   ember-modifier@4.2.0:
     resolution: {integrity: sha512-BJ48eTEGxD8J7+lofwVmee7xDgNDgpr5dd6+MSu4gk+I6xb35099RMNorXY5hjjwMJEyi/IRR6Yn3M7iJMz8Zw==}
@@ -5655,11 +5617,11 @@ packages:
   heimdalljs@0.2.6:
     resolution: {integrity: sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==}
 
-  highcharts@12.5.0:
-    resolution: {integrity: sha512-uNSSv1KqRLNvkyXlf1FbeGWB1mJ/8/IYpVeqYiTIop5Wo8peUvNyzUfLa58vILsmXyz+XrETtgKIEOcSgBBKuQ==}
+  highcharts@13.0.0:
+    resolution: {integrity: sha512-AoFXei9hSnVXo8X5PmXzSiNXwPMgA+NzyN35uRRy0N1XwbJbRI1laTCaaFci9QB9Wyv9ZFWlgF0xzgivavJpDA==}
     peerDependencies:
-      jspdf: ^3.0.0
-      svg2pdf.js: ^2.6.0
+      jspdf: ^4.1.0
+      svg2pdf.js: ^2.7.0
     peerDependenciesMeta:
       jspdf:
         optional: true
@@ -11368,12 +11330,12 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/store@5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.0(@glint/template@1.7.7))(@glint/template@1.7.7)':
+  '@ember-data/store@5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.2)(@glint/template@1.7.7)':
     dependencies:
       '@embroider/macros': 1.19.1(@glint/template@1.7.7)
       '@warp-drive/core': 5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7)
     optionalDependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11397,47 +11359,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@2.1.0(@babel/core@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))':
-    dependencies:
-      '@embroider/macros': 1.19.1(@glint/template@1.7.7)
-      ember-cli-babel: 7.26.11
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.4)
-      ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
-    optionalDependencies:
-      '@glint/template': 1.7.7
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   '@ember/string@4.0.1': {}
 
-  '@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7)':
+  '@ember/test-helpers@5.4.3(@babel/core@7.28.4)':
     dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.2
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.1(@babel/core@7.28.4)
       dom-element-descriptors: 0.5.1
     transitivePeerDependencies:
       - '@babel/core'
-      - '@glint/template'
       - supports-color
 
-  '@ember/test-waiters@3.1.0':
+  '@ember/test-waiters@4.1.2':
     dependencies:
-      calculate-cache-key-for-tree: 2.0.0
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      semver: 7.7.1
+      '@embroider/addon-shim': 1.10.2
     transitivePeerDependencies:
-      - supports-color
-
-  '@ember/test-waiters@4.1.0(@glint/template@1.7.7)':
-    dependencies:
-      '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.19.1(@glint/template@1.7.7)
-    transitivePeerDependencies:
-      - '@glint/template'
       - supports-color
 
   '@embroider/addon-shim@1.10.0':
@@ -11593,14 +11531,13 @@ snapshots:
       mem: 8.1.1
       resolve.exports: 2.0.3
 
-  '@embroider/router@3.0.4(@embroider/core@4.2.3(@glint/template@1.7.7))(@glint/template@1.7.7)':
+  '@embroider/router@3.0.4(@embroider/core@4.2.3(@glint/template@1.7.7))':
     dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
     optionalDependencies:
       '@embroider/core': 4.2.3(@glint/template@1.7.7)
     transitivePeerDependencies:
-      - '@glint/template'
       - supports-color
 
   '@embroider/shared-internals@2.6.2':
@@ -11918,7 +11855,7 @@ snapshots:
   '@frontile/forms@0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
       '@frontile/buttons': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
       '@frontile/collections': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
@@ -11942,7 +11879,7 @@ snapshots:
       '@frontile/buttons': 0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
       '@frontile/theme': 0.17.0-beta.25(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)
       ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
-      ember-css-transitions: 4.5.0(@babel/core@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
+      ember-css-transitions: 4.5.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-modifier: 4.2.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
     transitivePeerDependencies:
@@ -11961,7 +11898,7 @@ snapshots:
       '@frontile/theme': 0.17.0-beta.25(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)
       '@glint/template': 1.7.7
       ember-click-outside: 6.1.1(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
-      ember-css-transitions: 4.5.0(@babel/core@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
+      ember-css-transitions: 4.5.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-focus-trap: 1.1.1(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-modifier: 4.2.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
@@ -11994,7 +11931,7 @@ snapshots:
   '@frontile/utilities@0.17.0-beta.25(@babel/core@7.28.4)(@babel/runtime@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
       '@frontile/theme': 0.17.0-beta.25(@babel/runtime@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(tailwindcss@4.1.4)
       ember-auto-import: 2.10.0(@glint/template@1.7.7)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
@@ -13088,9 +13025,9 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/ember@5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.0(@glint/template@1.7.7))(@glint/template@1.7.7)':
+  '@warp-drive/ember@5.8.0(@babel/core@7.28.4)(@ember/test-waiters@4.1.2)(@glint/template@1.7.7)':
     dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/macros': 1.19.1(@glint/template@1.7.7)
       '@warp-drive/core': 5.8.0(@babel/core@7.28.4)(@glint/template@1.7.7)
     transitivePeerDependencies:
@@ -13490,11 +13427,6 @@ snapshots:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.94.0(lightningcss@1.29.2)(postcss@8.5.3)
-
-  babel-plugin-debug-macros@0.2.0(@babel/core@7.28.4):
-    dependencies:
-      '@babel/core': 7.28.4
-      semver: 5.7.2
 
   babel-plugin-debug-macros@0.3.4(@babel/core@7.28.4):
     dependencies:
@@ -14988,11 +14920,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-version-checker@2.2.0:
-    dependencies:
-      resolve: 1.22.10
-      semver: 5.7.2
-
   ember-cli-version-checker@4.1.1:
     dependencies:
       resolve-package-path: 2.0.0
@@ -15159,17 +15086,6 @@ snapshots:
       - ember-source
       - supports-color
 
-  ember-compatibility-helpers@1.2.7(@babel/core@7.28.4):
-    dependencies:
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.28.4)
-      ember-cli-version-checker: 5.1.2
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      semver: 5.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   ember-concurrency@4.0.3(@babel/core@7.28.4)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))):
     dependencies:
       '@babel/helper-module-imports': 7.25.9
@@ -15192,15 +15108,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-css-transitions@4.5.0(@babel/core@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))):
+  ember-css-transitions@4.5.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))):
     dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
       decorator-transforms: 2.3.0(@babel/core@7.28.4)
       ember-modifier: 4.2.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
     transitivePeerDependencies:
       - '@babel/core'
-      - '@glint/template'
       - ember-source
       - supports-color
 
@@ -15243,27 +15158,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-highcharts@7.0.0(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(highcharts@12.5.0):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.28.4)(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
-      '@ember/test-waiters': 3.1.0
-      '@embroider/addon-shim': 1.10.0
-      decorator-transforms: 2.3.0(@babel/core@7.28.4)
-      deepmerge: 4.3.1
-      ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
-      highcharts: 12.5.0
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-
-  ember-intl@8.2.1(@babel/core@7.28.4)(@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7))(typescript@5.9.3):
+  ember-intl@8.2.1(@babel/core@7.28.4)(@ember/test-helpers@5.4.3(@babel/core@7.28.4))(typescript@5.9.3):
     dependencies:
       '@embroider/addon-shim': 1.10.2
       '@formatjs/intl': 4.1.4(typescript@5.9.3)
       decorator-transforms: 2.3.1(@babel/core@7.28.4)
     optionalDependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.28.4)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -15286,15 +15187,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
-      - supports-color
-
-  ember-modifier-manager-polyfill@1.2.0(@babel/core@7.28.4):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 2.2.0
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.4)
-    transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   ember-modifier@4.2.0(@babel/core@7.28.4)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))):
@@ -15325,9 +15217,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-qunit@9.0.2(@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(qunit@2.24.1):
+  ember-qunit@9.0.2(@ember/test-helpers@5.4.3(@babel/core@7.28.4))(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))(qunit@2.24.1):
     dependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.28.4)
       '@embroider/addon-shim': 1.10.0
       '@embroider/macros': 1.19.1(@glint/template@1.7.7)
       ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
@@ -15365,16 +15257,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-simple-auth@8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))):
+  ember-simple-auth@8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.28.4))(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))):
     dependencies:
-      '@ember/test-waiters': 4.1.0(@glint/template@1.7.7)
+      '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.2
       ember-cookies: 1.4.1(ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)))
       ember-source: 6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3))
     optionalDependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.28.4)(@glint/template@1.7.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.28.4)
     transitivePeerDependencies:
-      - '@glint/template'
       - supports-color
 
   ember-source@6.3.0(@glimmer/component@2.0.0)(@glint/template@1.7.7)(rsvp@4.8.5)(webpack@5.94.0(lightningcss@1.29.2)(postcss@8.5.3)):
@@ -16793,7 +16684,7 @@ snapshots:
     dependencies:
       rsvp: 3.2.1
 
-  highcharts@12.5.0: {}
+  highcharts@13.0.0: {}
 
   homedir-polyfill@1.0.3:
     dependencies:

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed the on-map wind arrows rotating around a point that didn't line up with their visual center, causing the arrow's silhouette to shift unevenly within its frame as it turned to different wind directions.
 - Fixed the selected-marker ring on the map looking oversized around its wind arrow. The ring is now sized to frame the arrow closely, and shrinks together with it as a station's reading gets older or you zoom out, instead of staying a fixed size around a shrinking arrow.
+- Fixed the wind and air graphs sometimes opening zoomed out to show all of their history instead of the intended default 6-hour view, most noticeably when switching between stations in the sidebar.
 
 ## v0.19.2 - 2026-07-23
 

--- a/tests/integration/components/chart/point-order-test.ts
+++ b/tests/integration/components/chart/point-order-test.ts
@@ -131,7 +131,7 @@ module('Integration | Chart | point order', function (hooks) {
 
     await render(hbs`
       <div class="h-64 w-64">
-        <Station::Wind::Presenter @history={{this.data}} />
+        <Station::Wind::Presenter @history={{this.data}} @stationId="holfuy-1829" />
       </div>
     `);
 
@@ -152,10 +152,10 @@ module('Integration | Chart | point order', function (hooks) {
 
   // Root cause of issue #111, confirmed by a real browser repro (search for
   // and click between two stations, reading the rendered SVG before/after):
-  // ember-highcharts updates an existing chart in place via Highcharts'
-  // `series.setData()` rather than always destroying/recreating it, and
-  // Highcharts' default point-matching falls back to raw x value (wind
-  // direction here, a coarse 0-360 value) whenever it can't match an
+  // the chart-rendering code updates an existing chart in place via
+  // Highcharts' `series.setData()` rather than always destroying/recreating
+  // it, and Highcharts' default point-matching falls back to raw x value
+  // (wind direction here, a coarse 0-360 value) whenever it can't match an
   // incoming point by id. On a *fresh* fetch (cache miss, as simulated by
   // FakeStoreService below), StationHistorySection gets a genuinely new
   // Future and `<Request>` tears its content block down -- so this
@@ -261,8 +261,10 @@ module('Integration | Chart | point order', function (hooks) {
   // <Request>'s content block in the real app (confirmed against the real
   // running app: the chart's DOM node was reused across a station revisit,
   // and one point was displaced to the end of the array). The fix is
-  // `chart.allowMutatingData: false` in chart/polar.gts, which stops
-  // Highcharts from trying to match/reuse old points at all -- it always
+  // `updateChart` (app/utils/highcharts-lifecycle.ts, used by
+  // render-highcharts.ts) always calling `series.setData(data, false,
+  // false, false)` -- that last `false` is `updatePoints`, which stops
+  // Highcharts from trying to match/reuse old points at all; it always
   // rebuilds series data from the given array's own order instead.
   test('swapping @data on the same WindDirectionGraph instance still renders station order correctly', async function (this: Ctx, assert) {
     const stationA: History[] = [

--- a/tests/integration/components/chart/range-selector-reset-test.ts
+++ b/tests/integration/components/chart/range-selector-reset-test.ts
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+import {
+  render,
+  settled,
+  type RenderingTestContext,
+} from '@ember/test-helpers';
+import { set } from '@ember/object';
+import { hbs } from 'ember-cli-htmlbars';
+import { Type } from '@warp-drive/core/types/symbols';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+import type { History } from 'winds-mobi-client-web/services/store';
+import type { ChartWithRangeSelector } from 'winds-mobi-client-web/modifiers/render-highcharts';
+
+interface Ctx extends RenderingTestContext {
+  history: History[];
+  stationId: string;
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const now = Date.now();
+
+// Five days of hourly readings ending at `endTime`, matching the wind/air
+// charts' actual 5-day request duration -- long enough that "6h" (the
+// default range) and "all data" produce clearly distinguishable axis spans.
+function fiveDaysOfHistory(idPrefix: string, endTime: number): History[] {
+  const history: History[] = [];
+  for (let t = endTime - 5 * DAY; t <= endTime; t += HOUR) {
+    history.push({
+      id: `${idPrefix}:${t}`,
+      direction: 180,
+      speed: 10,
+      gusts: 12,
+      temperature: 10,
+      humidity: 50,
+      rain: 0,
+      timestamp: t,
+      [Type]: 'history',
+    });
+  }
+  return history;
+}
+
+// Issue #137: this app used to render its stock charts through
+// `ember-highcharts`, whose own update path called
+// `chart.xAxis[0].setExtremes()` with no arguments after every
+// content/options update, resetting any explicit range back to the full
+// data span ("All") rather than the configured `rangeSelector.selected`
+// default. On a station switch that reuses the same chart instance (no
+// `:loading` gap in between, see CLAUDE.md's Highcharts section and issue
+// #111), this silently left the chart zoomed out to everything instead of
+// resetting to the intended default range. `render-highcharts.ts` now
+// drives the chart directly and never does that blanket reset -- it only
+// re-applies the default range (via `RangeSelector#clickButton`) when
+// `stationId` itself changes. This test renders the real
+// `Station::Wind::Presenter` and keeps the same instance mounted across a
+// station switch (mirroring point-order-test.ts's own approach for the same
+// underlying reuse scenario) to confirm that behavior.
+module('Integration | Chart | range selector reset', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('switching stations resets the range selector to its default instead of leaving it at "All"', async function (this: Ctx, assert) {
+    set(this, 'history', fiveDaysOfHistory('holfuy-1829', now));
+    set(this, 'stationId', 'holfuy-1829');
+
+    await render(hbs`
+      <div class="h-64 w-64">
+        <Station::Wind::Presenter @history={{this.history}} @stationId={{this.stationId}} />
+      </div>
+    `);
+
+    const Highcharts = (await import('highcharts')).default;
+    const findChart = () =>
+      Highcharts.charts.findLast(
+        (c) => c && c.series.some((s) => s.name === 'Wind')
+      ) as ChartWithRangeSelector | undefined;
+
+    const chartBefore = findChart();
+    assert.strictEqual(
+      chartBefore?.rangeSelector?.selected,
+      4,
+      'the initial render defaults to the "6h" range selector button'
+    );
+
+    set(this, 'history', fiveDaysOfHistory('holfuy-1808', now + 1000));
+    set(this, 'stationId', 'holfuy-1808');
+    await settled();
+
+    const chartAfter = findChart();
+    assert.strictEqual(
+      chartAfter,
+      chartBefore,
+      'the same chart instance is reused across the station switch (matches the real cache-hit scenario)'
+    );
+    assert.strictEqual(
+      chartAfter?.rangeSelector?.selected,
+      4,
+      'switching stations resets the range selector back to its "6h" default, not left at "All"'
+    );
+
+    const extremes = chartAfter?.xAxis[0]?.getExtremes();
+    const spanHours = extremes
+      ? (extremes.max - extremes.min) / HOUR
+      : undefined;
+    assert.ok(
+      spanHours !== undefined && spanHours <= 7,
+      `the visible axis span (${spanHours} hours) reflects the 6h default, not the full 5-day history`
+    );
+  });
+});

--- a/tests/integration/components/chart/time-series-test.ts
+++ b/tests/integration/components/chart/time-series-test.ts
@@ -28,7 +28,9 @@ module('Integration | Component | chart/time-series', function (hooks) {
       },
     ];
 
-    await render(hbs`<Chart::TimeSeries @chartData={{this.chartData}} />`);
+    await render(
+      hbs`<Chart::TimeSeries @chartData={{this.chartData}} @stationId="holfuy-1829" />`
+    );
 
     assert.dom('.highcharts-container').exists();
   });
@@ -36,7 +38,9 @@ module('Integration | Component | chart/time-series', function (hooks) {
   test('it renders with no series data', async function (this: TimeSeriesTestContext, assert) {
     this.chartData = [];
 
-    await render(hbs`<Chart::TimeSeries @chartData={{this.chartData}} />`);
+    await render(
+      hbs`<Chart::TimeSeries @chartData={{this.chartData}} @stationId="holfuy-1829" />`
+    );
 
     assert.dom('.highcharts-container').exists();
   });

--- a/tests/integration/components/station/air/presenter-test.ts
+++ b/tests/integration/components/station/air/presenter-test.ts
@@ -44,7 +44,9 @@ module('Integration | Component | station/air/presenter', function (hooks) {
       },
     ];
 
-    await render(hbs`<Station::Air::Presenter @history={{this.history}} />`);
+    await render(
+      hbs`<Station::Air::Presenter @history={{this.history}} @stationId="holfuy-1829" />`
+    );
 
     assert.dom('.highcharts-container').exists();
   });
@@ -52,7 +54,9 @@ module('Integration | Component | station/air/presenter', function (hooks) {
   test('it renders the chart when there is no history', async function (this: AirPresenterTestContext, assert) {
     this.history = [];
 
-    await render(hbs`<Station::Air::Presenter @history={{this.history}} />`);
+    await render(
+      hbs`<Station::Air::Presenter @history={{this.history}} @stationId="holfuy-1829" />`
+    );
 
     assert.dom('.highcharts-container').exists();
   });

--- a/tests/integration/components/station/wind/presenter-test.ts
+++ b/tests/integration/components/station/wind/presenter-test.ts
@@ -44,7 +44,9 @@ module('Integration | Component | station/wind/presenter', function (hooks) {
       },
     ];
 
-    await render(hbs`<Station::Wind::Presenter @history={{this.history}} />`);
+    await render(
+      hbs`<Station::Wind::Presenter @history={{this.history}} @stationId="holfuy-1829" />`
+    );
 
     assert.dom('.highcharts-container').exists();
   });
@@ -52,7 +54,9 @@ module('Integration | Component | station/wind/presenter', function (hooks) {
   test('it renders the chart when there is no history', async function (this: WindPresenterTestContext, assert) {
     this.history = [];
 
-    await render(hbs`<Station::Wind::Presenter @history={{this.history}} />`);
+    await render(
+      hbs`<Station::Wind::Presenter @history={{this.history}} @stationId="holfuy-1829" />`
+    );
 
     assert.dom('.highcharts-container').exists();
   });


### PR DESCRIPTION
## Summary
- Fixes #137: wind/air charts sometimes opening zoomed out to "all data" instead of the intended 6h default, especially when switching stations. Root cause: `ember-highcharts`'s own update path unconditionally calls `chart.xAxis[0].setExtremes()` on every update, a 2016-era addon behavior with no upstream issue covering it.
- `ember-highcharts` is the only Ember-specific Highcharts wrapper that exists, so there was nothing to switch to — this replaces it with a small, hand-rolled driver instead:
  - `app/modifiers/render-highcharts.ts` — one class-based modifier drives both chart kinds this app uses (plain/polar for wind-direction, stock for wind/air), owning the full create/update/destroy lifecycle.
  - `app/utils/highcharts-lifecycle.ts` — shared update logic; series updates always disable Highcharts' point-matching (`setData(..., false, false, false)`), fixing issue #111 more directly than the old chart-level `allowMutatingData` flag.
  - Only the exact Highcharts modules this app actually uses are imported (`modules/stock`, `highcharts-more`), each as its own dynamically-loaded chunk wrapped in `@ember/test-waiters`. The accessibility module (previously force-loaded by the addon) is no longer imported at all.
- Bumps `highcharts` 12.5.0 → 13.0.0 (latest) and drops `ember-highcharts` entirely.
- Updates CLAUDE.md's Highcharts section and the changelog to match.

## Test plan
- [x] `pnpm lint` (types, eslint, template-lint, stylelint, prettier) clean
- [x] Full test suite (221 tests) passes
- [x] Verified the range-selector fix is load-bearing: disabled it and watched the new regression test fail, then restored it and watched it pass
- [x] Production build (`pnpm build`) succeeds with correct code-splitting (separate `stock`/`highcharts-more`/`highcharts` chunks, no `accessibility` chunk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)