### PR TITLE
🌐 Precache the CDN copy of the app shell, not the Caddy one

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,6 +112,16 @@ normally — no CORS obstacle.
 This also answers "cache everything for a week without even a freshness request":
 precached entries are served straight from Cache Storage with no network round-trip at all.
 
+**To see the pre-fix bug live in DevTools:** unregistering the service worker does not
+clear its Cache Storage, so a browser that has ever visited `winds.mobi` before will often
+show no live duplicate request on reload — Workbox checks Cache Storage first and skips
+re-fetching a precache entry it already has. Two ways to actually see it: (1) Application →
+Storage → Cache Storage → `workbox-precache-*` → look for `https://winds.mobi/assets/main-*`
+sitting there unread (the page always loads the CDN copy) — the duplicate is present even
+with no live request; or (2) Application → Storage → **"Clear site data"** (not just
+unregister), then reload with the Network panel filtered to `main` — this forces a true
+cache miss and shows both the CDN and Caddy requests firing live, one for each origin.
+
 Considered and explicitly deferred (not done as part of this fix): putting Bunny in front
 of `winds.mobi` itself (a custom hostname/CNAME) so there's no separate CDN origin at all,
 which would eliminate this entire class of base-mismatch bug rather than patching around

--- a/TODO.md
+++ b/TODO.md
@@ -53,7 +53,7 @@ decoding the sourcemap mappings) plus live headers from `https://winds.mobi` and
 - Origin (`winds.mobi`, Caddy): **no `cache-control` and no compression at all** on
   `index.html`, `sw.js`, or the `assets/*` copies it also serves.
 
-### 1. The service worker precaches the wrong origin (highest value, pure bug)
+### 1. The service worker precaches the wrong origin — ✅ done
 
 Where it lives: [vite.config.mjs](vite.config.mjs) — `base: process.env.CDN_URL || '/'`
 for Vite, but `VitePWA({ base: '/' })` hardcoded; CDN_URL is set to
@@ -65,27 +65,61 @@ Problem: the two `base` values disagree, so the built `sw.js` precaches
 `https://v2-winds-mobi.b-cdn.net/assets/main-*.js`. Verified against production: the live
 `sw.js` precache list is all root-relative (`assets/main-B1MYm70R.js`, …) and
 `https://winds.mobi/assets/main-B1MYm70R.js` returns the same file (rsync deploys `dist/`
-to Caddy too). Consequences, both real today:
+to Caddy too). Consequences, both real:
 
-- Every first visit downloads the app **twice** — ~605 kB zstd from the CDN to boot, plus a
+- Every first visit downloaded the app **twice** — ~605 kB zstd from the CDN to boot, plus a
   background precache of **2.9 MB uncompressed** from Caddy (which sends no
-  `content-encoding`), competing for bandwidth exactly during startup. On mobile this is
-  the single most expensive thing the app does.
-- Repeat visits get **no** service-worker benefit for JS/CSS — the CDN responses are in no
-  Workbox cache, so the app is only as fast as the HTTP cache allows and is not offline-capable.
+  `content-encoding`), competing for bandwidth exactly during startup. On mobile this was
+  the single most expensive thing the app did.
+- Repeat visits got **no** service-worker benefit for JS/CSS — the CDN responses were in no
+  Workbox cache, so the app was only as fast as the HTTP cache allowed and wasn't
+  offline-capable.
 
