### PR TITLE
🧹 Drop the dead Netlify redirects file, ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /node_modules/
 
 # misc
+.DS_Store
 /.env*
 /.pnp*
 /.eslintcache

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,0 @@
-# /public/_redirects
-
-/*    /index.html   200


### PR DESCRIPTION
## Summary
- Removes `public/_redirects`, a Netlify/Cloudflare-Pages SPA-fallback file that's been inert since hosting moved to Caddy + Bunny (added in ec89ffb, "fix: Netlify redirects")
- Adds `.DS_Store` to `.gitignore` (defensive only — these files were never committed or shipped; they're ignored via a global `core.excludesFile` and have never been in this repo's history)

Part of item 8 in the [startup performance audit](https://github.com/winds-mobi/winds-mobi-client-web/issues/143).

**Not a deep-link fix.** Removing `_redirects` doesn't regress anything (it did nothing on Caddy/Bunny), but it also doesn't fix deep links: Caddy 301-redirects every unknown path to `/`, so a shared station link opened without an active service worker lands on the map root instead of the station. That's tracked separately as item 9 in TODO.md and needs a `winds-mobi-config` Caddyfile change.

## Test plan
- [ ] Confirm `public/_redirects` removal doesn't affect deploy (Caddy/Bunny never read it)
- [ ] Confirm `.DS_Store` files still don't ship (verify via `dist/` after `pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)