### PR TITLE
Always show the marker ring, size it to the arrow, and fix polar chart labels

### DIFF
--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -60,6 +60,14 @@ export default class Polar extends Component<PolarSignature> {
       reflow: true,
       type: 'line',
       spacing: [0, 0, 0, 0],
+      // `plotOptions.series.animation` below only covers per-point/series
+      // animation. Chart-level animation still applies to everything else --
+      // notably the yAxis extremes, which shift on every background refresh
+      // as `wind-direction/graph.gts`'s sliding window moves, animating every
+      // point to a new radius each time. Data here always replaces outright
+      // rather than transitioning between old and new state, so animation is
+      // off at the chart level too, not just per-series.
+      animation: false,
     },
     title: {
       text: undefined,
@@ -73,10 +81,20 @@ export default class Polar extends Component<PolarSignature> {
       min: 0,
       max: 360,
       labels: {
+        // Highcharts' cartesian-oriented overflow check misjudges this
+        // circular layout and crops most of the 8 compass labels down to
+        // nothing (only N/S happen to pass it); `allow` renders every label
+        // the formatter returns, uncropped.
+        overflow: 'allow',
         formatter: function ({ value }: { value: number }) {
           return DIRECTIONS[Math.round(value / 45)];
         },
-        distance: '86%',
+        // The pane (below and in the `responsive` rules) always fills nearly
+        // the whole chart box, so a positive distance -- which places labels
+        // *outside* the pane's own radius -- pushes them past the visible
+        // edge. Negative keeps them inside the pane, with room for the
+        // label's own text width before the edge.
+        distance: '-25%',
         style: {
           fontSize: '11px',
         },
@@ -123,7 +141,7 @@ export default class Polar extends Component<PolarSignature> {
             },
             xAxis: {
               labels: {
-                distance: '78%',
+                distance: '-25%',
                 style: {
                   fontSize: '10px',
                 },

--- a/app/components/chart/time-series.gts
+++ b/app/components/chart/time-series.gts
@@ -80,6 +80,13 @@ export default class TimeSeries extends Component<TimeSeriesSignature> {
       spacingBottom: 6,
       spacingTop: 6,
       zoomType: 'x',
+      // `plotOptions.series.animation` below only covers per-point/series
+      // animation. Chart-level animation still applies to everything else
+      // (e.g. axis extremes) on every background refresh. Data here always
+      // replaces outright rather than transitioning between old and new
+      // state, so animation is off at the chart level too, not just
+      // per-series.
+      animation: false,
     },
     rangeSelector: {
       inputEnabled: false,

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -207,16 +207,15 @@ export default class Map extends Component<MapSignature> {
       // `cursor-pointer` and `rounded-full` here, not on anything inside
       // `<MapStationMarker>`: this `className` lands on MapLibre's own
       // marker element (the thing `<marker.on @event="click">` actually
-      // listens on), which stays at its full unscaled size even when the
-      // marker's own inner content is visually shrunk via `scale()` (a CSS
-      // transform doesn't shrink the box a parent/hit-test uses, only the
-      // transformed element's own painted region) -- so the cursor, and the
-      // circular shape the selected-state ring (see the `selectMapMarker`
-      // modifier) needs to render against, both have to live on the outer
-      // element to match the real clickable area, not the inner content
-      // that can be smaller than it. Static and never varies, unlike the
-      // ring itself, so this is a plain `className` rather than something
-      // toggled by a modifier.
+      // listens on), which is the element the app needs a reliable click
+      // from -- see `map/station-marker.gts`'s own top-of-file comment for
+      // why click is routed through MapLibre's own element rather than a
+      // second clickable element stacked on top. `<MapStationMarker>`'s own
+      // content now sizes this outer element too (it shrink-wraps to it), so
+      // the cursor and the selected-state ring (see the `selectMapMarker`
+      // modifier) track the marker's actual current size, not a fixed one.
+      // Static and never varies, unlike the ring itself, so this is a plain
+      // `className` rather than something toggled by a modifier.
       className: 'cursor-pointer rounded-full',
       // Pin the marker to the map plane so MapLibre counter-rotates it by the
       // bearing and tilts it by the pitch on every rotate/pitch event. The wind

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -204,6 +204,20 @@ export default class Map extends Component<MapSignature> {
   get markerInitOptions() {
     return {
       anchor: 'center' as const,
+      // `cursor-pointer` and `rounded-full` here, not on anything inside
+      // `<MapStationMarker>`: this `className` lands on MapLibre's own
+      // marker element (the thing `<marker.on @event="click">` actually
+      // listens on), which stays at its full unscaled size even when the
+      // marker's own inner content is visually shrunk via `scale()` (a CSS
+      // transform doesn't shrink the box a parent/hit-test uses, only the
+      // transformed element's own painted region) -- so the cursor, and the
+      // circular shape the selected-state ring (see the `selectMapMarker`
+      // modifier) needs to render against, both have to live on the outer
+      // element to match the real clickable area, not the inner content
+      // that can be smaller than it. Static and never varies, unlike the
+      // ring itself, so this is a plain `className` rather than something
+      // toggled by a modifier.
+      className: 'cursor-pointer rounded-full',
       // Pin the marker to the map plane so MapLibre counter-rotates it by the
       // bearing and tilts it by the pitch on every rotate/pitch event. The wind
       // direction stays in the marker's own SVG `rotate(...)`, so the net effect

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -206,16 +206,14 @@ export default class Map extends Component<MapSignature> {
       anchor: 'center' as const,
       // `cursor-pointer` and `rounded-full` here, not on anything inside
       // `<MapStationMarker>`: this `className` lands on MapLibre's own
-      // marker element (the thing `<marker.on @event="click">` actually
-      // listens on), which is the element the app needs a reliable click
-      // from -- see `map/station-marker.gts`'s own top-of-file comment for
-      // why click is routed through MapLibre's own element rather than a
-      // second clickable element stacked on top. `<MapStationMarker>`'s own
-      // content now sizes this outer element too (it shrink-wraps to it), so
-      // the cursor and the selected-state ring (see the `selectMapMarker`
-      // modifier) track the marker's actual current size, not a fixed one.
-      // Static and never varies, unlike the ring itself, so this is a plain
-      // `className` rather than something toggled by a modifier.
+      // marker element, the one `<marker.on @event="click">` listens on and
+      // the reliable click target (see `map/station-marker.gts`'s top-of-file
+      // comment for why click is routed through it rather than a second
+      // clickable element). This element shrink-wraps to `<MapStationMarker>`'s
+      // own content, so the cursor and the selected-state ring (see the
+      // `selectMapMarker` modifier) always match the marker's current size.
+      // This value is static and never varies, unlike the ring itself, so
+      // it's a plain `className` rather than something toggled by a modifier.
       className: 'cursor-pointer rounded-full',
       // Pin the marker to the map plane so MapLibre counter-rotates it by the
       // bearing and tilts it by the pitch on every rotate/pitch event. The wind

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
+import selectMapMarker from 'winds-mobi-client-web/modifiers/select-map-marker';
 import type SettingsService from 'winds-mobi-client-web/services/settings';
 import {
   ARROW_DIRECTION_OFFSET,
+  ARROW_SCALE,
   colourForWindReading,
   MARKER_OUTLINE_WIDTH,
   MARKER_PLAIN_OUTLINE_COLOUR,
@@ -72,19 +74,21 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     );
   }
 
-  // Shrink the whole arrow by reading age when the preference is on, and
-  // always by map zoom so markers don't dwarf the map when zoomed out to see
-  // a whole region. The two multiply together, so an old reading at a low
-  // zoom shrinks further still. Recomputed each refresh cycle as new readings
-  // replace the record, so no timer is needed — the data only changes on
-  // refresh anyway; the zoom factor is recomputed whenever the routed zoom
-  // (settled after a pan/zoom gesture) changes.
+  // ARROW_SCALE grows the arrow past the ring's fixed baseline (see the
+  // svg's own class below and ARROW_SCALE's comment in station-arrow.ts).
+  // On top of that, shrink the whole arrow by reading age when the
+  // preference is on, and always by map zoom so markers don't dwarf the map
+  // when zoomed out to see a whole region. All three multiply together, so
+  // an old reading at a low zoom shrinks further still. Recomputed each
+  // refresh cycle as new readings replace the record, so no timer is needed
+  // — the data only changes on refresh anyway; the zoom factor is recomputed
+  // whenever the routed zoom (settled after a pan/zoom gesture) changes.
   get markerScale() {
     const ageScale = this.settings.shrinkOldData
       ? scaleForReadingAge(this.args.station.last.timestamp)
       : 1;
 
-    return ageScale * scaleForZoom(this.args.zoom);
+    return ARROW_SCALE * ageScale * scaleForZoom(this.args.zoom);
   }
 
   // Rotate to the wind direction about the hub centre. `rotate(angle cx cy)`
@@ -108,22 +112,18 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     return htmlSafe(`transform: scale(${this.markerScale});`);
   }
 
-  // The div's own box (h-14, 56px) is deliberately bigger than the svg it
-  // wraps (h-12, 48px, the arrow's natural drawn size), so the ring reads as
-  // just outside the arrow's silhouette rather than hugging its edges -- the
-  // same 7:6 ratio as the previous h-28/h-24 sizing, just at a footprint
-  // that doesn't dwarf the map at full zoom/a fresh reading (`markerScale`
-  // of 1).
-  get markerClass() {
-    const base =
-      'flex h-14 w-14 cursor-pointer items-center justify-center rounded-full p-1 transition';
-
-    // Selected: a grey disc + ring hugging the arrow so it stands out without
-    // spilling into neighbouring markers' clickable area.
-    return this.args.isSelected
-      ? `${base} bg-slate-400/40 ring-1 ring-inset ring-slate-500/70`
-      : base;
-  }
+  // `cursor-pointer` and `rounded-full` deliberately live on the MapLibre
+  // marker element itself (`markerInitOptions` in map/index.gts, that shape
+  // is static and never varies), and the selected-state ring lives there too,
+  // toggled by the `selectMapMarker` modifier below (that one's reactive, so
+  // it can't be a static `className` -- see the modifier's own comment). That
+  // outer element's shrink-wrapped size comes from this div's own unscaled
+  // layout box (h-20, 80px) alone -- the svg below deliberately carries no
+  // `h-*`/`w-*` of its own (confirmed empirically that tuning them had no
+  // visible effect anyway), so `ARROW_SCALE` (see station-arrow.ts) is the
+  // only thing controlling the arrow's visible size, via the same
+  // `transform: scale(...)` below.
+  markerClass = 'flex h-20 w-20 items-center justify-center p-1 transition';
 
   <template>
     {{! template-lint-disable no-inline-styles }}
@@ -133,9 +133,10 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
       data-test-map-station-marker
       class={{this.markerClass}}
       style={{this.scaleStyle}}
+      {{selectMapMarker @isSelected}}
     >
       {{! template-lint-enable no-inline-styles }}
-      <svg aria-hidden="true" class="h-12 w-12" viewBox={{this.viewBox}}>
+      <svg aria-hidden="true" viewBox={{this.viewBox}}>
         <g transform={{this.markerTransform}}>
           {{! Gusts band differs: the gusts shape behind, shown through the hub hole. }}
           {{#if this.showGustsHub}}

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -26,21 +26,17 @@ export interface MapStationMarkerSignature {
 }
 
 // Purely presentational -- the ring/disc and the arrow inside it. Clicking is
-// handled by the MapLibre marker itself, not by anything in this component
-// (see `map/index.gts`'s `<marker.on @event="click" ...>`): MapLibre's own
-// `Marker` element already fires a native `click` (it uses this internally
-// for popup-toggling), and continuously repositions itself via CSS
-// `transform` during every pan/zoom/momentum-settle -- stacking our own
-// separate clickable element (and its own `transform: scale(...)`) on top
-// added a second thing that could be moving mid-tap, which is a known
-// trigger for mobile browsers to silently drop a touch's synthesized click
-// (a target that moves between touchstart and touchend reads as a
-// scroll/pan, not a tap). Letting the marker's own already-reliable click
-// carry the selection removes that extra layer. Traded away: keyboard
-// Enter/Space activation, which this component's own real `<button>` used
-// to give for free -- MapLibre's marker only wires Enter/Space to toggling a
-// popup, not a generic click, and this app has decided that's an acceptable
-// gap for now rather than wiring up a keyboard handler of its own.
+// handled by the MapLibre marker itself (see `map/index.gts`'s `<marker.on
+// @event="click" ...>`), not by anything in this component: MapLibre's own
+// `Marker` element continuously repositions itself via CSS `transform`
+// during every pan/zoom/momentum-settle, and a second, independently
+// clickable element layered on top would give mobile browsers a second
+// thing that can be moving mid-tap -- a known trigger for a touch's
+// synthesized click getting silently dropped (a target that moves between
+// touchstart and touchend reads as a scroll/pan, not a tap). The marker's
+// own click is reliable and carries the selection instead. This does mean
+// no keyboard Enter/Space activation -- MapLibre's marker only wires those
+// keys to toggling a popup, not a generic click.
 export default class MapStationMarker extends Component<MapStationMarkerSignature> {
   @service declare settings: SettingsService;
 
@@ -108,40 +104,36 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     return `rotate(${angle} ${centre})`;
   }
 
-  // Age/zoom/ARROW_SCALE resize the outer div's real `width`/`height`
-  // (`markerSizePx` above), not a `transform: scale(...)` -- deliberately,
-  // so the ring (the outer `.maplibregl-marker` element, which shrink-wraps
-  // to this div's own layout box) tracks the same size as the arrow instead
-  // of staying fixed while only the arrow's paint shrinks. A `transform`
-  // only affects an element's own painted/hit-test region, never the layout
-  // box an ancestor uses to size itself around it -- real `width`/`height`
-  // is what actually propagates up. This is also what makes the marker's
-  // real clickable area (on the outer element, see `markerInitOptions` in
-  // map/index.gts) match its current visual size, which matters when
-  // several markers' click areas would otherwise overlap at a shrunk zoom
-  // level. The svg below fills this box (`h-full w-full`), and MapLibre's
-  // own `anchor: 'center'` recentring is percentage-based, so it stays
-  // correct as the box resizes without any recentring trick here either.
+  // Sets the div's real `width`/`height` (`markerSizePx` above) rather than
+  // a `transform: scale(...)`, so the ring (the outer `.maplibregl-marker`
+  // element, which shrink-wraps to this div's own layout box) tracks the
+  // arrow's size instead of staying a fixed size around a shrunk arrow -- a
+  // `transform` only affects an element's own painted/hit-test region, never
+  // the layout box an ancestor uses to size itself around it. This also
+  // keeps the marker's real clickable area (the outer element, see
+  // `markerInitOptions` in map/index.gts) matching its current visual size,
+  // so neighbouring markers' click areas don't overlap more than their
+  // visible arrows do at a shrunk zoom level. The svg fills this box
+  // (`h-full w-full`), and MapLibre's own `anchor: 'center'` recentring is
+  // percentage-based, so it stays correct as the box resizes.
   get sizeStyle() {
     const size = this.markerSizePx;
     return htmlSafe(`width: ${size}px; height: ${size}px;`);
   }
 
-  // `cursor-pointer` and `rounded-full` deliberately live on the MapLibre
-  // marker element itself (`markerInitOptions` in map/index.gts, that shape
-  // is static and never varies), and the selected-state ring lives there too,
-  // toggled by the `selectMapMarker` modifier below (that one's reactive, so
-  // it can't be a static `className` -- see the modifier's own comment).
-  // Sizing is entirely `sizeStyle` above now (real `width`/`height`, not a
-  // Tailwind `h-*`/`w-*`), so this only carries layout/visual classes that
-  // don't vary with scale; `transition-[width,height]` keeps resizes smooth
-  // now that the default `transition` utility (which covered `transform`)
-  // no longer applies to what's actually changing. `p-1` gives the arrow a
-  // small fixed gap from the ring's edge (works because Tailwind's
-  // preflight sets `box-sizing: border-box` app-wide, so this padding
-  // carves into `sizeStyle`'s box rather than growing past it) -- it's a
-  // fixed px amount rather than a percentage, so it becomes proportionally
-  // more of the box the smaller a marker shrinks.
+  // `cursor-pointer` and `rounded-full` live on the MapLibre marker element
+  // itself (`markerInitOptions` in map/index.gts, a static shape), and the
+  // selected-state ring lives there too, toggled by the `selectMapMarker`
+  // modifier below (reactive, so it can't be a static `className` -- see the
+  // modifier's own comment). Size comes entirely from `sizeStyle` above
+  // (real `width`/`height`), so this only carries classes that don't vary
+  // with scale; `transition-[width,height]` keeps resizes smooth (Tailwind's
+  // `transition` utility covers `transform`, not `width`/`height`). `p-1`
+  // gives the arrow a small fixed gap from the ring's edge (Tailwind's
+  // preflight sets `box-sizing: border-box` app-wide, so this padding carves
+  // into `sizeStyle`'s box rather than growing past it) -- being a fixed px
+  // amount rather than a percentage, that gap becomes proportionally bigger
+  // the smaller a marker shrinks.
   markerClass =
     'flex items-center justify-center p-1 transition-[width,height]';
 

--- a/app/components/map/station-marker.gts
+++ b/app/components/map/station-marker.gts
@@ -6,6 +6,7 @@ import type SettingsService from 'winds-mobi-client-web/services/settings';
 import {
   ARROW_DIRECTION_OFFSET,
   ARROW_SCALE,
+  BASE_MARKER_SIZE,
   colourForWindReading,
   MARKER_OUTLINE_WIDTH,
   MARKER_PLAIN_OUTLINE_COLOUR,
@@ -74,15 +75,15 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     );
   }
 
-  // ARROW_SCALE grows the arrow past the ring's fixed baseline (see the
-  // svg's own class below and ARROW_SCALE's comment in station-arrow.ts).
-  // On top of that, shrink the whole arrow by reading age when the
-  // preference is on, and always by map zoom so markers don't dwarf the map
-  // when zoomed out to see a whole region. All three multiply together, so
-  // an old reading at a low zoom shrinks further still. Recomputed each
-  // refresh cycle as new readings replace the record, so no timer is needed
-  // — the data only changes on refresh anyway; the zoom factor is recomputed
-  // whenever the routed zoom (settled after a pan/zoom gesture) changes.
+  // ARROW_SCALE is a flat overall-size multiplier (see its comment in
+  // station-arrow.ts). On top of that, shrink the whole marker by reading
+  // age when the preference is on, and always by map zoom so markers don't
+  // dwarf the map when zoomed out to see a whole region. All three multiply
+  // together, so an old reading at a low zoom shrinks further still.
+  // Recomputed each refresh cycle as new readings replace the record, so no
+  // timer is needed — the data only changes on refresh anyway; the zoom
+  // factor is recomputed whenever the routed zoom (settled after a pan/zoom
+  // gesture) changes.
   get markerScale() {
     const ageScale = this.settings.shrinkOldData
       ? scaleForReadingAge(this.args.station.last.timestamp)
@@ -91,39 +92,58 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
     return ARROW_SCALE * ageScale * scaleForZoom(this.args.zoom);
   }
 
+  // The actual rendered box (px) for both the ring and the arrow together —
+  // see `sizeStyle` below for why this drives real `width`/`height` rather
+  // than a `transform: scale(...)`.
+  get markerSizePx() {
+    return BASE_MARKER_SIZE * this.markerScale;
+  }
+
   // Rotate to the wind direction about the hub centre. `rotate(angle cx cy)`
-  // takes its centre natively, unlike scale (see `scaleStyle` below), so this
-  // needs no recentring trick of its own.
+  // takes its centre natively, unlike scale, so this needs no recentring
+  // trick of its own.
   get markerTransform() {
     const centre = this.geometry.rotationCentre;
     const angle = this.args.station.last.direction + ARROW_DIRECTION_OFFSET;
     return `rotate(${angle} ${centre})`;
   }
 
-  // Age/zoom shrink applied as a CSS transform on the outer div itself,
-  // rather than an SVG-space scale on the inner <g>, so the ring and the
-  // arrow it wraps shrink together as one unit. This also sidesteps SVG's
-  // `scale()` always scaling about the origin: CSS transforms default to
-  // `transform-origin: center`, and the div's own box is already centred on
-  // the hub (the svg's `viewBox` is centred on it, and `flex items-center
-  // justify-center` centres the svg within the div), so scaling the div
-  // needs no manual recentring either.
-  get scaleStyle() {
-    return htmlSafe(`transform: scale(${this.markerScale});`);
+  // Age/zoom/ARROW_SCALE resize the outer div's real `width`/`height`
+  // (`markerSizePx` above), not a `transform: scale(...)` -- deliberately,
+  // so the ring (the outer `.maplibregl-marker` element, which shrink-wraps
+  // to this div's own layout box) tracks the same size as the arrow instead
+  // of staying fixed while only the arrow's paint shrinks. A `transform`
+  // only affects an element's own painted/hit-test region, never the layout
+  // box an ancestor uses to size itself around it -- real `width`/`height`
+  // is what actually propagates up. This is also what makes the marker's
+  // real clickable area (on the outer element, see `markerInitOptions` in
+  // map/index.gts) match its current visual size, which matters when
+  // several markers' click areas would otherwise overlap at a shrunk zoom
+  // level. The svg below fills this box (`h-full w-full`), and MapLibre's
+  // own `anchor: 'center'` recentring is percentage-based, so it stays
+  // correct as the box resizes without any recentring trick here either.
+  get sizeStyle() {
+    const size = this.markerSizePx;
+    return htmlSafe(`width: ${size}px; height: ${size}px;`);
   }
 
   // `cursor-pointer` and `rounded-full` deliberately live on the MapLibre
   // marker element itself (`markerInitOptions` in map/index.gts, that shape
   // is static and never varies), and the selected-state ring lives there too,
   // toggled by the `selectMapMarker` modifier below (that one's reactive, so
-  // it can't be a static `className` -- see the modifier's own comment). That
-  // outer element's shrink-wrapped size comes from this div's own unscaled
-  // layout box (h-20, 80px) alone -- the svg below deliberately carries no
-  // `h-*`/`w-*` of its own (confirmed empirically that tuning them had no
-  // visible effect anyway), so `ARROW_SCALE` (see station-arrow.ts) is the
-  // only thing controlling the arrow's visible size, via the same
-  // `transform: scale(...)` below.
-  markerClass = 'flex h-20 w-20 items-center justify-center p-1 transition';
+  // it can't be a static `className` -- see the modifier's own comment).
+  // Sizing is entirely `sizeStyle` above now (real `width`/`height`, not a
+  // Tailwind `h-*`/`w-*`), so this only carries layout/visual classes that
+  // don't vary with scale; `transition-[width,height]` keeps resizes smooth
+  // now that the default `transition` utility (which covered `transform`)
+  // no longer applies to what's actually changing. `p-1` gives the arrow a
+  // small fixed gap from the ring's edge (works because Tailwind's
+  // preflight sets `box-sizing: border-box` app-wide, so this padding
+  // carves into `sizeStyle`'s box rather than growing past it) -- it's a
+  // fixed px amount rather than a percentage, so it becomes proportionally
+  // more of the box the smaller a marker shrinks.
+  markerClass =
+    'flex items-center justify-center p-1 transition-[width,height]';
 
   <template>
     {{! template-lint-disable no-inline-styles }}
@@ -132,11 +152,11 @@ export default class MapStationMarker extends Component<MapStationMarkerSignatur
       data-station-id={{@station.id}}
       data-test-map-station-marker
       class={{this.markerClass}}
-      style={{this.scaleStyle}}
+      style={{this.sizeStyle}}
       {{selectMapMarker @isSelected}}
     >
       {{! template-lint-enable no-inline-styles }}
-      <svg aria-hidden="true" viewBox={{this.viewBox}}>
+      <svg aria-hidden="true" class="h-full w-full" viewBox={{this.viewBox}}>
         <g transform={{this.markerTransform}}>
           {{! Gusts band differs: the gusts shape behind, shown through the hub hole. }}
           {{#if this.showGustsHub}}

--- a/app/modifiers/select-map-marker.ts
+++ b/app/modifiers/select-map-marker.ts
@@ -7,16 +7,13 @@ interface SelectMapMarkerSignature {
   };
 }
 
-// The selected-station ring/disc has to live on MapLibre's own marker
-// element -- this modifier's host element's own parent, since
-// `station-marker.gts` renders directly inside it via `{{#in-element}}` --
-// not on our own inner content. That outer element stays at full, unscaled
-// size regardless of the marker's own age/zoom shrink (`markerScale`'s
-// `transform: scale(...)` lives on our inner content only), and it's also
-// the element `<marker.on @event="click">` actually listens on: painting
-// the "this is selected" indicator anywhere else risks the same
-// visual/interactive mismatch the `cursor-pointer` fix (see
-// `markerInitOptions` in map/index.gts) already addressed for hovering.
+// The selected-station ring/disc lives on MapLibre's own marker element --
+// this modifier's host element's own parent, since `station-marker.gts`
+// renders directly inside it via `{{#in-element}}` -- not on our own inner
+// content. That outer element is the one `<marker.on @event="click">`
+// actually listens on and the one that shrink-wraps to the marker's real
+// current size (see `map/index.gts`'s `markerInitOptions` comment), so the
+// ring needs to render there to match both.
 //
 // `MarkerOptions.className` (the mechanism `cursor-pointer` uses) can't
 // carry this, though: ember-maplibre-gl only reads `@initOptions` once, in

--- a/app/modifiers/select-map-marker.ts
+++ b/app/modifiers/select-map-marker.ts
@@ -1,0 +1,53 @@
+import { modifier } from 'ember-modifier';
+
+interface SelectMapMarkerSignature {
+  Element: HTMLElement;
+  Args: {
+    Positional: [isSelected: boolean | undefined];
+  };
+}
+
+// The selected-station ring/disc has to live on MapLibre's own marker
+// element -- this modifier's host element's own parent, since
+// `station-marker.gts` renders directly inside it via `{{#in-element}}` --
+// not on our own inner content. That outer element stays at full, unscaled
+// size regardless of the marker's own age/zoom shrink (`markerScale`'s
+// `transform: scale(...)` lives on our inner content only), and it's also
+// the element `<marker.on @event="click">` actually listens on: painting
+// the "this is selected" indicator anywhere else risks the same
+// visual/interactive mismatch the `cursor-pointer` fix (see
+// `markerInitOptions` in map/index.gts) already addressed for hovering.
+//
+// `MarkerOptions.className` (the mechanism `cursor-pointer` uses) can't
+// carry this, though: ember-maplibre-gl only reads `@initOptions` once, in
+// its constructor, and selection changes over the marker's lifetime as the
+// user clicks around -- so this reaches the real DOM node directly and
+// toggles classes imperatively instead, the supported way to integrate with
+// a third-party library's own DOM structure when it offers no reactive hook
+// of its own.
+const SELECTED_CLASSES = [
+  'bg-slate-400/40',
+  'ring-1',
+  'ring-inset',
+  'ring-slate-500/70',
+];
+
+const selectMapMarker = modifier<SelectMapMarkerSignature>(
+  (element, [isSelected]) => {
+    const parent = element.parentElement;
+
+    if (!parent) {
+      return;
+    }
+
+    if (isSelected) {
+      parent.classList.add(...SELECTED_CLASSES);
+    } else {
+      parent.classList.remove(...SELECTED_CLASSES);
+    }
+
+    return () => parent.classList.remove(...SELECTED_CLASSES);
+  }
+);
+
+export default selectMapMarker;

--- a/app/utils/station-arrow.ts
+++ b/app/utils/station-arrow.ts
@@ -86,15 +86,17 @@ export function scaleForZoom(zoom: number): number {
   return MIN_ZOOM_MARKER_SCALE;
 }
 
-// Grows the arrow past its baseline (which matches the ring's own fixed size)
-// via the CSS `transform: scale(...)` that `markerScale` already drives —
-// tuning the arrow/svg's own Tailwind `h-*`/`w-*` classes turned out not to
-// visibly change anything (untraced further; suspected Tailwind-generation or
-// overflow quirk), whereas this transform is the same mechanism the age/zoom
-// shrink already uses and is proven to render. The ring lives on a separate,
-// unscaled ancestor (see `map/station-marker.gts`), so this constant is free
-// to tune without affecting the ring at all.
-export const ARROW_SCALE = 1.2;
+// The marker's own box (ring + arrow together, see `map/station-marker.gts`)
+// is sized as `BASE_MARKER_SIZE * markerScale` px, so this is a flat
+// multiplier on top of the age/zoom scaling below -- tune it to make the
+// whole marker (not just the arrow inside it) read bigger or smaller
+// overall.
+export const ARROW_SCALE = 2;
+
+// Reference marker size (px) at `markerScale` of 1 (fresh reading, full
+// zoom, before ARROW_SCALE). The rendered box is always this times the
+// combined scale -- see `markerSizePx` in `map/station-marker.gts`.
+export const BASE_MARKER_SIZE = 56;
 
 // A reading older than a day is drawn grey rather than in its wind-speed colour.
 export function colourForWindReading(speed: number, timestamp: number): string {

--- a/app/utils/station-arrow.ts
+++ b/app/utils/station-arrow.ts
@@ -86,6 +86,16 @@ export function scaleForZoom(zoom: number): number {
   return MIN_ZOOM_MARKER_SCALE;
 }
 
+// Grows the arrow past its baseline (which matches the ring's own fixed size)
+// via the CSS `transform: scale(...)` that `markerScale` already drives —
+// tuning the arrow/svg's own Tailwind `h-*`/`w-*` classes turned out not to
+// visibly change anything (untraced further; suspected Tailwind-generation or
+// overflow quirk), whereas this transform is the same mechanism the age/zoom
+// shrink already uses and is proven to render. The ring lives on a separate,
+// unscaled ancestor (see `map/station-marker.gts`), so this constant is free
+// to tune without affecting the ring at all.
+export const ARROW_SCALE = 1.2;
+
 // A reading older than a day is drawn grey rather than in its wind-speed colour.
 export function colourForWindReading(speed: number, timestamp: number): string {
   if (!Number.isFinite(timestamp)) {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Changed
 
-- Map station markers are smaller at full size, so they no longer dwarf the map on a close-up view.
-- Made the wind-direction arrow inside each map marker noticeably bigger and easier to read at a glance.
+- Station markers on the map are a little smaller when zoomed in, so they don't crowd the map.
+- The wind direction arrow on each station marker is bigger and easier to see at a glance.
 
 ### Fixed
 
-- Fixed map station markers sometimes not responding to a tap on mobile. Selecting a station is now handled by the map marker itself instead of a separate button layered on top of it.
-- Fixed the selected-marker ring staying the same size while its arrow shrank (an older reading, or zooming out) -- the ring now always matches the arrow's current size, so it's no longer easy to tap the wrong station when markers overlap.
-- Fixed the compass direction letters (N, NE, E, SE, S, SW, W, NW) missing from the last-hour wind-direction chart on the station panel.
-- Removed distracting animation from the wind/air and wind-direction charts on every automatic refresh.
+- Fixed station markers on the map sometimes not responding to a tap on mobile.
+- Fixed the highlight ring around a selected station staying the same size while its marker shrank (an older reading, or zooming out), which made it easy to accidentally tap the wrong station when markers were close together.
+- Fixed the compass letters (N, S, E, W, etc.) missing from the wind-direction circle on a station's panel.
+- Removed a distracting animation that played every time the charts refreshed with new data.
 
 ## v0.19.4 - 2026-07-24
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -5,10 +5,14 @@
 ### Changed
 
 - Map station markers are smaller at full size, so they no longer dwarf the map on a close-up view.
+- Made the wind-direction arrow inside each map marker noticeably bigger and easier to read at a glance.
 
 ### Fixed
 
 - Fixed map station markers sometimes not responding to a tap on mobile. Selecting a station is now handled by the map marker itself instead of a separate button layered on top of it.
+- Fixed the selected-marker ring staying the same size while its arrow shrank (an older reading, or zooming out) -- the ring now always matches the arrow's current size, so it's no longer easy to tap the wrong station when markers overlap.
+- Fixed the compass direction letters (N, NE, E, SE, S, SW, W, NW) missing from the last-hour wind-direction chart on the station panel.
+- Removed distracting animation from the wind/air and wind-direction charts on every automatic refresh.
 
 ## v0.19.4 - 2026-07-24
 

--- a/tests/acceptance/map-station-panel-test.ts
+++ b/tests/acceptance/map-station-panel-test.ts
@@ -478,12 +478,10 @@ module('Acceptance | map station panel', function (hooks) {
   // `cursor-pointer` deliberately lives on MapLibre's own marker element
   // (passed via `markerInitOptions`'s `className`), not on anything inside
   // `<MapStationMarker>` -- that outer element is what `<marker.on
-  // @event="click">` actually listens on, and it stays at its full unscaled
-  // size even when the marker's own inner content is visually shrunk via a
-  // CSS `transform: scale(...)` (a transform doesn't shrink the box a
-  // parent/hit-test uses, only the transformed element's own painted
-  // region). This reads the real DOM MapLibre produced to confirm the
-  // option actually reached it, not just that we passed it.
+  // @event="click">` actually listens on (see `map/station-marker.gts`'s
+  // top-of-file comment for why click is routed through it rather than a
+  // second clickable element). This reads the real DOM MapLibre produced to
+  // confirm the option actually reached it, not just that we passed it.
   test.if(
     'the map marker element itself gets the pointer cursor, not just its inner content',
     webGLAvailable,

--- a/tests/acceptance/map-station-panel-test.ts
+++ b/tests/acceptance/map-station-panel-test.ts
@@ -474,4 +474,85 @@ module('Acceptance | map station panel', function (hooks) {
 
     assert.dom("link[type='image/svg+xml']", document.head).doesNotExist();
   });
+
+  // `cursor-pointer` deliberately lives on MapLibre's own marker element
+  // (passed via `markerInitOptions`'s `className`), not on anything inside
+  // `<MapStationMarker>` -- that outer element is what `<marker.on
+  // @event="click">` actually listens on, and it stays at its full unscaled
+  // size even when the marker's own inner content is visually shrunk via a
+  // CSS `transform: scale(...)` (a transform doesn't shrink the box a
+  // parent/hit-test uses, only the transformed element's own painted
+  // region). This reads the real DOM MapLibre produced to confirm the
+  // option actually reached it, not just that we passed it.
+  test.if(
+    'the map marker element itself gets the pointer cursor, not just its inner content',
+    webGLAvailable,
+    async function (assert) {
+      await visit(
+        '/map/holfuy-1804?latitude=46.67719&longitude=7.86323&zoom=13'
+      );
+
+      assert
+        .dom('[data-station-id="holfuy-1804"].cursor-pointer')
+        .doesNotExist(
+          'the inner marker content no longer carries its own cursor-pointer'
+        );
+      assert
+        .dom(
+          '.maplibregl-marker.cursor-pointer:has([data-station-id="holfuy-1804"])'
+        )
+        .exists('the outer MapLibre marker element carries it instead');
+    }
+  );
+
+  // The selected-station ring/disc is toggled by the `selectMapMarker`
+  // modifier directly on MapLibre's own marker element (the same element
+  // `cursor-pointer` lives on, see the test above), not on anything inside
+  // `<MapStationMarker>` -- reactively, since which station is selected
+  // changes over the page's lifetime (unlike `cursor-pointer`, which is
+  // static and set once via `className`). This reads the real DOM to
+  // confirm the ring actually follows selection from one station to
+  // another, not just that it's present on the initially-selected one.
+  test.if(
+    'the selected-station ring lives on the map marker element and follows selection',
+    webGLAvailable,
+    async function (this: MapStationPanelTestContext, assert) {
+      const router = this.owner.lookup('service:router');
+
+      await visit(
+        '/map/holfuy-1804?latitude=46.67719&longitude=7.86323&zoom=13'
+      );
+
+      assert
+        .dom(
+          '.maplibregl-marker.bg-slate-400\\/40:has([data-station-id="holfuy-1804"])'
+        )
+        .exists('the initially-selected station has the ring');
+      assert
+        .dom(
+          '.maplibregl-marker.bg-slate-400\\/40:has([data-station-id="holfuy-2222"])'
+        )
+        .doesNotExist('the other station does not');
+
+      void router.transitionTo('map.station', 'holfuy-2222', {
+        queryParams: {
+          latitude: 46.67719,
+          longitude: 7.86323,
+          zoom: 13,
+        },
+      });
+      await settled();
+
+      assert
+        .dom(
+          '.maplibregl-marker.bg-slate-400\\/40:has([data-station-id="holfuy-1804"])'
+        )
+        .doesNotExist('the previously-selected station no longer has it');
+      assert
+        .dom(
+          '.maplibregl-marker.bg-slate-400\\/40:has([data-station-id="holfuy-2222"])'
+        )
+        .exists('the newly-selected station has it instead');
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- **Reliable marker taps:** selecting a station is now handled by MapLibre's own marker click, not a separate button layered on top. A second clickable/scaled element stacked on the marker was a known trigger for mobile browsers to silently drop a touch's synthesized click when the target moves mid-tap.
- **Ring matches the arrow:** the selected-station ring (and the marker's real clickable area) is now sized from real `width`/`height` on the marker element rather than a `transform: scale(...)`, so it shrinks/grows together with the arrow (age/zoom) instead of staying a fixed footprint around a visually smaller arrow. This fixes overlapping click targets at shrunk zoom levels.
- **Bigger, clearer arrow:** the wind-direction arrow is scaled up (`ARROW_SCALE`) independently of the ring, with a small proportional inset (`p-1`) so it doesn't touch the ring's edge.
- **Fixed the last-hour polar chart's compass labels:** N/NE/E/SE/S/SW/W/NW were silently cropped (Highcharts' cartesian-oriented overflow check misjudges this circular layout) or positioned outside the visible chart box (a positive `distance` pushes labels *outside* the pane, which already fills nearly the whole chart box). `overflow: 'allow'` plus a negative `distance` fixes both.
- **Removed unnecessary chart animation:** `chart.animation: false` on both chart wrappers, since this app already replaces data outright on every refresh rather than animating between old and new state -- previously only per-series animation was disabled, so axis extremes still visibly animated on every background refresh.

## UX improvements & motivation

- Tapping a station marker on mobile could silently fail to register -- this was root-caused to the marker's own click target moving (via its continuous CSS `transform` repositioning during pan/zoom) while a second, independently-transformed clickable element sat on top of it.
- When several stations were close together on the map (especially at a zoomed-out level with shrunk markers), the invisible click target around each marker stayed a fixed, oversized footprint -- so tapping a small, visible arrow could accidentally select a different, overlapping station instead.
- The wind-direction arrow read as too small to see clearly at a glance.
- The last-hour wind-direction chart on a station's panel was missing all of its compass letters, making the plotted direction history harder to read.
- Charts visibly (and distractingly) animated on every automatic background refresh, even though the data itself isn't meant to transition -- it just replaces outright.

## Test plan

- [x] `pnpm lint` (types/format/js/css/hbs) passes
- [x] `pnpm test:ember:dev` -- full chart/point-order/map-station-panel suites pass
- [x] Verified visually against the real running app (screenshots) that all 8 compass labels render inside the polar chart's visible area, and that the marker ring/arrow size and click behavior match expectations