### PR TITLE
Route marker clicks through MapLibre's own click, shrink base size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,10 +317,23 @@ obvious from the decorator call site:
 - **Always use Frontile's `<Button>` (`@frontile/buttons`) instead of a bare HTML `<button>`.** Use `@onPress`
   (not an `{{on "click" ...}}` modifier). Reach for `@appearance="custom"` (plus an explicit `@intent="default"`,
   since `custom`'s own default intent resolves to `primary`) when a button needs fully bespoke, non-thematic
-  coloring (e.g. an SVG marker whose fill colors are computed data, not a Frontile intent) — `custom` has no
-  background/hover compound classes of its own to fight, unlike `minimal`/`outlined`/`default`. Only a handful of
-  _non-button_ clickable custom elements are legitimate exceptions (e.g. `<LinkTo>` navigation, or a MapLibre
-  control that isn't DOM at all) — a plain `<button>` standing in for one is not.
+  coloring — `custom` has no background/hover compound classes of its own to fight, unlike
+  `minimal`/`outlined`/`default`. Only a handful of _non-button_ clickable custom elements are legitimate
+  exceptions (e.g. `<LinkTo>` navigation) — a plain `<button>` standing in for one is not.
+  - **The on-map station marker ([map/station-marker.gts](app/components/map/station-marker.gts)) is a
+    deliberate exception, and isn't a button at all — not even Frontile's.** It's a plain, non-interactive
+    `<div>`; selecting a station is wired up in [map/index.gts](app/components/map/index.gts) via
+    `<marker.on @event="click" @action={{fn this.stationSelected station}}>`, using the click MapLibre's own
+    `Marker` already fires on itself (it uses this internally for popup-toggling). This replaced an earlier
+    version with its own nested `<Button>` and `@onSelect` callback: MapLibre repositions every marker via a
+    continuous CSS `transform` reassignment on every pan/zoom/momentum-settle, and stacking a second
+    independently-transformed clickable element on top of that gave mobile browsers a second thing that could be
+    moving mid-tap — a documented trigger for silently dropping a touch's synthesized click (a target moving
+    between touchstart and touchend reads as a scroll, not a tap). Routing the click through the marker's own
+    already-reliable element removes that. Traded away deliberately: keyboard Enter/Space activation, which the
+    old `<Button>` gave for free — MapLibre's own keyboard handling on a marker only wires Enter/Space to
+    toggling a popup, not a generic click, and this app has accepted that gap rather than wiring up a keyboard
+    handler of its own.
   - **A `class` override does NOT tailwind-merge against the theme's own base/variant classes** — verified
     empirically (render a `<Button class="rounded-full">`, inspect `element.className`): both `rounded-sm` (the
     theme's base) and your `rounded-full` end up in the class list, and plain CSS source order — not attribute

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,31 @@
 # TODO
 
+## Exploratory
+
+- **Render map station markers as native MapLibre GL layers instead of per-station DOM
+  markers.** Where it lives: `app/components/map/station-marker.gts` (the marker itself)
+  and `app/components/map/index.gts` (the `{{#each this.stations as |station|}}` /
+  `<map.marker>` loop). Problem: today each station is a real DOM element
+  (`<map.marker>`'s `domContent` div) repositioned via JS/CSS `transform` on every map
+  frame; that's one HTML node + CSS transform per station (currently capped at 470 by
+  `mapQuery`), and it's the same category of "DOM element with its own transform, stacked
+  on top of MapLibre's own transformed marker element" that turned out to cause the
+  mobile click-reliability bug fixed alongside this TODO entry. A `GeoJSONSource` +
+  `symbol`/`circle` layer setup (see MapLibre's own layer/source components,
+  `ember-maplibre-gl`'s `<map.source>`/`<source.layer>`) renders all stations as vector
+  data on the WebGL canvas instead, with MapLibre's own feature-click hit-testing (pure
+  GPU raycasting, no DOM/CSS-transform involved at all) replacing per-marker DOM click
+  handling entirely, and scales far better than one DOM node per station. Proposed fix:
+  not a quick swap -- would need (1) pre-rasterizing the two arrow shapes
+  (`public/images/arrow-not-peak.svg`/`arrow-peak.svg`) into recolorable SDF sprites
+  (`map.addImage(..., {sdf: true})`) instead of drawing the SVG paths directly, (2)
+  moving per-station rotation/color/scale from the current Ember getters
+  (`station-marker.gts`'s `markerColor`/`markerScale`/`markerTransform`) into precomputed
+  GeoJSON feature properties consumed via `icon-rotate`/`icon-color`/`icon-size`
+  expressions, (3) a separate filtered layer (or paint expression) for the gusts hub and
+  the selection ring. Worth prototyping as a throwaway spike first (confirm SDF
+  recoloring + rotation actually looks right) before committing to the full rewrite.
+
 Dev-environment cleanup audit (2026-07-11). Baseline for comparison: the stock
 `ember-cli` 6.3.1 app blueprint + `@ember/app-blueprint` (Vite) overlay, TypeScript
 variant. Each section below is worked as one focused commit that also removes its

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { array } from '@ember/helper';
+import { array, fn } from '@ember/helper';
 import { service } from '@ember/service';
 import type { Future } from '@warp-drive/core/request';
 import { getRequestState } from '@warp-drive/core/reactive';
@@ -371,12 +371,16 @@ export default class Map extends Component<MapSignature> {
           <map.marker
             @initOptions={{this.markerInitOptions}}
             @lngLat={{this.markerPosition station}}
+            as |marker|
           >
             <MapStationMarker
               @isSelected={{this.isStationSelected station}}
-              @onSelect={{this.stationSelected}}
               @station={{station}}
               @zoom={{this.mapView.zoom}}
+            />
+            <marker.on
+              @event="click"
+              @action={{fn this.stationSelected station}}
             />
           </map.marker>
         {{/each}}

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -1,8 +1,6 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
-import { Button } from '@frontile/buttons';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 import {
   ARROW_DIRECTION_OFFSET,
@@ -18,13 +16,28 @@ import type { Station } from 'winds-mobi-client-web/services/store';
 export interface MapStationMarkerSignature {
   Args: {
     isSelected?: boolean;
-    onSelect: (station: Station) => void;
     station: Station;
     zoom: number;
   };
-  Element: HTMLButtonElement;
+  Element: HTMLDivElement;
 }
 
+// Purely presentational -- the ring/disc and the arrow inside it. Clicking is
+// handled by the MapLibre marker itself, not by anything in this component
+// (see `map/index.gts`'s `<marker.on @event="click" ...>`): MapLibre's own
+// `Marker` element already fires a native `click` (it uses this internally
+// for popup-toggling), and continuously repositions itself via CSS
+// `transform` during every pan/zoom/momentum-settle -- stacking our own
+// separate clickable element (and its own `transform: scale(...)`) on top
+// added a second thing that could be moving mid-tap, which is a known
+// trigger for mobile browsers to silently drop a touch's synthesized click
+// (a target that moves between touchstart and touchend reads as a
+// scroll/pan, not a tap). Letting the marker's own already-reliable click
+// carry the selection removes that extra layer. Traded away: keyboard
+// Enter/Space activation, which this component's own real `<button>` used
+// to give for free -- MapLibre's marker only wires Enter/Space to toggling a
+// popup, not a generic click, and this app has decided that's an acceptable
+// gap for now rather than wiring up a keyboard handler of its own.
 export default class MapStationMarker extends Component<MapStationMarkerSignature> {
   @service declare settings: SettingsService;
 
@@ -83,42 +96,27 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     return `rotate(${angle} ${centre})`;
   }
 
-  // Age/zoom shrink applied as a CSS transform on the button itself, rather
-  // than an SVG-space scale on the inner <g>, so the button's own click
-  // target and the arrow it wraps shrink together as one unit -- a stale or
-  // zoomed-out station gets a smaller tap target to match its smaller
-  // silhouette, rather than a full-size ring around a shrunken arrow. This
-  // also sidesteps SVG's `scale()` always scaling about the origin: CSS
-  // transforms default to `transform-origin: center`, and the button's own
-  // box is already centred on the hub (the svg's `viewBox` is centred on it,
-  // and `flex! items-center justify-center` centres the svg within the
-  // button), so scaling the button needs no manual recentring either.
+  // Age/zoom shrink applied as a CSS transform on the outer div itself,
+  // rather than an SVG-space scale on the inner <g>, so the ring and the
+  // arrow it wraps shrink together as one unit. This also sidesteps SVG's
+  // `scale()` always scaling about the origin: CSS transforms default to
+  // `transform-origin: center`, and the div's own box is already centred on
+  // the hub (the svg's `viewBox` is centred on it, and `flex items-center
+  // justify-center` centres the svg within the div), so scaling the div
+  // needs no manual recentring either.
   get scaleStyle() {
     return htmlSafe(`transform: scale(${this.markerScale});`);
   }
 
-  // Frontile's Button doesn't tailwind-merge its `class` arg against the
-  // theme's own base/variant classes (verified empirically -- both a passed
-  // override and the conflicting theme class end up in the DOM, and CSS
-  // source order decides the winner, not attribute order). `!` forces our
-  // override to win regardless: without it, the theme's own `rounded-sm`/
-  // default-size padding non-deterministically fight this button's own
-  // `rounded-full`/`p-1`.
-  //
-  // The button's own box (h-28, 112px) is deliberately bigger than the svg it
-  // wraps (h-24, 96px, the arrow's natural drawn size) -- even after `p-1!`'s
-  // padding and Frontile's own 1px border eat into the interior (down to
-  // 102px), the svg still fits inside with room to spare, so the ring reads
-  // as just outside the arrow's silhouette rather than hugging its edges.
-  // `flex! items-center justify-center` centres the svg within that
-  // interior; `!` forces it over Frontile's own base `inline-block`
-  // (verified in `@frontile/theme`'s `baseButton`), which otherwise wins the
-  // `display` property by source order (same unmerged-class gotcha as
-  // elsewhere in this file) and leaves the svg anchored top-left instead of
-  // centred.
-  get buttonClass() {
+  // The div's own box (h-14, 56px) is deliberately bigger than the svg it
+  // wraps (h-12, 48px, the arrow's natural drawn size), so the ring reads as
+  // just outside the arrow's silhouette rather than hugging its edges -- the
+  // same 7:6 ratio as the previous h-28/h-24 sizing, just at a footprint
+  // that doesn't dwarf the map at full zoom/a fresh reading (`markerScale`
+  // of 1).
+  get markerClass() {
     const base =
-      'flex! h-28 w-28 cursor-pointer items-center justify-center rounded-full! p-1! transition focus:outline-none';
+      'flex h-14 w-14 cursor-pointer items-center justify-center rounded-full p-1 transition';
 
     // Selected: a grey disc + ring hugging the arrow so it stands out without
     // spilling into neighbouring markers' clickable area.
@@ -127,26 +125,17 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
       : base;
   }
 
-  @action
-  handleSelect() {
-    this.args.onSelect(this.args.station);
-  }
-
   <template>
     {{! template-lint-disable no-inline-styles }}
-    <Button
-      aria-label={{@station.name}}
+    <div
       data-selected={{if @isSelected "true"}}
       data-station-id={{@station.id}}
       data-test-map-station-marker
-      @appearance="custom"
-      @intent="default"
-      @onPress={{this.handleSelect}}
-      class={{this.buttonClass}}
+      class={{this.markerClass}}
       style={{this.scaleStyle}}
     >
       {{! template-lint-enable no-inline-styles }}
-      <svg aria-hidden="true" class="h-24 w-24" viewBox={{this.viewBox}}>
+      <svg aria-hidden="true" class="h-12 w-12" viewBox={{this.viewBox}}>
         <g transform={{this.markerTransform}}>
           {{! Gusts band differs: the gusts shape behind, shown through the hub hole. }}
           {{#if this.showGustsHub}}
@@ -164,6 +153,6 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
           />
         </g>
       </svg>
-    </Button>
+    </div>
   </template>
 }

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changed
+
+- Map station markers are smaller at full size, so they no longer dwarf the map on a close-up view.
+
+### Fixed
+
+- Fixed map station markers sometimes not responding to a tap on mobile. Selecting a station is now handled by the map marker itself instead of a separate button layered on top of it.
+
 ## v0.19.4 - 2026-07-24
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Fixes map station markers sometimes not responding to a tap on mobile: selection used to go through a nested Frontile `<Button>` inside each marker, each with its own `transform: scale(...)`. MapLibre repositions every marker via a continuous `transform` reassignment on every pan/zoom/momentum-settle, so a second independently-transformed clickable element on top gave mobile browsers a second thing that could be moving mid-tap -- a documented trigger for silently dropping a touch's synthesized click.
- `station-marker.gts` is now a plain, non-interactive `<div>` -- no button, no click handling of its own. `map/index.gts` wires selection through `<marker.on @event="click" @action={{fn this.stationSelected station}}>`, using the native click MapLibre's own `Marker` already fires on itself (it uses this internally for popup-toggling).
- Also halves the marker's base size (`h-28`/`h-24` -> `h-14`/`h-12`, same 7:6 div-to-arrow ratio) so it no longer dwarfs the map at a close-up view.
- Saves a bigger follow-up idea (render markers as native MapLibre GL layers instead of per-station DOM elements) as an exploratory TODO rather than folding it into this change.
- Updates CLAUDE.md's Button convention to document this as a deliberate exception.

## Notes
Traded away keyboard Enter/Space activation, which the old `<Button>` gave for free -- MapLibre's own keyboard handling on a marker only wires Enter/Space to toggling a popup, not a generic click. Accepted gap for now.

## Test plan
- [x] `pnpm lint` clean
- [x] Full test suite (223 tests) passes
- [ ] Visual/manual check of marker click reliability on a real mobile device (can't be verified in this headless dev container -- no WebGL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)