### PR TITLE
Refactor last-hour wind metrics and update wind direction graph behavior

### DIFF
--- a/app/components/chart/polar.gts
+++ b/app/components/chart/polar.gts
@@ -113,6 +113,12 @@ export default class Polar extends Component<PolarSignature> {
       showLastLabel: false,
     },
     tooltip: {
+      // This chart is small -- a station card, and a ~80px thumbnail in the
+      // compact nearby/favourites rows -- so a multi-line tooltip would be
+      // clipped by the chart box it is drawn inside by default. `outside`
+      // renders it in its own container on top of the page instead, the same
+      // way the wind/air charts' tooltips already do.
+      outside: true,
       formatter: function (this: { point: { customTooltip: string } }) {
         return this.point.customTooltip;
       },

--- a/app/components/station/last-hour/presenter.gts
+++ b/app/components/station/last-hour/presenter.gts
@@ -29,6 +29,11 @@ export default class StationLastHourContent extends Component<StationLastHourCon
     return this.args.history.map((record) => record.speed);
   }
 
+  @cached
+  get lastHourGusts() {
+    return this.args.history.map((record) => record.gusts);
+  }
+
   get hasHistory() {
     return this.args.history.length > 0;
   }
@@ -47,12 +52,12 @@ export default class StationLastHourContent extends Component<StationLastHourCon
     return total / this.lastHourSpeeds.length;
   }
 
