### PR TITLE
Fix map not flying to the user's location on a fresh load

### DIFF
--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -28,7 +28,6 @@ import onRouteChange from 'winds-mobi-client-web/modifiers/on-route-change';
 import registerLoadingProbe from 'winds-mobi-client-web/modifiers/register-loading-probe';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
-import { flyToCoordinates } from 'winds-mobi-client-web/utils/locate';
 import { responseData } from 'winds-mobi-client-web/utils/request-response';
 import {
   OSM_SWISS_STYLE,
@@ -41,7 +40,6 @@ import {
   mapViewCenter,
   mapViewsEqual,
   mapViewFromMap,
-  parseMapView,
   TrackedMapView,
   type MapBounds,
 } from 'winds-mobi-client-web/utils/map-view';
@@ -248,27 +246,16 @@ export default class Map extends Component<MapSignature> {
     void this.router.transitionTo('map.station', station.id);
   }
 
-  // True on a fresh load where no view is present in the URL, so the routed view
-  // still equals the whole-Switzerland default.
-  get isInitialDefaultView() {
-    return mapViewsEqual(this.mapView, parseMapView());
-  }
-
-  // Gates the `flyToUserLocation` modifier below: on a fresh load with the default
-  // Switzerland view, fly to the user's location once it's known -- no geolocation
-  // request happens here (that's `nearbyLocation.requestCurrentPosition`, already
-  // triggered by `ApplicationRoute#beforeModel`'s `syncPermissionState`). `coordinates`
-  // being set at all implies granted permission (see `updateFromPosition`), so there's
-  // nothing else to check. Not awaited there, so for an already-granted returning user
-  // `coordinates` typically resolves *after* the map has already mounted on the default
-  // view -- the modifier reacts whenever `coordinates` arrives, not just at mount, and
-  // `isInitialDefaultView` self-disarms once `flyToCoordinates` moves the routed view
-  // away from the default. The user's own pan or the locate button (a fresh, explicit
-  // request via `utils/locate`'s `requestAndFly`) handle every other case, including
-  // permission not yet granted and a transient geolocation failure at boot. Also don't
-  // fly in tests.
-  get shouldFlyToUserLocation() {
-    return this.isInitialDefaultView && config.environment !== 'test';
+  // Gates the `flyToUserLocation` modifier below: don't auto-fly during the app's
+  // own test suite, where a production geolocation-driven camera move could race a
+  // test's own assertions/URL expectations. Everything else -- whether the routed
+  // view is still the fresh-load default, whether coordinates are known -- the
+  // modifier derives and reacts to itself (it injects `router` and `nearbyLocation`
+  // directly), including the case where `coordinates` resolves after this component
+  // has already mounted, since `ApplicationRoute#beforeModel` no longer awaits
+  // `nearbyLocation.syncPermissionState()`.
+  get isFlyToUserLocationEnabled() {
+    return config.environment !== 'test';
   }
 
   @action
@@ -336,11 +323,7 @@ export default class Map extends Component<MapSignature> {
       {{onRouteChange this.router this.handleRouteChange}}
       {{commitResolvedStations this.requestState this.commitStations}}
       {{registerLoadingProbe this.mapRefresh this.loadingProbe}}
-      {{flyToUserLocation
-        this.nearbyLocation.coordinates
-        this.shouldFlyToUserLocation
-        (fn flyToCoordinates this.router this.nearbyLocation)
-      }}
+      {{flyToUserLocation this.isFlyToUserLocationEnabled}}
     >
       <MapLibreGL
         data-test-map-canvas

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -23,10 +23,12 @@ import MapLegend, {
 import MapStationMarker from 'winds-mobi-client-web/components/map/station-marker';
 import MapUserLocationMarker from 'winds-mobi-client-web/components/map/user-location-marker';
 import commitResolvedStations from 'winds-mobi-client-web/modifiers/commit-resolved-stations';
+import flyToUserLocation from 'winds-mobi-client-web/modifiers/fly-to-user-location';
 import onRouteChange from 'winds-mobi-client-web/modifiers/on-route-change';
 import registerLoadingProbe from 'winds-mobi-client-web/modifiers/register-loading-probe';
 import type MapRefreshService from 'winds-mobi-client-web/services/map-refresh';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
+import { flyToCoordinates } from 'winds-mobi-client-web/utils/locate';
 import { responseData } from 'winds-mobi-client-web/utils/request-response';
 import {
   OSM_SWISS_STYLE,
@@ -35,7 +37,6 @@ import {
 import {
   boundsFromMap,
   roundBoundsForRequest,
-  focusQueryParamsFor,
   mapBoundsEqual,
   mapViewCenter,
   mapViewsEqual,
@@ -253,27 +254,21 @@ export default class Map extends Component<MapSignature> {
     return mapViewsEqual(this.mapView, parseMapView());
   }
 
-  @action
-  handleMapLoaded() {
-    // On a fresh load with the default Switzerland view, fly to the user's
-    // location if it's already known -- no geolocation request happens here.
-    // `ApplicationRoute#beforeModel` already awaits `nearbyLocation.syncPermissionState()`
-    // before anything renders, and that already requests the position itself
-    // when permission is already granted, so `coordinates` is normally already
-    // populated by the time the map ever mounts. `coordinates` being set at all
-    // implies granted permission (see `updateFromPosition`), so there's nothing
-    // else to check. The user's own pan or the locate button (a fresh, explicit
-    // request) handle every other case, including permission not yet granted
-    // and a transient geolocation failure at boot.
-    if (!this.isInitialDefaultView || config.environment === 'test') return;
-
-    const { coordinates } = this.nearbyLocation;
-
-    if (coordinates) {
-      void this.router.replaceWith({
-        queryParams: focusQueryParamsFor(coordinates),
-      });
-    }
+  // Gates the `flyToUserLocation` modifier below: on a fresh load with the default
+  // Switzerland view, fly to the user's location once it's known -- no geolocation
+  // request happens here (that's `nearbyLocation.requestCurrentPosition`, already
+  // triggered by `ApplicationRoute#beforeModel`'s `syncPermissionState`). `coordinates`
+  // being set at all implies granted permission (see `updateFromPosition`), so there's
+  // nothing else to check. Not awaited there, so for an already-granted returning user
+  // `coordinates` typically resolves *after* the map has already mounted on the default
+  // view -- the modifier reacts whenever `coordinates` arrives, not just at mount, and
+  // `isInitialDefaultView` self-disarms once `flyToCoordinates` moves the routed view
+  // away from the default. The user's own pan or the locate button (a fresh, explicit
+  // request via `utils/locate`'s `requestAndFly`) handle every other case, including
+  // permission not yet granted and a transient geolocation failure at boot. Also don't
+  // fly in tests.
+  get shouldFlyToUserLocation() {
+    return this.isInitialDefaultView && config.environment !== 'test';
   }
 
   @action
@@ -341,12 +336,16 @@ export default class Map extends Component<MapSignature> {
       {{onRouteChange this.router this.handleRouteChange}}
       {{commitResolvedStations this.requestState this.commitStations}}
       {{registerLoadingProbe this.mapRefresh this.loadingProbe}}
+      {{flyToUserLocation
+        this.nearbyLocation.coordinates
+        this.shouldFlyToUserLocation
+        (fn flyToCoordinates this.router this.nearbyLocation)
+      }}
     >
       <MapLibreGL
         data-test-map-canvas
         class="h-full w-full"
         @initOptions={{this.initOptions}}
-        @mapLoaded={{this.handleMapLoaded}}
         @reuseMaps={{false}}
         as |map|
       >

--- a/app/modifiers/fly-to-user-location.ts
+++ b/app/modifiers/fly-to-user-location.ts
@@ -1,34 +1,53 @@
-import { modifier } from 'ember-modifier';
-import type { NearbyCoordinates } from 'winds-mobi-client-web/services/nearby-location';
+import Modifier from 'ember-modifier';
+import { service } from '@ember/service';
+import type RouterService from '@ember/routing/router-service';
+import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
+import { flyToCoordinates } from 'winds-mobi-client-web/utils/locate';
+import {
+  currentMapView,
+  mapViewsEqual,
+  parseMapView,
+} from 'winds-mobi-client-web/utils/map-view';
 
 interface FlyToUserLocationSignature {
   Element: Element;
   Args: {
-    Positional: [
-      // Only read to trigger a re-run when it changes -- `flyTo` (`utils/locate`'s
-      // `flyToCoordinates`, bound to the router and the `nearby-location` service)
-      // reads the current value itself, so this isn't passed through as a call
-      // argument.
-      coordinates: NearbyCoordinates | undefined,
-      isInitialDefaultView: boolean,
-      flyTo: () => void,
-    ];
+    // Just the "is this environment allowed to auto-fly at all" gate (`Map`
+    // passes `config.environment !== 'test'` -- see its own comment). Whether the
+    // *routed view itself* is still the default is derived below instead of
+    // passed in: unlike `Map`'s own `mapView` getter, this doesn't need
+    // `TrackedMapView`'s referential-stability trick (that exists solely to
+    // keep a downstream `@cached` consumer -- the station request -- from
+    // recomputing across a value-equal transition, see issue #131); a plain
+    // value comparison has no such consumer to protect.
+    Positional: [enabled: boolean];
   };
 }
 
-// Fires whenever `coordinates` or `isInitialDefaultView` change, not just once at
-// setup -- `nearbyLocation.syncPermissionState()` (see `ApplicationRoute#beforeModel`)
-// is no longer awaited before render, so coordinates for a returning, already-granted
-// user typically arrive *after* the map has already mounted on the default view.
-// `isInitialDefaultView` flips to `false` as soon as `flyTo` moves the routed view away
-// from the default, so this naturally fires at most once per load without any extra
-// guard state.
-const flyToUserLocation = modifier<FlyToUserLocationSignature>(
-  (_element, [coordinates, isInitialDefaultView, flyTo]) => {
-    if (coordinates && isInitialDefaultView) {
-      flyTo();
+// Class-based (not the plain `modifier()` helper) specifically to inject `router`
+// and `nearby-location` itself -- a function-based modifier has no owner, so it
+// can't reach services on its own (see `utils/locate.ts`'s `flyToCoordinates` for
+// why that function needs them passed in). `modify()` re-runs whenever any tracked
+// state it reads changes, not only its positional args, so reading
+// `this.router.currentRoute` and `this.nearbyLocation.coordinates` here is enough
+// to react to a real navigation or coordinates arriving -- neither needs to also
+// be passed through as an argument.
+export default class FlyToUserLocationModifier extends Modifier<FlyToUserLocationSignature> {
+  @service declare router: RouterService;
+  @service('nearby-location') declare nearbyLocation: NearbyLocationService;
+
+  modify(_element: Element, [enabled]: [boolean]) {
+    if (!enabled) {
+      return;
+    }
+
+    const isInitialDefaultView = mapViewsEqual(
+      currentMapView(this.router),
+      parseMapView()
+    );
+
+    if (isInitialDefaultView && this.nearbyLocation.coordinates) {
+      flyToCoordinates(this.router, this.nearbyLocation);
     }
   }
-);
-
-export default flyToUserLocation;
+}

--- a/app/modifiers/fly-to-user-location.ts
+++ b/app/modifiers/fly-to-user-location.ts
@@ -1,0 +1,34 @@
+import { modifier } from 'ember-modifier';
+import type { NearbyCoordinates } from 'winds-mobi-client-web/services/nearby-location';
+
+interface FlyToUserLocationSignature {
+  Element: Element;
+  Args: {
+    Positional: [
+      // Only read to trigger a re-run when it changes -- `flyTo` (`utils/locate`'s
+      // `flyToCoordinates`, bound to the router and the `nearby-location` service)
+      // reads the current value itself, so this isn't passed through as a call
+      // argument.
+      coordinates: NearbyCoordinates | undefined,
+      isInitialDefaultView: boolean,
+      flyTo: () => void,
+    ];
+  };
+}
+
+// Fires whenever `coordinates` or `isInitialDefaultView` change, not just once at
+// setup -- `nearbyLocation.syncPermissionState()` (see `ApplicationRoute#beforeModel`)
+// is no longer awaited before render, so coordinates for a returning, already-granted
+// user typically arrive *after* the map has already mounted on the default view.
+// `isInitialDefaultView` flips to `false` as soon as `flyTo` moves the routed view away
+// from the default, so this naturally fires at most once per load without any extra
+// guard state.
+const flyToUserLocation = modifier<FlyToUserLocationSignature>(
+  (_element, [coordinates, isInitialDefaultView, flyTo]) => {
+    if (coordinates && isInitialDefaultView) {
+      flyTo();
+    }
+  }
+);
+
+export default flyToUserLocation;

--- a/app/utils/locate.ts
+++ b/app/utils/locate.ts
@@ -2,15 +2,29 @@ import type RouterService from '@ember/routing/router-service';
 import type NearbyLocationService from 'winds-mobi-client-web/services/nearby-location';
 import { focusQueryParamsFor } from 'winds-mobi-client-web/utils/map-view';
 
+// Flies to whatever position `nearbyLocation` currently holds -- a no-op until
+// coordinates are known. Takes the service rather than a coordinates value so every
+// caller (the locate button's explicit request below, the map's reactive boot fly-to
+// in `modifiers/fly-to-user-location.ts`) shares one read of the same tracked state
+// instead of each threading its own local copy through.
+export function flyToCoordinates(
+  router: RouterService,
+  nearbyLocation: NearbyLocationService
+): void {
+  const { coordinates } = nearbyLocation;
+
+  if (coordinates) {
+    void router.replaceWith({ queryParams: focusQueryParamsFor(coordinates) });
+  }
+}
+
 export async function requestAndFly(
   nearbyLocation: NearbyLocationService,
   router: RouterService
 ): Promise<void> {
   await nearbyLocation.requestCurrentPosition();
 
-  const { coordinates } = nearbyLocation;
-
-  if (coordinates && router.currentRouteName?.startsWith('map')) {
-    void router.replaceWith({ queryParams: focusQueryParamsFor(coordinates) });
+  if (router.currentRouteName?.startsWith('map')) {
+    flyToCoordinates(router, nearbyLocation);
   }
 }

--- a/tests/integration/modifiers/fly-to-user-location-test.ts
+++ b/tests/integration/modifiers/fly-to-user-location-test.ts
@@ -1,0 +1,136 @@
+import { module, test } from 'qunit';
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { set } from '@ember/object';
+import { setupRenderingTest } from 'winds-mobi-client-web/tests/helpers';
+import type RouterService from '@ember/routing/router-service';
+
+function stubReplaceWith(router: RouterService) {
+  const calls: unknown[] = [];
+
+  router.replaceWith = ((...args: unknown[]) => {
+    calls.push(args[0]);
+    return Promise.resolve();
+  }) as unknown as RouterService['replaceWith'];
+
+  return calls;
+}
+
+function stubCurrentRouteQueryParams(
+  router: RouterService,
+  queryParams: Record<string, string>
+) {
+  Object.defineProperty(router, 'currentRoute', {
+    value: { queryParams },
+    configurable: true,
+  });
+}
+
+// Regression coverage for the bug this modifier fixes: `ApplicationRoute#beforeModel`
+// no longer awaits `nearbyLocation.syncPermissionState()` before render (see
+// TODO.md item 2), so for an already-granted returning user, `coordinates` on the
+// `nearby-location` service typically resolve *after* this modifier's host element
+// has already mounted. The modifier must react to that late arrival, not just check
+// once at setup.
+module('Integration | Modifier | fly-to-user-location', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it flies to coordinates that are already present, when enabled and on the default view', async function (assert) {
+    const nearbyLocation = this.owner.lookup('service:nearby-location');
+    const router = this.owner.lookup('service:router');
+    const calls = stubReplaceWith(router);
+
+    stubCurrentRouteQueryParams(router, {});
+    nearbyLocation.coordinates = {
+      accuracy: 10,
+      latitude: 46.521,
+      longitude: 6.632,
+    };
+    set(this, 'enabled', true);
+
+    await render(hbs`<div {{fly-to-user-location this.enabled}}></div>`);
+
+    assert.strictEqual(calls.length, 1);
+    assert.deepEqual(calls[0], {
+      queryParams: { latitude: 46.521, longitude: 6.632, zoom: 10 },
+    });
+  });
+
+  test('it does not fly when disabled', async function (assert) {
+    const nearbyLocation = this.owner.lookup('service:nearby-location');
+    const router = this.owner.lookup('service:router');
+    const calls = stubReplaceWith(router);
+
+    stubCurrentRouteQueryParams(router, {});
+    nearbyLocation.coordinates = {
+      accuracy: 10,
+      latitude: 46.521,
+      longitude: 6.632,
+    };
+    set(this, 'enabled', false);
+
+    await render(hbs`<div {{fly-to-user-location this.enabled}}></div>`);
+
+    assert.strictEqual(calls.length, 0);
+  });
+
+  test('it does not fly while there are no coordinates yet', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const calls = stubReplaceWith(router);
+
+    stubCurrentRouteQueryParams(router, {});
+    set(this, 'enabled', true);
+
+    await render(hbs`<div {{fly-to-user-location this.enabled}}></div>`);
+
+    assert.strictEqual(calls.length, 0);
+  });
+
+  test('it does not fly when the routed view is not the default anymore', async function (assert) {
+    const nearbyLocation = this.owner.lookup('service:nearby-location');
+    const router = this.owner.lookup('service:router');
+    const calls = stubReplaceWith(router);
+
+    stubCurrentRouteQueryParams(router, {
+      latitude: '10',
+      longitude: '20',
+      zoom: '5',
+    });
+    nearbyLocation.coordinates = {
+      accuracy: 10,
+      latitude: 46.521,
+      longitude: 6.632,
+    };
+    set(this, 'enabled', true);
+
+    await render(hbs`<div {{fly-to-user-location this.enabled}}></div>`);
+
+    assert.strictEqual(calls.length, 0);
+  });
+
+  test('it flies once coordinates arrive after the initial render', async function (assert) {
+    const nearbyLocation = this.owner.lookup('service:nearby-location');
+    const router = this.owner.lookup('service:router');
+    const calls = stubReplaceWith(router);
+
+    stubCurrentRouteQueryParams(router, {});
+    set(this, 'enabled', true);
+
+    await render(hbs`<div {{fly-to-user-location this.enabled}}></div>`);
+
+    assert.strictEqual(calls.length, 0, 'nothing yet -- coordinates unknown');
+
+    nearbyLocation.coordinates = {
+      accuracy: 10,
+      latitude: 46.521,
+      longitude: 6.632,
+    };
+    await settled();
+
+    assert.strictEqual(
+      calls.length,
+      1,
+      'flies once coordinates resolve later, matching a granted-but-not-yet-fixed boot'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #150.

## What went wrong

The last release made the app open faster: it no longer waits for your device to report your GPS location before showing the map. That's a real improvement — the app feels snappier, especially on mobile.

As a side effect, it broke a smaller feature: if you'd previously allowed winds.mobi to know your location, opening the app fresh (a full page reload — not just switching between screens inside the app) used to automatically fly the map to your area. After the speed-up, this silently stopped happening: the map always opened to the whole-Switzerland overview instead, even for people who'd already said yes to location access.

## What's supposed to happen

- Open the app fresh, having previously granted location access → the map flies to your location automatically, no button press needed.
- First-time visitor, never granted access before → nothing automatic. We don't nag you for location on load. The "locate me" button in the navbar is still there whenever you want it.
- You've already navigated somewhere yourself — opened a specific station, searched for a place, panned/zoomed the map, or opened a shared link that already points at a location → the app leaves you exactly where you are. It should never yank the map away from something you deliberately looked at.
- Once the map has flown to your location on a fresh load, it doesn't try to do it again during that same visit (e.g. if you then pan away, it won't keep pulling you back).

## The fix (plain terms)

The map now keeps watching for your location to become known, instead of only checking once at the instant the map first appears. Since the app no longer waits for GPS before showing the page, your location can arrive a moment *after* the map is already on screen — the fix makes sure that moment still triggers the fly-to, instead of it being silently missed.

The map only ever flies automatically when both of these are true:

1. It's a genuinely fresh load — no location or station already specified in the page you opened, and
2. Your location has actually become known — which itself only happens if you'd already granted permission previously.

In every other case — you've navigated somewhere yourself, your location isn't known yet, or you've never granted permission — the map simply stays as it is, exactly as before.

## The fix (technical)

- `Map`'s fly-to-user-location check used to run only once, at `mapLoaded` — too early for a granted-but-not-yet-fixed user's coordinates, which now typically resolve after the map has already mounted (since `nearbyLocation.syncPermissionState()` is no longer awaited before render).
- `flyToUserLocation` is now a class-based `ember-modifier` that injects `router`/`nearby-location` itself and re-runs on any tracked state it reads (not just its args), so it reacts whenever `coordinates` actually arrives. It derives "is this still the fresh-load default view" itself; its only argument is whether auto-flying is enabled at all (off during this app's own test suite).
- Extracted the shared "fly to whatever position `nearbyLocation` currently holds" logic into `utils/locate`'s `flyToCoordinates`, reused by both this modifier and the existing locate-button flow (`requestAndFly`), instead of two copies of the same `router.replaceWith(...)` call.

## Test plan
- [x] `pnpm lint` (ESLint, Glint, template-lint, stylelint, prettier) — clean
- [x] `pnpm test:ember:dev` full suite — 226 passed, 8 skipped (known WebGL-less-container skips), 0 failed
- [x] New `tests/integration/modifiers/fly-to-user-location-test.ts` covers: flying when enabled/default-view/coordinates-known, staying put when disabled, when there are no coordinates yet, and when the routed view already moved off the default — plus the actual regression case, coordinates arriving after the initial render

https://claude.ai/code/session_0187y5aWMxJsxurS9z2S4skR
