### PR TITLE
🗺️ Stop the map jumping when a station panel opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Tapping a station on the map no longer makes the map jump. The station's panel now slides in _over_ the map — a sheet from the bottom on phones, a side panel on wider screens — instead of squeezing it into a smaller space, so the map itself stays exactly where you left it while you read a station and after you close it again. Opening a station from a link, from search or from Nearby still brings it into view, and now places it in the part of the map the panel leaves visible instead of behind the panel. ([#155](https://github.com/winds-mobi/winds-mobi-client-web/issues/155))
+
+### Changed
+
+- The wind-speed legend moved to the top-right corner alongside the zoom, compass and 3D buttons, so it stays visible whichever side the station panel opens from.
+
 ## v0.21.0 - 2026-08-04
 
 ### Added

--- a/app/components/map/index.gts
+++ b/app/components/map/index.gts
@@ -14,7 +14,12 @@ import type RouterService from '@ember/routing/router-service';
 import { t } from 'ember-intl';
 import MapLibreGL from 'ember-maplibre-gl/components/maplibre-gl';
 import type { Map as MaplibreMap, MapInitOptions } from 'ember-maplibre-gl';
-import { NavigationControl, TerrainControl, setWorkerUrl } from 'maplibre-gl';
+import {
+  NavigationControl,
+  TerrainControl,
+  setWorkerUrl,
+  type IControl,
+} from 'maplibre-gl';
 // maplibre-gl v6 is ESM-only and resolves its worker file at runtime via
 // `new URL('./maplibre-gl-worker.mjs', import.meta.url)` relative to its own
 // module -- that only works unbundled; under Vite/Rollup, `import.meta.url`