-  get lastHourMaximumSpeed() {
-    return this.hasHistory ? Math.max(...this.lastHourSpeeds) : undefined;
+  get lastHourMaximumGusts() {
+    return this.hasHistory ? Math.max(...this.lastHourGusts) : undefined;
   }
 
   get lastHourMaximumValueClass() {
-    return this.windClassFor(this.lastHourMaximumSpeed);
+    return this.windClassFor(this.lastHourMaximumGusts);
   }
 
   get lastHourMeanValueClass() {
@@ -77,7 +82,7 @@ export default class StationLastHourContent extends Component<StationLastHourCon
         <StationMetricCard
           @format="windSpeed"
           @label={{t "wind.maximum"}}
-          @value={{this.lastHourMaximumSpeed}}
+          @value={{this.lastHourMaximumGusts}}
           @valueClass={{this.lastHourMaximumValueClass}}
           @icon={{if this.settings.useIconLabels ArrowLineUp}}
         />

--- a/app/components/station/wind-direction/graph.gts
+++ b/app/components/station/wind-direction/graph.gts
@@ -9,6 +9,7 @@ import {
   COMPASS_LABEL_FONT_FAMILY,
 } from 'winds-mobi-client-web/utils/compass-labels';
 import { windDirectionMarkerColours } from 'winds-mobi-client-web/utils/wind-direction-marker';
+import windToColour from 'winds-mobi-client-web/helpers/wind-to-colour';
 
 export interface WindDirectionGraphSignature {
   Args: {
@@ -40,44 +41,28 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
   // "changed" args on every access and re-run its update mid-render -- the
   // root cause of this component's flaky marker-rendering (see TODO.md).
 
-  // The radial window spans exactly the given data's own oldest-to-newest
-  // range -- not a fixed 1-hour span anchored off either end (issue #120).
-  // Anchoring to a fixed duration (e.g. `newest - 1 hour`) was tried first
-  // and was wrong two ways: anchoring off wall-clock `Date.now()` let the
-  // window drift away from a station that had gone quiet, leaving the graph
-  // looking sparse or empty; anchoring the span off the newest reading
-  // instead still assumed the returned data always covers a full hour, so
-  // any time it covered less (a quiet spell, a station just back online)
-  // the real oldest reading sat inside that assumed boundary while nothing
-  // else moved to match -- not itself a visible bug, but proof the window
-  // and the data could disagree. Deriving both ends directly from the
-  // data's own extremes make that impossible by construction: no point can
-  // ever fall outside axis bounds that are its own dataset's bounds. `data`
-  // is chronological (oldest first, see app/handlers/history.ts), so the
-  // first/last elements are the two extremes.
+  // The radial window is always exactly one hour wide, anchored on the newest
+  // reading: the outer ring is the last measurement and the center is exactly
+  // an hour before it, whether or not a reading exists at that instant. That
+  // makes the radius a constant time scale, so radial distance always means
+  // the same number of minutes and a quiet spell reads as an empty inner (or
+  // outer) area rather than silently rescaling the whole graph.
+  //
+  // The anchor is the newest reading, never wall-clock `Date.now()`: anchoring
+  // off `Date.now()` (tried in issue #120) let the window drift away from a
+  // station that had gone quiet, leaving the graph looking sparse or empty.
+  // The historic API returns the last `duration` seconds relative to the
+  // station's own latest entry, so with `duration` of 1 hour no reading can
+  // fall outside these bounds. `data` is chronological (oldest first, see
+  // app/handlers/history.ts), so the last element is the newest reading.
   @cached
   get windowBounds() {
     const data = this.args.data ?? [];
+    // With no data at all there is no reading to anchor to; show the hour
+    // ending now, so the empty graph still draws its ring at a sane scale.
+    const newest = data[data.length - 1]?.timestamp ?? Date.now();
 
-    if (data.length === 0) {
-      const now = Date.now();
-
-      return { min: now - LAST_HOUR, max: now };
-    }
-
-    // A single reading has no range of its own to derive from -- fall back
-    // to a 1-hour span so it still draws as a spoke (see `points` below)
-    // instead of collapsing both axis ends onto the same value.
-    if (data.length === 1) {
-      const only = data[0]!.timestamp;
-
-      return { min: only - LAST_HOUR, max: only };
-    }
-
-    return {
-      min: data[0]!.timestamp,
-      max: data[data.length - 1]!.timestamp,
-    };
+    return { min: newest - LAST_HOUR, max: newest };
   }
 
   @cached
@@ -119,7 +104,7 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
         max: maxTimestamp,
         // Highcharts' radial axis places `min` at the pane center and `max`
         // at the outer edge by default, so the newest reading lands right
-        // on the outer ring and the oldest reading sits at the center, with
+        // on the outer ring and an hour earlier sits at the center, with
         // everything else spread linearly between (issue #120). A point
         // exactly at the center can't show a direction (the angle is
         // meaningless at radius 0), so this deliberately keeps the newest
@@ -139,6 +124,38 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
         gridLineWidth: 0,
       },
     };
+  }
+
+  // Mirrors the markup Highcharts' own default tooltip uses, which is what
+  // the wind history chart renders (see chart/time-series.gts): a smaller
+  // time header, then one line per value made of a wind-band-coloured
+  // bullet, the label, and the value in bold. Highcharts parses this subset
+  // of HTML inside its SVG text, so the tooltip needs no `useHTML` -- and a
+  // `var(--color-wind-NN)` colour resolves there just as it already does for
+  // the wind chart's zone-coloured bullets. Gusts come first to match the
+  // "Last hour" panel's own cards, which lead with the hour's maximum gust.
+  #tooltipFor(reading: History) {
+    const time = this.intl.formatTime(reading.timestamp, {
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: false,
+    });
+    const rows = [
+      { label: this.intl.t('wind.gusts'), value: reading.gusts },
+      { label: this.intl.t('wind.speed'), value: reading.speed },
+    ];
+
+    return [
+      `<span style="font-size: 0.8em">${time}</span>`,
+      ...rows.map(
+        ({ label, value }) =>
+          `<span style="color:${windToColour(
+            value
+          )}">●</span> ${label}: <b>${this.intl.formatNumber(value, {
+            format: 'windSpeed',
+          })}</b>`
+      ),
+    ].join('<br/>');
   }
 
   @cached
@@ -164,13 +181,7 @@ export default class WindDirectionGraph extends Component<WindDirectionGraphSign
           lineColor,
           fillColor,
         },
-        customTooltip: `${this.intl.formatTime(elm.timestamp, {
-          hour: 'numeric',
-          minute: 'numeric',
-          hour12: false,
-        })} ${this.intl.formatNumber(elm.speed, {
-          format: 'windSpeed',
-        })}`,
+        customTooltip: this.#tooltipFor(elm),
       };
     });
 