-Proposed fix: make the two bases agree — `VitePWA({ base: process.env.CDN_URL || '/' })`.
-Bunny already sends `access-control-allow-origin: *` and the script/link tags already carry
-`crossorigin`, so cross-origin precaching will work. Verify by building with
-`CDN_URL=https://v2-winds-mobi.b-cdn.net/` and confirming the precache URLs in `dist/sw.js`
-are absolute CDN URLs while `index.html`/`registerSW.js`/`manifest.webmanifest` (served by
-Caddy, not the CDN) stay root-relative — those three must NOT move to the CDN, since the
-service worker's scope is `winds.mobi`. If `workbox.base` can't express that split, the
-alternative is to drop `globPatterns` for `assets/**` from the precache entirely and add a
-runtime `CacheFirst` route for `^https://v2-winds-mobi\.b-cdn\.net/` instead — same effect,
-less coupling to the CDN URL. Either way this also answers "cache everything for a week
-without even a freshness request": precached and `CacheFirst` entries are served straight
-from Cache Storage with no network round-trip at all.
+**The naive fix — `VitePWA({ base: process.env.CDN_URL || '/' })`, as originally proposed
+here — is wrong and was tested to confirm it: it doesn't just fix the precache, it also
+moves the service worker's own registration URL and scope to the CDN, and a service worker
+can only be registered from the same origin as the document registering it.** Built with
+that change and confirmed the browser-facing breakage directly: `registerSW.js` came out
+calling `navigator.serviceWorker.register('https://v2-winds-mobi.b-cdn.net/sw.js', { scope:
+'https://v2-winds-mobi.b-cdn.net/' })`, which browsers reject outright. `base: '/'` here is
+not an oversight — it's PR #107 (`bb9c92c`), a deliberate prior fix by Yann Savary for
+exactly this failure mode; its own PR body shows the `manifest.webmanifest`/`registerSW.js`
+tags staying root-relative as the point of the change. That fix is correct and still
+needed; it just left the precache-manifest mismatch (this item) unaddressed, since Workbox
+derives the precache manifest's URL prefix from the same `base` value.
+
+**Actual fix:** kept `base: '/'` for `VitePWA`'s own artifacts, and added Workbox's
+`modifyURLPrefix` — a `generateSW` option that rewrites only the precache manifest's own
+URLs, independent of the `base` used for the SW's registration/scope/manifest tags — scoped
+to exactly the two prefixes the real page actually fetches from the CDN in production
+(`assets/` and `@embroider/virtual/`; verified against a real prod `index.html`, not
+assumed). Applied only when `CDN_URL` is set, so a local/CDN-less `pnpm build` is unaffected.
+
+Verified with real builds, both with and without `CDN_URL` set:
+
+- With `CDN_URL`: `registerSW.js`/`manifest.webmanifest`/`index.html`'s manifest and
+  registerSW `<link>`/`<script>` tags all stayed root-relative; the precache list's
+  `assets/*` and `@embroider/virtual/*` entries became CDN-absolute; `index.html`,
+  `registerSW.js`, `manifest.webmanifest`, and the icon files stayed root-relative (correct
+  — those are genuinely Caddy-served, not on the CDN).
+- Without `CDN_URL`: precache list is entirely root-relative, unchanged from before this fix
+  — no regression for a CDN-less build.
+
+Bunny already sends `access-control-allow-origin: *` on CDN assets, so Workbox's
+cross-origin precache fetches get a real (non-opaque) response it can verify and cache
+normally — no CORS obstacle.
+
+This also answers "cache everything for a week without even a freshness request":
+precached entries are served straight from Cache Storage with no network round-trip at all.
+
+Considered and explicitly deferred (not done as part of this fix): putting Bunny in front
+of `winds.mobi` itself (a custom hostname/CNAME) so there's no separate CDN origin at all,
+which would eliminate this entire class of base-mismatch bug rather than patching around
+it. Real option — the team controls DNS, Bunny, and Caddy — but it's a bigger cross-repo,
+cross-dashboard change with real tradeoffs (Bunny becomes load-bearing for the whole site,
+not just static assets; needs edge-rule work to keep `/api`, `/admin`, `/user`,
+`/django-static` bypassing cache correctly) that needs its own discussion, not something to
+fold into an app-level bug fix.
 
 ### 2. First render is blocked on a GPS fix
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -37,6 +37,15 @@ export default defineConfig(({ mode }) => ({
     tailwindcss(),
     mode === 'production'
       ? VitePWA({
+          // Deliberately '/', not CDN_URL (see PR #107): the service worker
+          // itself, registerSW.js, and manifest.webmanifest must stay
+          // same-origin with the page (winds.mobi/Caddy) -- a service worker
+          // can only be registered from the same origin as the document that
+          // registers it, so pointing this at the CDN breaks registration
+          // outright. Vite's own `base` (above) already sends the real JS/CSS
+          // bundle and pwaAssets' icon links to the CDN independently of this
+          // option. What this `base` leaves wrong is the precache manifest
+          // Workbox builds below -- see the `modifyURLPrefix` comment.
           base: '/',
           registerType: 'autoUpdate',
           pwaAssets: {
@@ -88,6 +97,31 @@ export default defineConfig(({ mode }) => ({
               /^\/admin/,
               /^\/django-static/,
             ],
+            // `base: '/'` above (needed to keep the service worker itself
+            // same-origin) means Workbox's own asset scan builds the precache
+            // manifest with root-relative URLs for everything, including the
+            // hashed JS/CSS bundle -- but that bundle is actually served from
+            // CDN_URL in production (Vite's real `base`, set at the top of
+            // this file), not from winds.mobi. Left alone, the precache list
+            // points at a copy of the bundle that exists (rsync also deploys
+            // dist/ to Caddy) but that the page never actually requests, so
+            // every first visit downloads the app twice: once from the CDN to
+            // render, once more in the background to satisfy this precache.
+            // `modifyURLPrefix` rewrites just these two prefixes -- the
+            // hashed bundle (`assets/`) and Embroider's virtual entry chunks
+            // (`@embroider/virtual/`), the only precache entries actually
+            // fetched from the CDN by the real page -- to match. `index.html`,
+            // `registerSW.js`, `manifest.webmanifest`, and the PWA icon files
+            // are deliberately left root-relative: they're served from Caddy
+            // (registerSW.js's own SW registration call must be, per the
+            // comment on `base` above), and rewriting entries with no
+            // matching prefix here is a no-op, so this can't touch them.
+            ...(process.env.CDN_URL && {
+              modifyURLPrefix: {
+                'assets/': `${process.env.CDN_URL}assets/`,
+                '@embroider/virtual/': `${process.env.CDN_URL}@embroider/virtual/`,
+              },
+            }),
             runtimeCaching: [
               {
                 // Base raster map tiles (tile.osm.ch/switzerland): roads/labels


### PR DESCRIPTION
## Summary

Item 1 from the [startup performance audit](https://github.com/winds-mobi/winds-mobi-client-web/issues/143). The service worker's precache manifest and the page's real asset URLs disagree, so every visitor's first service-worker install silently re-downloads the entire app a second time in the background, from the wrong origin, and gets no benefit from it.

## The bug

Vite's own `base` is the CDN (`CDN_URL`, set in CI) in production, so the page loads `main-*.js`/`main-*.css` from `v2-winds-mobi.b-cdn.net`. But `VitePWA`'s own `base` was hardcoded to `'/'`, so Workbox builds the service worker's precache manifest with root-relative URLs — pointing the *same* files back at `winds.mobi` (Caddy), which also happens to serve them since `dist/` is rsynced there too.

Net effect: the service worker's install step downloads a second, uncompressed copy of the whole app from Caddy that the page never reads from — it always loads the CDN copy. Confirmed live on production (still pre-fix) with a fresh browser profile:

```
https://v2-winds-mobi.b-cdn.net/assets/main-B1MYm70R.js   (the page's real load)
https://winds.mobi/assets/main-B1MYm70R.js                (the SW's dead-weight precache copy)
```

## Why not just make the two `base` values match

Tried the obvious fix first — `VitePWA({ base: CDN_URL })` — and it's wrong: it also moves the service worker's *own registration URL and scope* to the CDN, and a service worker can only be registered from the same origin as the page registering it. Built it and confirmed the breakage directly: `registerSW.js` came out calling `navigator.serviceWorker.register('https://v2-winds-mobi.b-cdn.net/sw.js', ...)`, which every browser rejects.

`base: '/'` isn't an oversight — it's [PR #107](https://github.com/winds-mobi/winds-mobi-client-web/pull/107) (`bb9c92c`), a deliberate earlier fix by @ysavary for exactly this failure mode. That fix is correct and stays; it just left this precache-manifest mismatch unaddressed, since Workbox derives the precache URLs from the same `base`.

## The actual fix

Kept `base: '/'` for `VitePWA`'s own artifacts (registration/scope/manifest — unaffected), and added Workbox's `modifyURLPrefix`, which rewrites *only* the precache manifest's own URLs. Scoped to exactly the two prefixes the real page fetches from the CDN (`assets/`, `@embroider/virtual/`), applied only when `CDN_URL` is set.

## Verification

Built both with and without `CDN_URL`:

- **With `CDN_URL`:** `registerSW.js`/`manifest.webmanifest`/`index.html`'s manifest and registerSW tags stay root-relative (Caddy); the precache list's `assets/*` and `@embroider/virtual/*` entries become CDN-absolute; `index.html`, `registerSW.js`, `manifest.webmanifest`, and the icon files stay root-relative (correct — those aren't on the CDN).
- **Without `CDN_URL`:** precache list is entirely root-relative, unchanged from before this fix — no regression for a local/CDN-less build.

`pnpm lint` (incl. Glint) is clean.

### How to see the bug live (pre-fix) or confirm it's gone (post-fix)

Not as simple as reload-and-check-Network — unregistering the service worker does **not** clear its Cache Storage, so a browser with any prior visit to `winds.mobi` often shows no live duplicate request, since Workbox checks Cache Storage first and skips re-fetching an entry it already has. Two reliable ways:

1. **Application → Storage → Cache Storage → `workbox-precache-*`** — look for `https://winds.mobi/assets/main-*` sitting there. Present regardless of whether a live request fires on this particular reload.
2. **Application → Storage → "Clear site data"** (not just unregister), then reload with the Network panel filtered to `main` — forces a genuine cache miss, so both requests fire live if the bug is present.

## Test plan

- [ ] Deploy and confirm `dist/sw.js`'s precache list is CDN-absolute for `assets/*`/`@embroider/virtual/*`
- [ ] Confirm the service worker still registers and activates normally (Application → Service Workers)
- [ ] Using a fresh profile (or "Clear site data"), confirm no duplicate `winds.mobi`-origin fetch for `assets/main-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