@@ -35,6 +40,7 @@ import MapLegend, {
 import MapStationMarker from 'winds-mobi-client-web/components/map/station-marker';
 import MapUserLocationMarker from 'winds-mobi-client-web/components/map/user-location-marker';
 import commitResolvedStations from 'winds-mobi-client-web/modifiers/commit-resolved-stations';
+import driveMapCamera from 'winds-mobi-client-web/modifiers/drive-map-camera';
 import flyToUserLocation from 'winds-mobi-client-web/modifiers/fly-to-user-location';
 import onRouteChange from 'winds-mobi-client-web/modifiers/on-route-change';
 import registerLoadingProbe from 'winds-mobi-client-web/modifiers/register-loading-probe';
@@ -70,6 +76,13 @@ export default class Map extends Component<MapSignature> {
   @service declare mapRefresh: MapRefreshService;
   @service('nearby-location') declare nearbyLocation: NearbyLocationService;
 
+  // The buttons and the wind legend live in the top-right corner, the one area
+  // neither shape of the station panel covers (a bottom sheet in portrait, a
+  // side panel in landscape and on desktop) now that the panel overlays the map
+  // instead of shrinking it. MapLibre stacks them there itself, in the order
+  // they're added in the template below. The map credit stays where MapLibre
+  // puts it, bottom-right, and so is covered by the bottom sheet while a
+  // station is open on a phone — visible again as soon as it's closed.
   private navigationControl = new NavigationControl({
     showCompass: true,
     visualizePitch: true,
@@ -81,6 +94,21 @@ export default class Map extends Component<MapSignature> {
           source: 'terrainSource',
           exaggeration: 1,
         });
+
+  // The wind legend as a control of MapLibre's own, so it stacks under the
+  // buttons natively rather than being positioned against them by hand. The
+  // element is created up front instead of inside `onAdd`, so the `{{in-element}}`
+  // that fills it with `<MapLegend>` never has to wait on (or react to) MapLibre
+  // adopting the control.
+  legendElement = Object.assign(document.createElement('div'), {
+    // MapLibre's own control class: it floats and spaces the legend in the
+    // corner exactly like the buttons above it.
+    className: 'maplibregl-ctrl',
+  });
+  private legendControl: IControl = {
+    onAdd: () => this.legendElement,
+    onRemove: () => this.legendElement.remove(),
+  };
 
   // See `TrackedMapView` for why this needs to be more than `currentMapView(this.router)`
   // read directly (issue #131). `handleRouteChange`, wired to the `onRouteChange`
@@ -118,6 +146,10 @@ export default class Map extends Component<MapSignature> {
     }
 
     return undefined;
+  }
+
+  get isStationPanelOpen(): boolean {
+    return this.selectedStationId !== undefined;
   }
 
   isStationSelected = (station: Station): boolean => {
@@ -313,20 +345,15 @@ export default class Map extends Component<MapSignature> {
     }
   }
 
-  // Cached so the reference is stable across re-renders (stations loading, each
-  // refresh tick): the declarative `<map.call @func="flyTo">` re-fires only when
-  // this reference changes, so it fires only on a real routed-view change rather
-  // than on every render. Without this a refresh tick could re-issue a fly-to
-  // mid-gesture, before `moveend` writes the new view back, yanking the camera
-  // to the stale routed view. Invalidates when `mapView` (the routed query
-  // params) changes, which is exactly when the map should move.
-  @cached
-  get flyToOptions() {
-    return {
-      center: mapViewCenter(this.mapView),
-      zoom: this.mapView.zoom,
-    };
-  }
+  // MapLibre's own instance, for `driveMapCamera` on the overlay slot — which
+  // lives outside `<MapLibreGL>`'s block (and so outside the block param that
+  // yields it) so the panel renders immediately on a cold deep link instead of
+  // waiting for the map to load.
+  @tracked private mapInstance?: MaplibreMap;
+
+  handleMapLoaded = (map: MaplibreMap) => {
+    this.mapInstance = map;
+  };
 
   <template>
     <div
@@ -341,20 +368,17 @@ export default class Map extends Component<MapSignature> {
         data-test-map-canvas
         class="h-full w-full"
         @initOptions={{this.initOptions}}
+        @mapLoaded={{this.handleMapLoaded}}
         @reuseMaps={{false}}
         as |map|
       >
-        <map.call
-          @func="flyTo"
-          @positionalArguments={{array this.flyToOptions}}
-        />
-
         <map.on @event="idle" @action={{this.captureBounds}} />
         <map.on @event="moveend" @action={{this.handleMoveEnd}} />
         <map.on @event="terrain" @action={{this.handleTerrainChange}} />
+        <map.control @control={{this.legendControl}} @position="top-right" />
         <map.control
           @control={{this.navigationControl}}
-          @position="bottom-right"
+          @position="top-right"
         />
         {{#if this.terrainControl}}
           <map.control @control={{this.terrainControl}} @position="top-right" />
@@ -390,12 +414,31 @@ export default class Map extends Component<MapSignature> {
           </map.marker>
         {{/each}}
 
-        <MapLegend
-          class="pointer-events-none absolute left-2.5 top-2.5 z-10"
-          @bands={{this.legendBands}}
-          @title={{t "map.legend.windSpeed"}}
-        />
+        {{#in-element this.legendElement insertBefore=null}}
+          <MapLegend
+            class="pointer-events-none"
+            @bands={{this.legendBands}}
+            @title={{t "map.legend.windSpeed"}}
+          />
+        {{/in-element}}
       </MapLibreGL>
+
+      {{! The station panel's slot. Sized by CSS whether or not a panel is
+      rendered in it — a bottom sheet in portrait, a side panel in landscape and
+      on desktop — which is what lets `mapPaddingFromOverlay` measure the area a
+      panel covers without waiting for one to render, and what keeps that
+      measurement out of any breakpoint duplicated in TypeScript. It overlays
+      the map rather than shrinking it: the map's own box never resizes, so
+      MapLibre never re-centres itself into a new one, which is what made
+      opening a station visibly heave the whole map around (#155). Transparent
+      to pointer events so the covered map still pans and zooms while nothing
+      is open. }}
+      <div
+        class="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-96 landscape:inset-x-auto landscape:left-0 landscape:top-0 landscape:h-auto landscape:w-[min(32rem,50vw)] md:inset-x-auto md:left-0 md:top-0 md:h-auto md:w-[32rem]"
+        {{driveMapCamera this.mapInstance this.mapView this.isStationPanelOpen}}
+      >
+        {{yield}}
+      </div>
     </div>
   </template>
 }

--- a/app/components/station/index.gts
+++ b/app/components/station/index.gts
@@ -38,9 +38,12 @@ export default class StationIndex extends Component<StationIndexSignature> {
   }
 
   <template>
+    {{! Fills the map's overlay slot, which owns the panel's size and where it
+    sits (`app/components/map/index.gts`) — the map measures that slot to know
+    how much of itself the panel covers. }}
     <section
       data-test-station-panel
-      class="flex h-[24rem] w-full shrink-0 flex-col overflow-hidden border-t border-slate-200 bg-white shadow-md shadow-slate-900/12 landscape:h-full landscape:w-[min(32rem,50vw)] landscape:border-r landscape:border-t-0 landscape:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)] md:h-full md:w-[32rem] md:border-r md:border-t-0 md:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)]"
+      class="pointer-events-auto flex h-full w-full flex-col overflow-hidden border-t border-slate-200 bg-white shadow-md shadow-slate-900/12 landscape:border-r landscape:border-t-0 landscape:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)] md:border-r md:border-t-0 md:shadow-[12px_0_28px_-12px_rgba(15,23,42,0.42)]"
     >
       <div
         class="relative z-10 shrink-0 flex items-start justify-between gap-4 px-4 py-2 shadow-md shadow-slate-900/10"

--- a/app/modifiers/drive-map-camera.ts
+++ b/app/modifiers/drive-map-camera.ts
@@ -1,0 +1,100 @@
+import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+import type { Map as MaplibreMap } from 'ember-maplibre-gl';
+import {
+  applyMapPadding,
+  mapPaddingFromOverlay,
+  NO_MAP_PADDING,
+} from 'winds-mobi-client-web/utils/map-padding';
+import {
+  mapViewCenter,
+  mapViewsEqual,
+  type MapView,
+} from 'winds-mobi-client-web/utils/map-view';
+
+interface DriveMapCameraSignature {
+  Element: HTMLElement;
+  Args: {
+    Positional: [
+      map: MaplibreMap | undefined,
+      view: MapView,
+      isPanelOpen: boolean,
+    ];
+  };
+}
+
+// The one and only thing that moves the map's camera, attached to the station
+// panel's overlay slot so it can measure how much of the map that panel covers.
+// It does two things, in this order and never separately:
+//
+// 1. Matches MapLibre's padding to the covered area, absorbing the change so
+//    the view holds still (see `applyMapPadding`). Opening or closing the panel
+//    is nothing but this — the map stays exactly where the user left it (#155).
+// 2. Flies to the routed view, but only when that view actually changed — a
+//    search result, a nearby card, a deep link, the locate button. Compared by
+//    value, not by reference: a transition that leaves the view alone (opening
+//    a panel, switching stations) must not move the camera, and that has to
+//    hold however the routed view reaches this modifier.
+//
+// Both live here, rather than the padding in a modifier and the flight in a
+// declarative `<map.call @func="flyTo">`, because those two run in different
+// phases: template helpers evaluate during render, modifiers afterwards during
+// commit, so a transition that opens the panel *and* moves the view would start
+// the flight first and then have the padding change stop it mid-air (MapLibre's
+// camera methods stop whatever is in flight). One writer, one order, no race:
+// padding is settled before the flight starts, so the flight already frames its
+// destination inside the part of the map the panel leaves visible.
+export default class DriveMapCameraModifier extends Modifier<DriveMapCameraSignature> {
+  private element?: HTMLElement;
+  private map?: MaplibreMap;
+  private isPanelOpen = false;
+  private lastView?: MapView;
+
+  modify(
+    element: HTMLElement,
+    [map, view, isPanelOpen]: [MaplibreMap | undefined, MapView, boolean]
+  ) {
+    this.element = element;
+    this.isPanelOpen = isPanelOpen;
+
+    if (!map) {
+      return;
+    }
+
+    if (map !== this.map) {
+      this.map = map;
+
+      // The panel is the only thing that covers the map without resizing it, so
+      // this fires for genuine size changes only — a rotated phone, a resized
+      // window — where the slot's own measurements change with it. MapLibre's
+      // own event rather than an observer of ours, and harmless when the
+      // measurement comes back unchanged (`applyMapPadding` no-ops).
+      map.on('resize', this.syncPadding);
+      registerDestructor(this, () => map.off('resize', this.syncPadding));
+    }
+
+    this.syncPadding();
+
+    if (this.lastView && mapViewsEqual(this.lastView, view)) {
+      return;
+    }
+
+    this.lastView = view;
+
+    // No `padding` of its own: the transform already carries the padding
+    // `syncPadding` just settled, and MapLibre keeps it for any camera call
+    // that doesn't name one.
+    map.flyTo({ center: mapViewCenter(view), zoom: view.zoom });
+  }
+
+  private syncPadding = () => {
+    if (!this.map || !this.element) {
+      return;
+    }
+
+    applyMapPadding(
+      this.map,
+      this.isPanelOpen ? mapPaddingFromOverlay(this.element) : NO_MAP_PADDING
+    );
+  };
+}

--- a/app/templates/map.gts
+++ b/app/templates/map.gts
@@ -8,16 +8,14 @@ interface MyRouteSignature {
 // eslint-disable-next-line ember/no-empty-glimmer-component-classes
 export default class MyRoute extends Component<MyRouteSignature> {
   <template>
-    <div
-      class="flex min-h-0 flex-1 flex-col overflow-hidden bg-slate-200 landscape:flex-row-reverse md:flex-row-reverse"
-    >
-      <div
-        class="min-h-[18rem] min-w-0 flex-1 bg-white landscape:min-h-0 md:min-h-0"
-      >
-        <Map />
-      </div>
-
-      {{outlet}}
+    {{! The station panel is rendered into the map's own overlay slot rather than
+    beside the map: a sibling panel shrinks the map's box, and MapLibre keeps its
+    geographic centre through a resize, so the same coordinates land on a
+    different pixel and the whole map appears to lurch (#155). }}
+    <div class="min-h-0 flex-1 overflow-hidden bg-white">
+      <Map>
+        {{outlet}}
+      </Map>
     </div>
   </template>
 }

--- a/app/utils/map-padding.ts
+++ b/app/utils/map-padding.ts
@@ -1,0 +1,118 @@
+import type { Map as MaplibreMap } from 'ember-maplibre-gl';
+import type { PaddingOptions } from 'maplibre-gl';
+
+// MapLibre types every edge as optional (an unset one means 0); this app always
+// states all four, so its own padding values are safe to do arithmetic on.
+export type MapPadding = Required<PaddingOptions>;
+
+export const NO_MAP_PADDING: MapPadding = {
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+};
+
+// Sub-pixel layout rounding: a full-bleed overlay can miss its container's own
+// size by a fraction, so "spans the whole width/height" is a near-comparison
+// rather than an exact one.
+const EDGE_TOLERANCE = 1;
+
+// How much of the map the station panel covers, in MapLibre `padding` terms
+// (its own "edge insets" / vanishing-point concept). Measured from the overlay
+// slot's real geometry rather than re-declaring the panel's Tailwind sizes and
+// breakpoints in TypeScript, so the two can't drift.
+//
+// The slot always covers a full-width or full-height slab against one edge of
+// the map (a bottom sheet in portrait, a side panel in landscape and on
+// desktop), which is what makes the uncovered area a rectangle MapLibre can
+// express as padding: whichever edge the slab sits against gets its thickness,
+// the other three stay 0.
+export function mapPaddingFromOverlay(overlay: HTMLElement): MapPadding {
+  // The slot is absolutely positioned inside the map's own box, so its offset
+  // geometry is already relative to exactly the box MapLibre pads. Offsets
+  // rather than `getBoundingClientRect`, because MapLibre's padding is in the
+  // map's own CSS pixels: a bounding rect is measured in *rendered* pixels and
+  // comes back scaled wherever an ancestor carries a transform, which is how
+  // Ember's own test container renders the whole app (`scale(0.5)`).
+  const container = overlay.offsetParent;
+
+  if (!(container instanceof HTMLElement)) {
+    return NO_MAP_PADDING;
+  }
+
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+
+  if (overlay.offsetWidth >= width - EDGE_TOLERANCE) {
+    return overlay.offsetTop > 0
+      ? { ...NO_MAP_PADDING, bottom: height - overlay.offsetTop }
+      : { ...NO_MAP_PADDING, top: overlay.offsetHeight };
+  }
+
+  if (overlay.offsetHeight >= height - EDGE_TOLERANCE) {
+    return overlay.offsetLeft > 0
+      ? { ...NO_MAP_PADDING, right: width - overlay.offsetLeft }
+      : { ...NO_MAP_PADDING, left: overlay.offsetWidth };
+  }
+
+  return NO_MAP_PADDING;
+}
+
+export function mapPaddingsEqual(
+  left: PaddingOptions,
+  right: PaddingOptions
+): boolean {
+  return (
+    (left.top ?? 0) === (right.top ?? 0) &&
+    (left.bottom ?? 0) === (right.bottom ?? 0) &&
+    (left.left ?? 0) === (right.left ?? 0) &&
+    (left.right ?? 0) === (right.right ?? 0)
+  );
+}
+
+// Sets the map's padding without moving a single pixel of what's on screen.
+//
+// Padding is not framing bookkeeping — it moves the vanishing point, the screen
+// position the map draws its center at (`EdgeInsets#getCenter`, below). Setting
+// it on its own therefore slides the whole map by half the panel, which is
+// exactly the heave this app is getting rid of. Handing MapLibre a new center
+// in the same call is what absorbs it: whatever is drawn at the point the
+// vanishing point is *about to* move to becomes the center, so it is drawn at
+// that same point afterwards and nothing shifts.
+//
+// The center is a real change though, and a deliberate one: while the panel is
+// open the map's center is the middle of the part it leaves visible, which is
+// what `getCenter`, the zoom buttons, and every later `flyTo` should mean.
+// Framing a station against the open panel needs nothing further — an ordinary
+// `flyTo(center)` already lands it there.
+//
+// A no-op when the padding already matches, so this can run before a `flyTo`
+// without stopping it (MapLibre's camera methods stop whatever is in flight).
+export function applyMapPadding(map: MaplibreMap, padding: MapPadding): void {
+  const current = map.getPadding();
+
+  if (mapPaddingsEqual(current, padding)) {
+    return;
+  }
+
+  // Where the vanishing point is about to move to. Expressed as a shift of the
+  // one MapLibre is using right now — which is where it projects its own center
+  // — so the map's dimensions cancel out of the arithmetic and never have to be
+  // read: `EdgeInsets#getCenter` is `(left + width - right) / 2` per axis, and
+  // the same `width` sits in both the old and new value.
+  const centerPoint = map.project(map.getCenter());
+  const vanishingPoint: [number, number] = [
+    centerPoint.x +
+      (padding.left -
+        padding.right -
+        ((current.left ?? 0) - (current.right ?? 0))) /
+        2,
+    centerPoint.y +
+      (padding.top -
+        padding.bottom -
+        ((current.top ?? 0) - (current.bottom ?? 0))) /
+        2,
+  ];
+
+  map.jumpTo({ center: map.unproject(vanishingPoint), padding });
+}

--- a/tests/acceptance/map-station-panel-test.ts
+++ b/tests/acceptance/map-station-panel-test.ts
@@ -33,6 +33,26 @@ async function waitForMarker(stationId: string) {
   });
 }
 
+// Where MapLibre currently draws a station's marker, relative to the map's own
+// box, so it measures the camera rather than where the page happens to sit.
+function markerPosition(stationId: string) {
+  const map = find('[data-test-map-container]')?.getBoundingClientRect();
+  const marker = find(
+    `[data-station-id="${stationId}"]`
+  )?.getBoundingClientRect();
+
+  return map && marker
+    ? { x: marker.x - map.x, y: marker.y - map.y, width: marker.width }
+    : undefined;
+}
+
+// MapLibre's camera animations run outside anything `settled()` knows about, so
+// a map that is merely slow to leave still looks still right after a click.
+// Long enough for MapLibre's own default ease (500ms) to have visibly started.
+function afterAnyCameraAnimation() {
+  return new Promise((resolve) => setTimeout(resolve, 400));
+}
+
 type DeferredRequest = {
   promise: Promise<{ content: { data: Station } }>;
   resolve: (value: { content: { data: Station } }) => void;
@@ -512,6 +532,84 @@ module('Acceptance | map station panel', function (hooks) {
           '.maplibregl-marker.cursor-pointer:has([data-station-id="holfuy-1804"])'
         )
         .exists('the outer MapLibre marker element carries it instead');
+    }
+  );
+
+  // #155: opening the panel used to shrink the map's own box, and MapLibre
+  // keeps its geographic centre through a resize, so everything on screen slid
+  // by half the panel. The panel overlays the map now, and the padding that
+  // tells the camera about the covered area is applied so the view holds still
+  // (`applyMapPadding`) -- both of which are invisible to any assertion about
+  // the DOM alone. Where MapLibre actually draws a marker is the observable
+  // proof, and it's proof about our own layout and camera handling rather than
+  // about how MapLibre chooses to draw: any correct implementation leaves that
+  // marker on the same pixel.
+  test.if(
+    'opening a station panel leaves the map exactly where it was',
+    webGLAvailable,
+    async function (assert) {
+      await visit('/map?latitude=46.67719&longitude=7.86323&zoom=13');
+      await waitForMarker('holfuy-2222');
+
+      const before = markerPosition('holfuy-2222');
+
+      await click('[data-station-id="holfuy-1804"]');
+      await waitForMarker('holfuy-2222');
+
+      assert.dom('[data-test-station-panel]').exists('the panel opened');
+      assert.deepEqual(
+        markerPosition('holfuy-2222'),
+        before,
+        'the other station’s marker has not moved on screen'
+      );
+
+      await afterAnyCameraAnimation();
+
+      assert.deepEqual(
+        markerPosition('holfuy-2222'),
+        before,
+        'and has not drifted once any camera animation would have run'
+      );
+
+      await click('[data-test-station-close]');
+      await waitForMarker('holfuy-2222');
+
+      assert.deepEqual(
+        markerPosition('holfuy-2222'),
+        before,
+        'and closing the panel puts nothing back either — it never moved'
+      );
+    }
+  );
+
+  // The flip side of the test above: an overlaying panel hides part of the map,
+  // so a station the app deliberately focuses (a search result, a nearby card,
+  // its own title here) has to land in the part the panel leaves visible, not
+  // behind it. That's what MapLibre's padding buys once it's set -- without it
+  // this station would sit in the middle of the whole map, which on a phone is
+  // under the sheet.
+  test.if(
+    'focusing a station frames it in the part of the map the panel leaves visible',
+    webGLAvailable,
+    async function (assert) {
+      await visit(
+        '/map/holfuy-1804?latitude=46.70719&longitude=7.91323&zoom=8'
+      );
+      await waitForMarker('holfuy-1804');
+
+      await click('[data-test-station-title]');
+      await waitForMarker('holfuy-1804');
+      await afterAnyCameraAnimation();
+
+      // Same units as `markerPosition`, which measures against this same box.
+      const mapWidth =
+        find('[data-test-map-container]')?.getBoundingClientRect().width ?? 0;
+      const marker = markerPosition('holfuy-1804');
+
+      assert.ok(
+        marker && marker.x + marker.width / 2 > mapWidth / 2,
+        'the focused station sits clear of the panel, not at the centre of the whole map'
+      );
     }
   );
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/71a3d2e4-4d91-41c7-9191-be5c180a201c






Fixes #155.

## What was wrong

Tapping a station on the map made the whole map lurch. On a phone it was hard to miss: open a station, and everything you were looking at slid a few hundred pixels away.

The panel used to sit *beside* the map — a sheet below it on phones, a column next to it on desktop. That meant opening it physically shrank the map's box. And a map keeps its **centre** when it's resized, not its corners, so the same coordinates end up drawn on a different pixel. Nothing was moving the camera; the map was simply being given a smaller window and re-centring itself inside it. Closing the panel did the same thing in reverse.

## What it does now

The panel floats **over** the map instead of taking space from it. The map's box never changes size, so there is nothing to re-centre and the map holds perfectly still — while the panel is open, and after it closes.

The catch with overlaying is that part of the map is now hidden behind the panel, and the map doesn't know that. So it gets told, using MapLibre's own `padding` — the same "there's a sidebar in the way" mechanism Mapbox and MapLibre ship an [official example](https://maplibre.org/maplibre-gl-js/docs/examples/offset-the-vanishing-point-using-padding/) for. That's what makes opening a station from a link, from search or from Nearby put it in the part of the map you can actually see, rather than behind the panel.

The wind legend moved to the top-right with the zoom/compass/3D buttons — the one corner neither the bottom sheet nor the side panel covers.

## A bit of the tech, for review

- **How much of the map is covered is measured, not hardcoded.** The overlay slot is sized by CSS whether or not a panel is in it, so `mapPaddingFromOverlay` can measure the real thing instead of restating the panel's Tailwind sizes and breakpoints in TypeScript, where they could drift.
- **Padding is never set on its own.** It moves the vanishing point, so setting it alone slides the map by half the panel — the very jump being removed. `applyMapPadding` always hands MapLibre a compensating centre in the same call.
- **One thing moves the camera.** `driveMapCamera` settles the padding, then flies to the routed view only when that view actually changed *by value*. An earlier version split those — padding in a modifier, the flight in a declarative `<map.call @func="flyTo">` — which cannot work: template helpers run in the render phase and modifiers in the commit phase, so the flight always started first and the padding write then stopped it mid-air. Tracing it live in the browser is what surfaced that.
- **No observers.** The only reactive hook is MapLibre's own `resize` event, for genuine size changes like a rotated phone.

Worth knowing: while a panel is open, `map.getCenter()` — and so the URL after any pan — now means the centre of the *visible* part of the map. That is what lets an ordinary `flyTo(station)` frame a station beside the panel with no extra work. Padding doesn't affect `getBounds()`, so station fetching is unchanged.

## Verification

`pnpm lint` clean, 252/252 tests pass. Two new acceptance tests pin the behaviour by measuring where MapLibre actually draws a marker: it must not move by a pixel across open → wait → close, and it must clear the panel after a focus fly. Also checked in a real browser at phone and desktop sizes.

One consequence to flag: the map credit stays bottom-right, so a phone's bottom sheet covers it while a station is open (it's back as soon as you close it). Happy to lift it above the sheet if that's not acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFdDjerSugwpZo3vMMtXVb