### PR TITLE
Pin charts to light mode regardless of OS/browser color scheme

### DIFF
--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -34,6 +34,16 @@ export default class Polar extends Component<PolarSignature> {
     credits: {
       enabled: false,
     },
+    // Highcharts 13 auto-follows the OS/browser's prefers-color-scheme by
+    // default (`palette.colorScheme` defaults to `'light dark'`, resolved via
+    // CSS `light-dark()` on Highcharts' own inner wrapper div) -- verified by
+    // reading `renderer.box.parentElement`'s inline style directly in a
+    // scratch test. We only ever draw a light UI, so pin it explicitly
+    // rather than silently switching palettes when a station panel is
+    // viewed on a device set to dark mode.
+    palette: {
+      colorScheme: 'light',
+    },
     // No accessibility module is imported at all (see render-highcharts.ts)
     // -- unlike ember-highcharts, which always imported it, so the crash risk
     // that used to force this option (keyboard-navigation point proxies

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -46,6 +46,16 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
     credits: {
       enabled: false,
     },
+    // Highcharts 13 auto-follows the OS/browser's prefers-color-scheme by
+    // default (`palette.colorScheme` defaults to `'light dark'`, resolved via
+    // CSS `light-dark()` on Highcharts' own inner wrapper div) -- verified by
+    // reading `renderer.box.parentElement`'s inline style directly in a
+    // scratch test. We only ever draw a light UI, so pin it explicitly
+    // rather than silently switching palettes when a station panel is
+    // viewed on a device set to dark mode.
+    palette: {
+      colorScheme: 'light',
+    },
     // No accessibility module is imported at all (see render-highcharts.ts)
     // -- unlike ember-highcharts, which always imported it, so the crash risk
     // that used to force this option (keyboard-navigation point proxies

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed the wind/air and wind-direction charts sometimes rendering in a dark palette when your device's browser or OS is set to dark mode. They're always meant to match the rest of the app's light UI.
+
 ## v0.19.3 - 2026-07-23
 
 ### Fixed

--- a/tests/integration/components/chart/time-series-test.ts
+++ b/tests/integration/components/chart/time-series-test.ts
@@ -44,4 +44,24 @@ module('Integration | Component | chart/time-series', function (hooks) {
 
     assert.dom('.highcharts-container').exists();
   });
+
+  // Highcharts 13 auto-follows the OS/browser's prefers-color-scheme by
+  // default (`palette.colorScheme` defaults to `'light dark'`), which would
+  // otherwise silently switch this chart to a dark palette on a device set
+  // to dark mode. `defaultChartOptions` pins `palette.colorScheme` to
+  // `'light'`, which Highcharts reflects as an inline `color-scheme: light`
+  // style on its own wrapper (`.highcharts-container`) -- reading that
+  // confirms our option actually reached and took effect on the real chart,
+  // not just that we passed it.
+  test('it pins the chart to light mode regardless of the OS/browser color scheme preference', async function (this: TimeSeriesTestContext, assert) {
+    this.chartData = [{ name: 'Wind', data: [[Date.now(), 10]] }];
+
+    await render(
+      hbs`<Chart::TimeSeries @chartData={{this.chartData}} @stationId="holfuy-1829" />`
+    );
+
+    assert
+      .dom('.highcharts-container')
+      .hasAttribute('style', /color-scheme:\s*light/);
+  });
 });

--- a/tests/integration/components/station/wind-direction/graph-test.ts
+++ b/tests/integration/components/station/wind-direction/graph-test.ts
@@ -35,6 +35,36 @@ module(
       assert.dom('.highcharts-container').exists();
     });
 
+    // Highcharts 13 auto-follows the OS/browser's prefers-color-scheme by
+    // default (`palette.colorScheme` defaults to `'light dark'`), which would
+    // otherwise silently switch this chart to a dark palette on a device set
+    // to dark mode. `chart/polar.gts`'s `defaultChartOptions` pins
+    // `palette.colorScheme` to `'light'`, which Highcharts reflects as an
+    // inline `color-scheme: light` style on its own wrapper
+    // (`.highcharts-container`) -- reading that confirms our option actually
+    // reached and took effect on the real chart, not just that we passed it.
+    test('it pins the chart to light mode regardless of the OS/browser color scheme preference', async function (this: WindDirectionGraphTestContext, assert) {
+      this.data = [
+        {
+          id: 'reading',
+          direction: 180,
+          speed: 10,
+          gusts: 14,
+          temperature: 6,
+          humidity: 60,
+          rain: 0,
+          timestamp: Date.now(),
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+
+      assert
+        .dom('.highcharts-container')
+        .hasAttribute('style', /color-scheme:\s*light/);
+    });
+
     test('it renders the chart for recent history', async function (this: WindDirectionGraphTestContext, assert) {
       this.data = [
         {


### PR DESCRIPTION
## Summary
- Highcharts 13 (bumped in the recent `ember-highcharts` removal, #138) auto-follows the OS/browser's `prefers-color-scheme` by default -- `palette.colorScheme` defaults to `"light dark"`, resolved via CSS `light-dark()` on Highcharts' own inner wrapper div. This app's UI is always light, so the wind/air and wind-direction charts would silently switch to a dark palette on a device set to dark mode, clashing with the rest of the page.
- Pins `palette: { colorScheme: 'light' }` in both chart wrappers' default options (`chart/time-series.gts`, `chart/polar.gts`).

## Test plan
- [x] `pnpm lint` clean
- [x] Full test suite (223 tests) passes
- [x] Verified via Highcharts' own source, then empirically via a scratch test reading the resulting inline style
- [x] Confirmed the new regression tests are load-bearing: disabled the fix and watched both new tests fail, then restored it

🤖 Generated with [Claude Code](https://claude.com/claude-code)