--- a/tests/integration/components/station/last-hour/presenter-test.ts
+++ b/tests/integration/components/station/last-hour/presenter-test.ts
@@ -17,7 +17,7 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test('it renders sorted minimum, middle, and maximum wind speeds', async function (this: StationLastHourPresenterTestContext, assert) {
+    test('it renders the minimum and mean average speed, and the maximum gust', async function (this: StationLastHourPresenterTestContext, assert) {
       this.history = [
         {
           id: 'three',
@@ -31,10 +31,12 @@ module(
           [Type]: 'history',
         },
         {
+          // The strongest gust of the hour sits on a record that is not the
+          // strongest average, so the maximum card can't pass by accident.
           id: 'one',
           direction: 180,
           speed: 12,
-          gusts: 14,
+          gusts: 24,
           temperature: 6,
           humidity: 63,
           rain: 0,
@@ -59,11 +61,13 @@ module(
       );
 
       assert.dom(this.element).includesText('Maximum');
-      assert.dom(this.element).includesText('18 km/h');
+      assert.dom(this.element).includesText('24 km/h');
       assert.dom(this.element).includesText('Mean');
       assert.dom(this.element).includesText('12 km/h');
       assert.dom(this.element).includesText('Minimum');
       assert.dom(this.element).includesText('7 km/h');
+      // The maximum reads gusts, so the strongest average is not shown.
+      assert.dom(this.element).doesNotIncludeText('18 km/h');
     });
   }
 );

--- a/tests/integration/components/station/wind-direction/graph-test.ts
+++ b/tests/integration/components/station/wind-direction/graph-test.ts
@@ -96,14 +96,11 @@ module(
       assert.dom('.highcharts-container').exists();
     });
 
-    // issue #120: the window is derived from the data's own oldest/newest
-    // timestamps, not anchored to wall-clock `Date.now()` or to a fixed
-    // 1-hour span off either end. Anchoring off `Date.now()` let the window
-    // drift away from a station that had gone quiet; anchoring a fixed
-    // 1-hour span off the newest reading instead assumed the returned data
-    // always covers a full hour, which isn't guaranteed -- so a reading
-    // could fall outside the assumed span. Deriving both axis ends from the
-    // data itself rules that out by construction.
+    // issue #120: the hour-wide window is anchored on the newest reading in
+    // the data, never on wall-clock `Date.now()`. Anchoring off `Date.now()`
+    // let the window drift away from a station that had gone quiet -- here,
+    // one that last reported almost three hours ago -- pushing every reading
+    // it did return outside the window and leaving the graph empty.
     test('it keeps stale readings on screen instead of anchoring the window to wall-clock time', async function (this: WindDirectionGraphTestContext, assert) {
       const lastReadingTimestamp = Date.now() - 170 * 60 * 1000;
 
@@ -134,23 +131,33 @@ module(
 
       await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
 
-      const series = (await renderedPolarChart())?.series[0];
+      const chart = await renderedPolarChart();
 
       assert.deepEqual(
-        series?.data.map((p) => p.y),
+        chart?.series[0]?.data.map((p) => p.y),
         this.data.map((row) => row.timestamp),
         'both stale readings still render, none clipped by a real-time window'
       );
+      assert.strictEqual(
+        chart?.yAxis[0]?.max,
+        lastReadingTimestamp,
+        "the outer edge is the stale station's last reading, not the current time"
+      );
+      assert.strictEqual(
+        chart?.yAxis[0]?.min,
+        lastReadingTimestamp - LAST_HOUR,
+        'the center is an hour before that reading, not an hour before now'
+      );
     });
 
-    test('it sizes the axis to the data span it was actually given, not a fixed 1-hour offset', async function (this: WindDirectionGraphTestContext, assert) {
+    test('it spans exactly one hour ending at the newest reading, even when the data covers less', async function (this: WindDirectionGraphTestContext, assert) {
       const now = Date.now();
 
-      // Only 12 minutes apart -- far short of a full hour. Under a fixed
-      // `newest - 1 hour` window this data would still render fine (nothing
-      // falls outside a *wider* assumed span), but the axis and the data
-      // would disagree about what "the edge" means; deriving the axis from
-      // the data itself keeps them in lockstep, which is what this test pins.
+      // Only 12 minutes apart -- far short of a full hour. The window is
+      // still a full hour wide, so these two readings occupy just the outer
+      // fifth of the radius and the missing 48 minutes read as an empty
+      // center, rather than the axis shrinking to the data's own span and
+      // making radial distance mean something different per station.
       this.data = [
         {
           id: 'oldest',
@@ -182,13 +189,13 @@ module(
 
       assert.strictEqual(
         chart?.yAxis[0]?.min,
-        this.data[0]!.timestamp,
-        'axis min is the oldest reading in the data, not an hour before the newest'
+        this.data[1]!.timestamp - LAST_HOUR,
+        'the center is exactly one hour before the newest reading, not the oldest reading in the data'
       );
       assert.strictEqual(
         chart?.yAxis[0]?.max,
         this.data[1]!.timestamp,
-        'axis max is the newest reading in the data'
+        'the outer edge is the newest reading in the data'
       );
     });
 
@@ -303,6 +310,65 @@ module(
       assert.strictEqual(formatter?.({ value: 90 }), 'E');
       assert.strictEqual(formatter?.({ value: 45 }), '');
       assert.strictEqual(formatter?.({ value: 315 }), '');
+    });
+
+    // The tooltip mirrors the wind history chart's: a time header, then one
+    // line per value with a wind-band-coloured bullet, the label, and the
+    // value in bold. Reading the string back off the rendered point checks
+    // what this component actually handed Highcharts -- how Highcharts then
+    // paints that markup is its own business, not ours to assert.
+    test('it builds a tooltip listing the gust and the average wind, each with a coloured bullet and a bold speed', async function (this: WindDirectionGraphTestContext, assert) {
+      this.data = [
+        {
+          id: 'reading',
+          direction: 180,
+          // Two different wind bands, so each bullet has to pick up its own
+          // value's colour rather than sharing one.
+          speed: 12,
+          gusts: 24,
+          temperature: 6,
+          humidity: 60,
+          rain: 0,
+          timestamp: Date.now(),
+          [Type]: 'history',
+        },
+      ];
+
+      await render(hbs`<Station::WindDirection::Graph @data={{this.data}} />`);
+
+      const series = (await renderedPolarChart())?.series[0];
+      const tooltip =
+        (
+          series?.data[0]?.options as unknown as
+            | { customTooltip?: string }
+            | undefined
+        )?.customTooltip ?? '';
+
+      // Whitespace between the number and its unit is whatever `Intl` emits
+      // for the locale (a plain space or a non-breaking one), so match either
+      // rather than pinning the exact formatted string.
+      assert.true(
+        /<span style="color:var\(--color-wind-25\)">●<\/span> Gusts: <b>24\s?km\/h<\/b>/.test(
+          tooltip
+        ),
+        'the gust row leads with a bullet in the gust’s own wind-band colour and shows the speed in bold'
+      );
+      assert.true(
+        /<span style="color:var\(--color-wind-15\)">●<\/span> Wind: <b>12\s?km\/h<\/b>/.test(
+          tooltip
+        ),
+        'the average-wind row leads with a bullet in its own wind-band colour and shows the speed in bold'
+      );
+      assert.true(
+        tooltip.indexOf('Gusts:') < tooltip.indexOf('Wind:'),
+        'the gust is listed first, matching the panel’s own cards'
+      );
+      assert.true(
+        /^<span style="font-size: 0\.8em">\d{1,2}:\d{2}<\/span><br\/>/.test(
+          tooltip
+        ),
+        'the reading’s time heads the tooltip, in a smaller type size'
+      );
     });
   }
 );

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -127,7 +127,7 @@ help:
       nowTitle: Now
       nowDescription: Latest wind, gusts, direction, temperature, humidity, pressure, and rain.
       lastHourTitle: Last hour
-      lastHourDescription: Trend values and a compact wind-direction history for the last hour.
+      lastHourDescription: Trend values (maximum gust, mean and minimum wind speed) and a compact wind-direction history for the last hour.
       windHistoryTitle: Wind history
       windHistoryDescription: Wind speed, gusts, and direction over time.
       airHistoryTitle: Air history


### PR DESCRIPTION
Why:
- Improve clarity for last-hour wind gust and speed metrics, aligning maximum gust with UI expectations.
- Ensure wind direction graphs use a consistent 1-hour radial window, anchored on the newest reading rather than the current time.
- Enhance tooltip readability and visual parity with other charts.

How:
- Added `lastHourGusts` and refactored wind metrics to display maximum gusts.
- Updated radial axis logic to ensure it spans exactly one hour relative to the latest data point.
- Refactored graph tooltips to include gusts and average speed with color-coded bullets and better layout.
- Adjusted tests to match the updated functionality, including gust precedence and radial window behavior.

<img width="495" height="518" alt="Screenshot 2026-07-31 at 15 58 43" src="https://github.com/user-attachments/assets/131b025a-f6a9-443b-a920-41518e855979" />
