### PR TITLE
⚡ Stop blocking first render on a GPS permission/position fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -87,9 +87,9 @@ less coupling to the CDN URL. Either way this also answers "cache everything for
 without even a freshness request": precached and `CacheFirst` entries are served straight
 from Cache Storage with no network round-trip at all.
 
-### 2. First render is blocked on a GPS fix
+### 2. First render is blocked on a GPS fix — ✅ done
 
-Where it lives: [app/routes/application.ts](app/routes/application.ts) —
+Where it lived: [app/routes/application.ts](app/routes/application.ts) —
 `await this.nearbyLocation.syncPermissionState()` in `beforeModel`, and
 [app/services/nearby-location.ts](app/services/nearby-location.ts), whose
 `syncPermissionState` ends with `await this.requestCurrentPosition()` when the permission
@@ -107,10 +107,16 @@ mobile GPS fix. Nothing needs the result synchronously: every consumer
 the service's tracked state, and `isCheckingPermission` already exists to express
 "not known yet".
 
-Proposed fix: stop awaiting it — kick the sync off without blocking the transition. Keep
-the existing re-entrancy guard so it still runs exactly once. The permission-state machine
-already models the intermediate state, so the UI should need no change; confirm the
-locate-control's disabled/spinner states still read correctly while it's in flight.
+Fix: dropped the `await` (`void this.nearbyLocation.syncPermissionState();`). No other
+change needed — `syncPermissionState`'s own re-entrancy guard (the synchronous
+`this.permissionState = 'syncing'` transition before its first `await`) lives entirely
+inside the service method itself, so it still runs exactly once regardless of whether the
+caller awaits it, and the existing `isCheckingPermission`/tracked-state consumers already
+render the "not known yet" state correctly with no changes on their end.
+
+Verified: `pnpm lint` clean; full `pnpm test:ember:dev` suite (217 passed, 8 skipped —
+the WebGL-dependent tests, unrelated) including `navbar/locate-control`'s pending/disabled
+integration tests and every `nearby-route` acceptance test, none of which needed changes.
 
 ### 3. Caddy serves the origin uncompressed and without cache headers
 

--- a/app/routes/application.ts
+++ b/app/routes/application.ts
@@ -26,6 +26,11 @@ export default class ApplicationRoute extends Route {
     this.intl.setFormats(formats);
     this.intl.setLocale(['en-us']);
 
-    await this.nearbyLocation.syncPermissionState();
+    // Not awaited: nothing needs the result synchronously (every consumer
+    // derives from the service's tracked state, and isCheckingPermission
+    // already models "not known yet"), and awaiting it here means the whole
+    // app waits behind a cold GPS fix -- up to the 15s timeout in
+    // utils/location.ts -- before anything renders.
+    void this.nearbyLocation.syncPermissionState();
   }
 }


### PR DESCRIPTION
## Summary

Item 2 from the [startup performance audit](https://github.com/winds-mobi/winds-mobi-client-web/issues/143).

The application route's `beforeModel` awaited `nearbyLocation.syncPermissionState()`, which in turn awaits `requestCurrentPosition()` when permission is already granted. Ember renders nothing until `beforeModel` resolves — so any returning user who'd granted location sat on `navigator.geolocation.getCurrentPosition` before seeing anything at all: instant on a `maximumAge` cache hit, but up to the 15s timeout on a cold mobile GPS fix.

## The fix

Dropped the `await` in `app/routes/application.ts`. That's the whole change — no other code needed touching:

- `syncPermissionState`'s re-entrancy guard (the synchronous `permissionState = 'syncing'` transition before its first `await`) lives entirely inside the service method itself, so it still runs exactly once regardless of whether the caller awaits it.
- Every consumer (`locate-control`, `search`, `search-result`) already derives from the service's tracked state, and `isCheckingPermission` already models "not known yet" — no UI changes required.

## Verification

- `pnpm lint` clean
- Full `pnpm test:ember:dev` suite: 217 passed, 8 skipped (WebGL-dependent, unrelated), 0 failed — including `locate-control`'s pending/disabled integration tests and every `nearby-route` acceptance test, none of which needed changes. Checked *why*: their `nearbyLocation.syncPermissionState` stubs mutate tracked state synchronously inside the stub body itself before returning a resolved promise, so removing the `await` doesn't shift their timing either.
- Screenshot of `/nearby` in a headless run confirms it renders correctly (shows the "Use location" prompt immediately).

Also marks item 2 done in `TODO.md`.

## Test plan
- [ ] `pnpm test:ember:dev --test_page "tests/index.html?hidepassed&filter=/nearby|locate|search|walkthrough/"`
- [ ] On a device/browser with location permission already granted, confirm the app renders immediately instead of waiting on a GPS fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
